### PR TITLE
fix: Исправлен баг со сбросом состояния задачи во время печати текста

### DIFF
--- a/src/Unlimotion.ViewModel/FileDbWatcher.cs
+++ b/src/Unlimotion.ViewModel/FileDbWatcher.cs
@@ -50,7 +50,7 @@ namespace Unlimotion.ViewModel
         {
             lock (itLock)
             {
-                ignoredTasks.Add(taskId, itLock, new CacheItemPolicy { SlidingExpiration = TimeSpan.FromSeconds(5) });
+                ignoredTasks.Add(taskId, itLock,  new CacheItemPolicy { SlidingExpiration = TimeSpan.FromSeconds(5) });
                 logger.Write($"{DateTimeOffset.Now}: ${taskId} is added to ignored", LogLevel.Debug);
             }
         }
@@ -87,8 +87,6 @@ namespace Unlimotion.ViewModel
                 var fileInfo = new FileInfo(e.FullPath);
                 if (ignoredTasks.Contains(fileInfo.FullName))
                 {
-                    ignoredTasks.Remove(fileInfo.FullName);
-                    logger.Write($"{DateTimeOffset.Now}: {fileInfo.FullName} is removed from ignored", LogLevel.Debug);
                     return;
                 }
             }

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -58,7 +58,7 @@ namespace Unlimotion.ViewModel
                 .AddToDisposeAndReturn(this);
             Settings.ConnectCommand = conn;
 
-            conn.Subscribe(RegisterCommands);
+            conn.Subscribe(RegisterCommands).AddToDispose(this);
             try
             {
                 conn.Execute().Wait();

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -469,7 +469,7 @@ namespace Unlimotion.ViewModel
             });
 
             Contains.ToObservableChangeSet()
-                .Throttle(TimeSpan.FromSeconds(2))
+                //.Throttle(TimeSpan.FromSeconds(2))
                 .Subscribe(set =>
                 {
                     if (_isInited) SaveItemCommand.Execute();
@@ -477,7 +477,7 @@ namespace Unlimotion.ViewModel
                 .AddToDispose(this);
 
             Blocks.ToObservableChangeSet()
-                .Throttle(TimeSpan.FromSeconds(2))
+                //.Throttle(TimeSpan.FromSeconds(2))
                 .Subscribe(set =>
                 {
                     if (_isInited) SaveItemCommand.Execute();


### PR DESCRIPTION
При срабатывании вотчера он игнорировал изменения только один раз, а там для этого был механизм протухающего кэша, два подхода мешали друг другу