### PR TITLE
Add Codex env setup script and improve SSH handling in BackupViaGitService

### DIFF
--- a/scripts/prepare-codex-env.sh
+++ b/scripts/prepare-codex-env.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   source scripts/prepare-codex-env.sh
+#
+# This script normalizes PATH for Codex sessions so `dotnet` and global tools
+# are available immediately.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+if [[ -x "/root/.dotnet/dotnet" ]]; then
+  export DOTNET_ROOT="/root/.dotnet"
+  export PATH="${DOTNET_ROOT}:${PATH}"
+fi
+
+if [[ -d "${HOME}/.dotnet/tools" ]]; then
+  export PATH="${HOME}/.dotnet/tools:${PATH}"
+fi
+
+if command -v dotnet >/dev/null 2>&1; then
+  echo "[prepare-codex-env] dotnet: $(command -v dotnet)"
+  dotnet --version
+else
+  echo "[prepare-codex-env] dotnet not found in PATH after setup." >&2
+  echo "[prepare-codex-env] Expected location: /root/.dotnet/dotnet" >&2
+  exit 1
+fi
+
+git config --global --add safe.directory "${REPO_ROOT}" || true
+
+# Best-effort tuning for large test runs that create many file watchers.
+if command -v sysctl >/dev/null 2>&1; then
+  CURRENT_INOTIFY_LIMIT="$(sysctl -n fs.inotify.max_user_instances 2>/dev/null || echo "")"
+  TARGET_INOTIFY_LIMIT="1024"
+  if [[ -n "${CURRENT_INOTIFY_LIMIT}" ]] && [[ "${CURRENT_INOTIFY_LIMIT}" -lt "${TARGET_INOTIFY_LIMIT}" ]]; then
+    if sysctl -w "fs.inotify.max_user_instances=${TARGET_INOTIFY_LIMIT}" >/dev/null 2>&1; then
+      echo "[prepare-codex-env] inotify max_user_instances raised to ${TARGET_INOTIFY_LIMIT}"
+    else
+      echo "[prepare-codex-env] warning: unable to raise fs.inotify.max_user_instances (insufficient privileges?)"
+    fi
+  fi
+fi
+
+echo "[prepare-codex-env] Environment ready for ${REPO_ROOT}"

--- a/src/Unlimotion/Services/BackupViaGitService.cs
+++ b/src/Unlimotion/Services/BackupViaGitService.cs
@@ -175,6 +175,12 @@ public class BackupViaGitService : IRemoteBackupService
         {
             if (IsSshUrl(url))
             {
+                var privateKeyPath = gitSettings.SshPrivateKeyPath;
+                if (!string.IsNullOrWhiteSpace(privateKeyPath) && File.Exists(privateKeyPath))
+                {
+                    TryAddSshKeyToAgent(privateKeyPath);
+                }
+
                 return new DefaultCredentials();
             }
 
@@ -427,8 +433,48 @@ public class BackupViaGitService : IRemoteBackupService
             return false;
         }
 
-        return remoteUrl.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase)
-               || remoteUrl.StartsWith("git@", StringComparison.OrdinalIgnoreCase);
+        if (remoteUrl.StartsWith("ssh://", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (Uri.TryCreate(remoteUrl, UriKind.Absolute, out var uri))
+        {
+            return string.Equals(uri.Scheme, "ssh", StringComparison.OrdinalIgnoreCase);
+        }
+
+        var atSignIndex = remoteUrl.IndexOf('@');
+        var colonIndex = remoteUrl.LastIndexOf(':');
+        return atSignIndex > 0
+               && colonIndex > atSignIndex + 1
+               && remoteUrl.IndexOf("://", StringComparison.Ordinal) < 0;
+    }
+
+    private static void TryAddSshKeyToAgent(string privateKeyPath)
+    {
+        try
+        {
+            var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "ssh-add",
+                Arguments = $"\"{privateKeyPath}\"",
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            });
+
+            if (process == null)
+            {
+                return;
+            }
+
+            process.WaitForExit();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to add SSH key to agent: {ex.Message}");
+        }
     }
 
     private static string GetSshDirectory()


### PR DESCRIPTION
### Motivation

- Ensure `dotnet` and global tools are available immediately in Codex sessions by normalizing PATH and environment.
- Improve SSH-based git authentication by detecting a wider range of SSH URL formats and trying to add an SSH private key to the agent when available.

### Description

- Add `scripts/prepare-codex-env.sh` to export `DOTNET_ROOT`, prepend `~/.dotnet/tools` to `PATH`, configure the repo as a safe Git directory, and attempt to raise `fs.inotify.max_user_instances` for large test runs.
- Update `GetCredentials` in `BackupViaGitService` to, for SSH URLs, attempt to add the configured private key (`gitSettings.SshPrivateKeyPath`) to the SSH agent before returning `DefaultCredentials`.
- Replace the previous simple string checks in `IsSshUrl` with robust detection that handles `ssh://` URIs, absolute URIs with `ssh` scheme, and SCP-like `user@host:repo` forms while avoiding false positives for other schemes.
- Add `TryAddSshKeyToAgent` helper which runs `ssh-add` against a private key path and logs failures to `Debug` without throwing.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa24d9f308328ae2273333bcb5b97)