### PR TITLE
Fix Android CI, local build, and debug libgit2 runtime

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/android-packaging.yml
+++ b/.github/workflows/android-packaging.yml
@@ -16,11 +16,11 @@ permissions:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ANDROID_API_LEVEL: 24
-  ANDROID_PLATFORM: android-35
+  ANDROID_PLATFORM: android-36
   ANDROID_BUILD_TOOLS: 35.0.0
   ANDROID_NDK_VERSION: 27.2.12479018
   OPENSSL_VERSION: 3.0.14
-  LIBGIT2_NATIVE_PACKAGE_VERSION: 2.0.324-android.4
+  LIBGIT2_NATIVE_PACKAGE_VERSION: 2.0.324-android.5
 
 jobs:
   android-build:
@@ -67,16 +67,18 @@ jobs:
 
     - name: Prepare Local Android Feed
       run: |
-        sudo mkdir -p /storage/emulated/0/nuget-local
-        sudo chown -R "$USER":"$USER" /storage
-        mkdir -p artifacts/android artifacts/android-native
+        mkdir -p artifacts/android artifacts/android-native artifacts/nuget-local
 
     - name: Build Android Native Dependencies
       run: |
+        bash ./scripts/build-openssl-android.sh
+        export OPENSSL_ROOT_DIR="${GITHUB_WORKSPACE}/artifacts/android-native/openssl-${OPENSSL_VERSION}-android-arm64/prefix"
+        export OPENSSL_INCLUDE_DIR="${OPENSSL_ROOT_DIR}/include"
+        export OPENSSL_SSL_LIBRARY="${OPENSSL_ROOT_DIR}/lib/libssl.so.3"
+        export OPENSSL_CRYPTO_LIBRARY="${OPENSSL_ROOT_DIR}/lib/libcrypto.so.3"
         export LIB_OUTPUT_PATH="${GITHUB_WORKSPACE}/artifacts/android-native/libgit2-3f4182d.so"
         export LIBGIT2_PATH="$LIB_OUTPUT_PATH"
         bash ./scripts/build-libgit2-android.sh
-        bash ./scripts/build-openssl-android.sh
         bash ./scripts/pack-libgit2sharp-nativebinaries-android.sh
 
     - name: Build Android APK

--- a/scripts/build-libgit2-android.sh
+++ b/scripts/build-libgit2-android.sh
@@ -1,4 +1,4 @@
-#!/data/data/com.termux/files/usr/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -7,8 +7,14 @@ BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/.native/libgit2-build-android-arm64}"
 LIB_NAME="libgit2-3f4182d.so"
 LIB_OUTPUT_PATH="${LIB_OUTPUT_PATH:-$ROOT_DIR/$LIB_NAME}"
 ANDROID_API_LEVEL="${ANDROID_API_LEVEL:-24}"
+OPENSSL_VERSION="${OPENSSL_VERSION:-3.0.14}"
+LIBGIT2_HTTPS_BACKEND="${LIBGIT2_HTTPS_BACKEND:-OpenSSL}"
 
-ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-/data/data/com.termux/files/home/android-sdk}"
+ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/data/data/com.termux/files/home/android-sdk}}"
+OPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-android-arm64/prefix}"
+OPENSSL_INCLUDE_DIR="${OPENSSL_INCLUDE_DIR:-$OPENSSL_ROOT_DIR/include}"
+OPENSSL_SSL_LIBRARY="${OPENSSL_SSL_LIBRARY:-$OPENSSL_ROOT_DIR/lib/libssl.so.3}"
+OPENSSL_CRYPTO_LIBRARY="${OPENSSL_CRYPTO_LIBRARY:-$OPENSSL_ROOT_DIR/lib/libcrypto.so.3}"
 
 if [ -z "${ANDROID_NDK_ROOT:-}" ]; then
   if [ -d "$ANDROID_SDK_ROOT/ndk" ]; then
@@ -21,7 +27,7 @@ if [ -z "${ANDROID_NDK_ROOT:-}" ]; then
   fi
 fi
 
-if [ ! -d "$SRC_DIR/.git" ]; then
+if [ ! -d "$SRC_DIR" ] || ! git -C "$SRC_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Missing submodule at $SRC_DIR. Run: git submodule update --init --recursive"
   exit 1
 fi
@@ -32,17 +38,53 @@ if [ ! -f "$CMAKE_TOOLCHAIN" ]; then
   exit 1
 fi
 
-cmake -S "$SRC_DIR" -B "$BUILD_DIR" -G Ninja \
-  -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN" \
-  -DANDROID_ABI=arm64-v8a \
-  -DANDROID_PLATFORM="android-$ANDROID_API_LEVEL" \
-  -DBUILD_SHARED_LIBS=ON \
-  -DBUILD_CLAR=OFF \
-  -DUSE_SSH=OFF \
-  -DUSE_HTTPS=ON \
+CMAKE_ARGS=(
+  -S "$SRC_DIR"
+  -B "$BUILD_DIR"
+  -G Ninja
+  -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN"
+  -DANDROID_ABI=arm64-v8a
+  -DANDROID_PLATFORM="android-$ANDROID_API_LEVEL"
+  -DBUILD_SHARED_LIBS=ON
+  -DBUILD_TESTS=OFF
+  -DBUILD_CLI=OFF
+  -DBUILD_EXAMPLES=OFF
+  -DBUILD_FUZZERS=OFF
+  -DUSE_SSH=OFF
+  -DUSE_HTTPS="$LIBGIT2_HTTPS_BACKEND"
   -DUSE_BUNDLED_ZLIB=ON
+)
 
-cmake --build "$BUILD_DIR" --target git2
+case "$LIBGIT2_HTTPS_BACKEND" in
+  OpenSSL|OpenSSL-Dynamic)
+    if [ ! -f "$OPENSSL_INCLUDE_DIR/openssl/ssl.h" ]; then
+      echo "Android OpenSSL headers not found under $OPENSSL_INCLUDE_DIR. Run: bash ./scripts/build-openssl-android.sh"
+      exit 1
+    fi
+
+    CMAKE_ARGS+=(
+      -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR"
+      -DOPENSSL_INCLUDE_DIR="$OPENSSL_INCLUDE_DIR"
+      -DCMAKE_PREFIX_PATH="$OPENSSL_ROOT_DIR"
+    )
+
+    if [ "$LIBGIT2_HTTPS_BACKEND" = "OpenSSL" ]; then
+      if [ ! -f "$OPENSSL_SSL_LIBRARY" ] || [ ! -f "$OPENSSL_CRYPTO_LIBRARY" ]; then
+        echo "Android OpenSSL shared libraries not found under $OPENSSL_ROOT_DIR/lib. Run: bash ./scripts/build-openssl-android.sh"
+        exit 1
+      fi
+
+      CMAKE_ARGS+=(
+        -DOPENSSL_SSL_LIBRARY="$OPENSSL_SSL_LIBRARY"
+        -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_CRYPTO_LIBRARY"
+      )
+    fi
+    ;;
+esac
+
+cmake "${CMAKE_ARGS[@]}"
+
+cmake --build "$BUILD_DIR" --target libgit2package
 
 LIB_PATH="$(find "$BUILD_DIR" -type f -name "libgit2.so" | head -n 1 || true)"
 if [ -z "$LIB_PATH" ]; then

--- a/scripts/build-openssl-android.sh
+++ b/scripts/build-openssl-android.sh
@@ -34,8 +34,45 @@ host_tag() {
         echo "darwin-x86_64"
       fi
       ;;
+    MINGW*|MSYS*|CYGWIN*)
+      echo "windows-x86_64"
+      ;;
     *)
       echo "Unsupported host OS: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+ensure_perl() {
+  if perl -MLocale::Maketext::Simple -e1 >/dev/null 2>&1; then
+    return
+  fi
+
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+      local portable_perl_root="$ROOT_DIR/artifacts/tools/strawberry-perl/perl"
+      local portable_perl_lib="$ROOT_DIR/artifacts/tools/perl-lib"
+      if [ -f "$portable_perl_root/lib/Locale/Maketext/Simple.pm" ]; then
+        if [ ! -f "$portable_perl_lib/Locale/Maketext/Simple.pm" ] || [ ! -f "$portable_perl_lib/ExtUtils/MakeMaker.pm" ] || [ ! -f "$portable_perl_lib/Pod/Usage.pm" ]; then
+          mkdir -p "$portable_perl_lib"
+          cp -R "$portable_perl_root/lib/Locale" "$portable_perl_lib/"
+          cp -R "$portable_perl_root/lib/ExtUtils" "$portable_perl_lib/"
+          cp -R "$portable_perl_root/lib/Pod" "$portable_perl_lib/"
+        fi
+
+        export PERL5LIB="$portable_perl_lib${PERL5LIB:+:$PERL5LIB}"
+        if perl -MLocale::Maketext::Simple -MExtUtils::MakeMaker -MPod::Usage -e1 >/dev/null 2>&1; then
+          return
+        fi
+      fi
+
+      echo "A Perl distribution with Locale::Maketext::Simple is required to build Android OpenSSL on Windows."
+      echo "Place a portable Strawberry Perl under artifacts/tools/strawberry-perl so Git Bash perl can reuse Locale and ExtUtils modules."
+      exit 1
+      ;;
+    *)
+      echo "Perl is missing the Locale::Maketext::Simple module required by OpenSSL Configure."
       exit 1
       ;;
   esac
@@ -77,28 +114,101 @@ fi
 rm -rf "$SOURCE_DIR" "$INSTALL_DIR"
 tar -xzf "$ARCHIVE_PATH" -C "$SOURCE_PARENT_DIR"
 
+if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && [ -f "$SOURCE_DIR/Configure" ]; then
+  perl -0pi -e 's/\$target\{exe_extension\}="\.pm"  if \(\$config\{target\} =~ \/vos\/\);/\$target{exe_extension}=".pm"  if (\$config{target} =~ \/vos\/);\n\$target{exe_extension}=".exe" if (\$^O eq "MSWin32" \&\& !\$target{exe_extension});/g' "$SOURCE_DIR/Configure"
+  perl -0pi -e 's/if \(eval \{ require IPC::Cmd; 1; \}\) \{/if (0 \&\& eval { require IPC::Cmd; 1; }) {/g; s/foreach \(File::Spec->path\(\)\) \{\n            my \$fullpath = catfile\(\$_, "\$name\$target\{exe_extension\}"\);\n            if \(-f \$fullpath and -x \$fullpath\) \{\n                return \$fullpath;\n            \}\n        \}/foreach (File::Spec->path()) {\n            foreach my \$fullpath (catfile(\$_, "\$name\$target{exe_extension}"), catfile(\$_, "\$name.exe"), catfile(\$_, \$name)) {\n                next unless -f \$fullpath and -x \$fullpath;\n                \$fullpath =~ s{\\\\}{\/}g;\n                return \$fullpath;\n            }\n        }/g; s/return \$fullpath;/\$fullpath =~ s{\\\\}{\/}g;\n                return \$fullpath;/g' "$SOURCE_DIR/Configure"
+  perl -0pi -e 's/\$ndk = canonpath\(\$ndk\);/\$ndk = canonpath(\$ndk);\n            \$ndk =~ s{\\\\}{\/}g;/g' "$SOURCE_DIR/Configurations/15-android.conf"
+fi
+
 export PATH="$TOOLCHAIN_DIR/bin:$PATH"
-export CC="$TOOLCHAIN_DIR/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang"
-export CXX="$TOOLCHAIN_DIR/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang++"
-export AR="$TOOLCHAIN_DIR/bin/llvm-ar"
-export AS="$CC"
-export LD="$TOOLCHAIN_DIR/bin/ld"
-export RANLIB="$TOOLCHAIN_DIR/bin/llvm-ranlib"
+export ANDROID_NDK_ROOT
+export MSYS2_ENV_CONV_EXCL="PERL5LIB${MSYS2_ENV_CONV_EXCL:+;$MSYS2_ENV_CONV_EXCL}"
 export STRIP="$TOOLCHAIN_DIR/bin/llvm-strip"
 
+if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
+  export SHELL="${SHELL:-$(command -v sh)}"
+  export MAKESHELL="$SHELL"
+fi
+
+ensure_perl
+
 pushd "$SOURCE_DIR" >/dev/null
-./Configure \
+perl ./Configure \
   android-arm64 \
   "-D__ANDROID_API__=$ANDROID_API_LEVEL" \
   shared \
   no-tests \
   no-unit-test \
-  no-docs \
   --prefix="$INSTALL_DIR" \
   --openssldir="$INSTALL_DIR/ssl"
 
-make -j"$(cpu_count)"
-make install_sw
+if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
+  make -j"$(cpu_count)" build_generated libcrypto.a libssl.a libcrypto.ld libssl.ld crypto/libssl-shlib-packet.o
+
+  if [ ! -f "crypto/libssl-shlib-packet.o" ]; then
+    echo "Expected OpenSSL shared packet object was not generated: $SOURCE_DIR/crypto/libssl-shlib-packet.o"
+    exit 1
+  fi
+
+  for generated_file in libcrypto.ld libssl.ld; do
+    if [ ! -f "$generated_file" ]; then
+      echo "Expected OpenSSL version script was not generated: $SOURCE_DIR/$generated_file"
+      exit 1
+    fi
+  done
+
+  "$TOOLCHAIN_DIR/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang" \
+    -fPIC \
+    -pthread \
+    -Wa,--noexecstack \
+    -Qunused-arguments \
+    -Wall \
+    -O3 \
+    -Wl,-znodelete \
+    -shared \
+    -Wl,-Bsymbolic \
+    -Wl,-soname=libcrypto.so.3 \
+    -o libcrypto.so.3 \
+    -Wl,--version-script=libcrypto.ld \
+    -Wl,--whole-archive libcrypto.a \
+    -Wl,--no-whole-archive \
+    -ldl \
+    -pthread
+
+  "$TOOLCHAIN_DIR/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang" \
+    -fPIC \
+    -pthread \
+    -Wa,--noexecstack \
+    -Qunused-arguments \
+    -Wall \
+    -O3 \
+    -Wl,-znodelete \
+    -shared \
+    -Wl,-Bsymbolic \
+    -Wl,-soname=libssl.so.3 \
+    -o libssl.so.3 \
+    -Wl,--version-script=libssl.ld \
+    crypto/libssl-shlib-packet.o \
+    -Wl,--whole-archive libssl.a \
+    -Wl,--no-whole-archive \
+    ./libcrypto.so.3 \
+    -ldl \
+    -pthread
+
+  mkdir -p "$INSTALL_DIR/lib" "$INSTALL_DIR/include"
+  cp -R include/openssl "$INSTALL_DIR/include/"
+  install -m 0644 libcrypto.so.3 "$INSTALL_DIR/lib/libcrypto.so.3"
+  install -m 0644 libssl.so.3 "$INSTALL_DIR/lib/libssl.so.3"
+else
+  # Android packaging only needs the shared libraries and headers; building the
+  # full software bundle also pulls in target-side programs we never ship.
+  make -j"$(cpu_count)" build_generated libcrypto.so libssl.so
+
+  mkdir -p "$INSTALL_DIR/lib" "$INSTALL_DIR/include"
+  cp -R include/openssl "$INSTALL_DIR/include/"
+  install -m 0644 libcrypto.so "$INSTALL_DIR/lib/libcrypto.so.3"
+  install -m 0644 libssl.so "$INSTALL_DIR/lib/libssl.so.3"
+fi
 popd >/dev/null
 
 "$STRIP" --strip-unneeded "$INSTALL_DIR/lib/libssl.so.3" "$INSTALL_DIR/lib/libcrypto.so.3"

--- a/scripts/pack-libgit2sharp-nativebinaries-android.sh
+++ b/scripts/pack-libgit2sharp-nativebinaries-android.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_ID="${PACKAGE_ID:-LibGit2Sharp.NativeBinaries}"
 UPSTREAM_VERSION="${UPSTREAM_VERSION:-2.0.323}"
-PACKAGE_VERSION="${PACKAGE_VERSION:-${LIBGIT2_NATIVE_PACKAGE_VERSION:-2.0.324-android.4}}"
+PACKAGE_VERSION="${PACKAGE_VERSION:-${LIBGIT2_NATIVE_PACKAGE_VERSION:-2.0.324-android.5}}"
 OPENSSL_VERSION="${OPENSSL_VERSION:-3.0.14}"
-NUGET_LOCAL_FEED="${NUGET_LOCAL_FEED:-/storage/emulated/0/nuget-local}"
+NUGET_LOCAL_FEED="${NUGET_LOCAL_FEED:-$ROOT_DIR/artifacts/nuget-local}"
 LIBGIT2_PATH="${LIBGIT2_PATH:-$ROOT_DIR/libgit2-3f4182d.so}"
 OPENSSL_LIB_DIR="${OPENSSL_LIB_DIR:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-android-arm64/prefix/lib}"
 DOWNLOAD_DIR="${PACKAGE_DOWNLOAD_DIR:-$ROOT_DIR/artifacts/android-native/nuget-downloads}"
@@ -17,6 +17,56 @@ STAGING_DIR="$TEMP_DIR/package"
 
 cleanup() {
   rm -rf "$TEMP_DIR"
+}
+
+create_package_archive() {
+  if command -v zip >/dev/null 2>&1; then
+    pushd "$STAGING_DIR" >/dev/null
+    zip -X -q -r "$OUTPUT_PACKAGE_PATH" .
+    popd >/dev/null
+    return
+  fi
+
+  local python_bin=""
+  if command -v python3 >/dev/null 2>&1; then
+    python_bin="python3"
+  elif command -v python >/dev/null 2>&1; then
+    python_bin="python"
+  fi
+
+  if [ -n "$python_bin" ]; then
+    "$python_bin" - "$STAGING_DIR" "$OUTPUT_PACKAGE_PATH" <<'PY'
+import pathlib
+import sys
+import zipfile
+
+staging_dir = pathlib.Path(sys.argv[1])
+output_path = pathlib.Path(sys.argv[2])
+
+with zipfile.ZipFile(output_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+    for candidate in sorted(staging_dir.rglob("*")):
+        if candidate.is_dir():
+            continue
+        archive.write(candidate, candidate.relative_to(staging_dir).as_posix())
+PY
+    return
+  fi
+
+  if command -v powershell.exe >/dev/null 2>&1; then
+    local staging_windows_path="$STAGING_DIR"
+    local output_windows_path="$OUTPUT_PACKAGE_PATH"
+
+    if command -v cygpath >/dev/null 2>&1; then
+      staging_windows_path="$(cygpath -w "$STAGING_DIR")"
+      output_windows_path="$(cygpath -w "$OUTPUT_PACKAGE_PATH")"
+    fi
+
+    powershell.exe -NoProfile -Command "\$ErrorActionPreference = 'Stop'; \$stagingPath = '$staging_windows_path'; \$outputPath = '$output_windows_path'; if (Test-Path -LiteralPath \$outputPath) { Remove-Item -LiteralPath \$outputPath -Force }; Compress-Archive -Path (Join-Path \$stagingPath '*') -DestinationPath \$outputPath -CompressionLevel Optimal"
+    return
+  fi
+
+  echo "Neither zip, python, nor powershell.exe is available to create $OUTPUT_PACKAGE_PATH"
+  exit 1
 }
 
 trap cleanup EXIT
@@ -50,9 +100,7 @@ install -m 0644 "$OPENSSL_LIB_DIR/libcrypto.so.3" "$STAGING_DIR/runtimes/android
 sed -i "s#<version>$UPSTREAM_VERSION</version>#<version>$PACKAGE_VERSION</version>#" "$STAGING_DIR/$PACKAGE_ID.nuspec"
 rm -f "$OUTPUT_PACKAGE_PATH"
 
-pushd "$STAGING_DIR" >/dev/null
-zip -X -q -r "$OUTPUT_PACKAGE_PATH" .
-popd >/dev/null
+create_package_archive
 
 for required_entry in \
   "runtimes/android-arm64/native/libgit2-3f4182d.so" \

--- a/scripts/test-android-build-scripts.ps1
+++ b/scripts/test-android-build-scripts.ps1
@@ -1,0 +1,129 @@
+$ErrorActionPreference = 'Stop'
+
+$rootDir = Split-Path -Parent $PSScriptRoot
+$buildLibgit2Script = Get-Content -Raw (Join-Path $PSScriptRoot 'build-libgit2-android.sh')
+$buildOpenSslScript = Get-Content -Raw (Join-Path $PSScriptRoot 'build-openssl-android.sh')
+$packScript = Get-Content -Raw (Join-Path $PSScriptRoot 'pack-libgit2sharp-nativebinaries-android.sh')
+$nugetConfig = Get-Content -Raw (Join-Path $rootDir 'src\nuget.config')
+$gitattributes = Get-Content -Raw (Join-Path $rootDir '.gitattributes')
+$workflow = Get-Content -Raw (Join-Path $rootDir '.github\workflows\android-packaging.yml')
+$submoduleGitFile = Join-Path $rootDir '.native\libgit2-src\.git'
+$shellScripts = @(
+    @{
+        Name = 'build-libgit2-android.sh'
+        Path = Join-Path $PSScriptRoot 'build-libgit2-android.sh'
+        Content = $buildLibgit2Script
+    },
+    @{
+        Name = 'build-openssl-android.sh'
+        Path = Join-Path $PSScriptRoot 'build-openssl-android.sh'
+        Content = $buildOpenSslScript
+    },
+    @{
+        Name = 'pack-libgit2sharp-nativebinaries-android.sh'
+        Path = Join-Path $PSScriptRoot 'pack-libgit2sharp-nativebinaries-android.sh'
+        Content = $packScript
+    }
+)
+
+function Assert-Match {
+    param(
+        [string]$Content,
+        [string]$Pattern,
+        [string]$Message
+    )
+
+    if ($Content -notmatch $Pattern) {
+        throw $Message
+    }
+}
+
+function Assert-NotMatch {
+    param(
+        [string]$Content,
+        [string]$Pattern,
+        [string]$Message
+    )
+
+    if ($Content -match $Pattern) {
+        throw $Message
+    }
+}
+
+function Assert-NoCrLf {
+    param(
+        [string]$Content,
+        [string]$Message
+    )
+
+    if ($Content.Contains("`r`n")) {
+        throw $Message
+    }
+}
+
+if (-not (Test-Path $submoduleGitFile -PathType Leaf)) {
+    throw "Expected git submodule marker file at $submoduleGitFile"
+}
+
+Assert-Match $buildLibgit2Script 'git -C "\$SRC_DIR" rev-parse --is-inside-work-tree' 'build-libgit2-android.sh must validate submodule with git rev-parse.'
+Assert-NotMatch $buildLibgit2Script '\[ ! -d "\$SRC_DIR/\.git" \]' 'build-libgit2-android.sh must not require .git to be a directory.'
+
+Assert-Match $buildLibgit2Script '#!/usr/bin/env bash' 'build-libgit2-android.sh must use a portable bash shebang.'
+Assert-Match $buildLibgit2Script 'LIBGIT2_HTTPS_BACKEND="\$\{LIBGIT2_HTTPS_BACKEND:-OpenSSL\}"' 'build-libgit2-android.sh must default libgit2 HTTPS backend to OpenSSL for Android builds.'
+Assert-Match $buildLibgit2Script 'OPENSSL_ROOT_DIR="\$\{OPENSSL_ROOT_DIR:-\$ROOT_DIR/artifacts/android-native/openssl-\$OPENSSL_VERSION-android-arm64/prefix\}"' 'build-libgit2-android.sh must default OpenSSL root to repo-local Android artifacts.'
+Assert-Match $buildLibgit2Script '-DBUILD_TESTS=OFF' 'build-libgit2-android.sh must disable libgit2 tests for Android packaging.'
+Assert-Match $buildLibgit2Script '-DBUILD_CLI=OFF' 'build-libgit2-android.sh must disable libgit2 CLI for Android packaging.'
+Assert-Match $buildLibgit2Script '--target libgit2package' 'build-libgit2-android.sh must build the shared libgit2 package target.'
+Assert-Match $buildOpenSslScript 'MINGW\*\|MSYS\*\|CYGWIN\*' 'build-openssl-android.sh must support Windows Git Bash/MSYS host detection.'
+Assert-Match $buildOpenSslScript 'Locale::Maketext::Simple' 'build-openssl-android.sh must validate a usable Perl runtime for OpenSSL on Windows.'
+Assert-Match $buildOpenSslScript '\$ROOT_DIR/artifacts/tools/strawberry-perl/perl' 'build-openssl-android.sh must source repo-local portable Strawberry Perl modules on Windows.'
+Assert-Match $buildOpenSslScript '\$ROOT_DIR/artifacts/tools/perl-lib' 'build-openssl-android.sh must stage portable Perl modules into repo-local perl-lib for Git Bash.'
+Assert-Match $buildOpenSslScript 'export PERL5LIB=' 'build-openssl-android.sh must support Git Bash perl via portable Strawberry Perl modules.'
+Assert-Match $buildOpenSslScript 'ExtUtils/MakeMaker\.pm' 'build-openssl-android.sh must stage ExtUtils::MakeMaker for Git Bash perl.'
+Assert-Match $buildOpenSslScript 'Pod/Usage\.pm' 'build-openssl-android.sh must stage Pod::Usage for Git Bash perl.'
+Assert-Match $buildOpenSslScript 'MSYS2_ENV_CONV_EXCL' 'build-openssl-android.sh must prevent MSYS from rewriting PERL5LIB for Windows-host make invocations.'
+Assert-Match $buildOpenSslScript 'export MAKESHELL' 'build-openssl-android.sh must force make to run under sh on Windows hosts.'
+Assert-Match $buildOpenSslScript 'exe_extension' 'build-openssl-android.sh must patch OpenSSL Configure host executable extension on Windows hosts.'
+Assert-Match $buildOpenSslScript 'MSWin32' 'build-openssl-android.sh must special-case Windows-host OpenSSL Configure execution.'
+Assert-Match $buildOpenSslScript 'if \(0 \\&\\& eval \{ require IPC::Cmd; 1; \}\)' 'build-openssl-android.sh must disable IPC::Cmd path probing in OpenSSL Configure on Windows hosts.'
+Assert-Match $buildOpenSslScript '\$name\.exe' 'build-openssl-android.sh must teach OpenSSL Configure fallback tool lookup to probe .exe host tools.'
+Assert-Match $buildOpenSslScript 'Configurations/15-android\.conf' 'build-openssl-android.sh must patch OpenSSL Android config for Windows-host Android builds.'
+Assert-Match $buildOpenSslScript '\$ndk =~ s' 'build-openssl-android.sh must normalize Android NDK paths inside OpenSSL Android config on Windows hosts.'
+Assert-Match $buildOpenSslScript 'build_generated libcrypto\.a libssl\.a libcrypto\.ld libssl\.ld crypto/libssl-shlib-packet\.o' 'build-openssl-android.sh must build OpenSSL version scripts and shared packet object before Windows relinking.'
+Assert-Match $buildOpenSslScript 'crypto/libssl-shlib-packet\.o' 'build-openssl-android.sh must include the OpenSSL shared packet object in the Windows libssl.so.3 relink.'
+Assert-Match $buildOpenSslScript 'for generated_file in libcrypto\.ld libssl\.ld' 'build-openssl-android.sh must verify OpenSSL version scripts exist before Windows relinking.'
+Assert-Match $buildOpenSslScript '--whole-archive libcrypto\.a' 'build-openssl-android.sh must relink libcrypto.so.3 from libcrypto.a on Windows hosts.'
+Assert-Match $buildOpenSslScript '--whole-archive libssl\.a' 'build-openssl-android.sh must relink libssl.so.3 from libssl.a on Windows hosts.'
+Assert-NotMatch $buildOpenSslScript '-Wl,--version-script=libssl\.ld\s+-Wl,--whole-archive libssl\.a\s+-Wl,--no-whole-archive\s+\./libcrypto\.so\.3' 'build-openssl-android.sh must not relink libssl.so.3 without crypto/libssl-shlib-packet.o.'
+Assert-Match $buildOpenSslScript 'export ANDROID_NDK_ROOT' 'build-openssl-android.sh must export ANDROID_NDK_ROOT for OpenSSL Configure.'
+Assert-Match $buildOpenSslScript 'perl \./Configure' 'build-openssl-android.sh must invoke OpenSSL Configure via the selected perl runtime.'
+Assert-NotMatch $buildOpenSslScript 'export CC=' 'build-openssl-android.sh must rely on NDK clang detection from PATH instead of hardwiring CC.'
+Assert-NotMatch $buildOpenSslScript 'no-docs' 'build-openssl-android.sh must not pass unsupported no-docs to OpenSSL Configure.'
+Assert-Match $buildOpenSslScript 'make -j"\$\(cpu_count\)" build_generated libcrypto\.so libssl\.so' 'build-openssl-android.sh must build only the Android OpenSSL shared libraries on non-Windows hosts.'
+Assert-Match $buildOpenSslScript 'install -m 0644 libcrypto\.so "\$INSTALL_DIR/lib/libcrypto\.so\.3"' 'build-openssl-android.sh must rename the non-Windows libcrypto.so output to libcrypto.so.3 when staging Android artifacts.'
+Assert-Match $buildOpenSslScript 'install -m 0644 libssl\.so "\$INSTALL_DIR/lib/libssl\.so\.3"' 'build-openssl-android.sh must rename the non-Windows libssl.so output to libssl.so.3 when staging Android artifacts.'
+Assert-NotMatch $buildOpenSslScript '(?s)else\s+.*build_sw' 'build-openssl-android.sh must not invoke OpenSSL build_sw on non-Windows hosts.'
+Assert-NotMatch $buildOpenSslScript '(?s)else\s+.*make install_sw' 'build-openssl-android.sh must not invoke install_sw on non-Windows hosts.'
+
+Assert-Match $packScript '\$ROOT_DIR/artifacts/nuget-local' 'pack-libgit2sharp-nativebinaries-android.sh must default to repo-local NuGet feed.'
+Assert-NotMatch $packScript '/storage/emulated/0/nuget-local' 'pack-libgit2sharp-nativebinaries-android.sh must not hardcode Termux feed path.'
+Assert-Match $packScript '2\.0\.324-android\.5' 'pack-libgit2sharp-nativebinaries-android.sh must default to the fixed Android native package version.'
+Assert-Match $packScript 'command -v zip' 'pack-libgit2sharp-nativebinaries-android.sh must probe for zip before packing.'
+Assert-Match $packScript 'command -v python3' 'pack-libgit2sharp-nativebinaries-android.sh must probe for a native Python archiver fallback.'
+Assert-Match $packScript 'zipfile' 'pack-libgit2sharp-nativebinaries-android.sh must support Python-based package creation when zip is unavailable.'
+Assert-Match $packScript 'powershell\.exe' 'pack-libgit2sharp-nativebinaries-android.sh must fall back to PowerShell packing on Windows hosts.'
+Assert-Match $packScript 'Compress-Archive' 'pack-libgit2sharp-nativebinaries-android.sh must support PowerShell archive creation when zip is unavailable.'
+
+Assert-Match $nugetConfig '\.\./artifacts/nuget-local' 'src/nuget.config must reference repo-local NuGet feed.'
+Assert-Match $gitattributes '(?m)^\*\.sh\s+text\s+eol=lf\s*$' '.gitattributes must pin shell scripts to LF line endings.'
+Assert-Match $workflow 'ANDROID_PLATFORM:\s+android-36' 'android-packaging workflow must install Android platform 36 for the current .NET Android workload.'
+Assert-Match $workflow 'artifacts/android artifacts/android-native artifacts/nuget-local' 'android-packaging workflow must create repo-local feed directory.'
+Assert-Match $workflow 'bash ./scripts/build-openssl-android\.sh[\s\S]*bash ./scripts/build-libgit2-android\.sh' 'android-packaging workflow must build Android OpenSSL before libgit2.'
+Assert-NotMatch $workflow '/storage/emulated/0/nuget-local' 'android-packaging workflow must not prepare Termux-only feed path.'
+
+foreach ($shellScript in $shellScripts) {
+    $rawContent = [System.IO.File]::ReadAllText($shellScript.Path)
+    Assert-NoCrLf $rawContent "$($shellScript.Name) must use LF line endings so Git Bash can execute it on Windows."
+}
+
+Write-Output 'Android build script regression checks passed.'

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -50,7 +50,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="AvaloniaGraphControl" Version="0.6.1" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
-	<PackageVersion Include="LibGit2Sharp.NativeBinaries" Version="2.0.324-android.4" />
+	<PackageVersion Include="LibGit2Sharp.NativeBinaries" Version="2.0.324-android.5" />
     <PackageVersion Include="Mileeena.Notification.Avalonia" Version="2.1.2" />
     <PackageVersion Include="Packaging.Targets" Version="0.1.232" />
     <PackageVersion Include="Quartz" Version="3.8.1" />

--- a/src/Unlimotion.sln
+++ b/src/Unlimotion.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.3.32811.315
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11626.173 insiders
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unlimotion", "Unlimotion\Unlimotion.csproj", "{7F213DC0-4CB1-477D-A526-70A95AE3E622}"
 EndProject
@@ -15,6 +15,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Unlimotion.Desktop", "Unlim
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution", "Solution", "{4BD8DA85-B821-4032-98CA-F82B4DE4532C}"
 	ProjectSection(SolutionItems) = preProject
+		.env = .env
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 		global.json = global.json

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -6,7 +6,7 @@
 
 <configuration>
   <packageSources>
-    <add key="local" value="/storage/emulated/0/nuget-local" />
+    <add key="local" value="../artifacts/nuget-local" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
## Summary
- fix Android CI and local native dependency build flow, including submodule gitdir detection, repo-local NuGet packaging, and Android SDK alignment
- fix Windows-host OpenSSL relink for Android so Debug APK no longer carries a broken `libssl.so.3` that causes `System.DllNotFoundException: "git2-3f4182d"`
- bump custom `LibGit2Sharp.NativeBinaries` to `2.0.324-android.5` and add regression coverage for the Android build scripts

## Validation
- `pwsh -File scripts/test-android-build-scripts.ps1`
- `dotnet restore src/Unlimotion.Android/Unlimotion.Android.csproj --configfile src/nuget.config`
- `dotnet build src/Unlimotion.Android/Unlimotion.Android.csproj -c Release -t:Package`
- `dotnet build src/Unlimotion.Android/Unlimotion.Android.csproj -c Debug -t:Package --no-restore -m:1 -nr:false -p:RuntimeIdentifier=android-arm64`

## Notes
- The latest Debug native fix was validated by inspecting the rebuilt ARM64 APK and native libraries.
- A fresh `adb` runtime smoke test was not rerun at PR time because no Android device was connected.