### PR TITLE
Show repeater marker in task views

### DIFF
--- a/specs/2026-04-22-repeater-list-badge.md
+++ b/specs/2026-04-22-repeater-list-badge.md
@@ -1,0 +1,219 @@
+# Пометка повторяемых задач в списках и на карте
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; profile `dotnet-desktop-client`; context `testing-dotnet`
+- Владелец: Codex
+- Масштаб: small
+- Целевой релиз / ветка: `feature/repeater-list-badge`
+- Ограничения: реализация после подтверждения фразой `Спеку подтверждаю`; не менять persisted model и публичные API без необходимости
+- Связанные ссылки: запрос пользователя от 2026-04-22
+
+## 1. Overview / Цель
+Добавить в списках задач и на карте видимую компактную пометку для задач, у которых задан шаблон повторения. Пользователь должен видеть повторяемость прямо в списке или узле карты, без открытия карточки задачи.
+
+## 2. Текущее состояние (AS-IS)
+- Повторение хранится в `TaskItemViewModel.Repeater` как `RepeaterPatternViewModel`.
+- Признак активного повторения уже вычисляется через `TaskItemViewModel.IsHaveRepeater`: `Repeater != null && Repeater.Type != RepeaterType.None`.
+- В `MainControl.axaml` есть общий `DataTemplate` для `TaskItemViewModel`; он используется в основном дереве `AllTasksTree` и relation-деревьях в карточке.
+- Вкладки `LastCreated`, `LastUpdated`, `Unlocked`, `Completed`, `Archived`, `LastOpened` имеют inline-шаблоны строк с `TaskItem.GetAllEmoji` и `TaskItem.Title`.
+- В `GraphControl.axaml` узлы карты задач показывают checkbox, emoji и `TitleWithoutEmoji`, но не показывают повторяемость.
+- В деталях задачи уже есть блок выбора `RepeaterTemplates`, но списки задач не показывают, что у задачи есть повторение.
+
+## 3. Проблема
+Повторяемые задачи визуально не отличаются от обычных задач в списках и на карте, поэтому пользователь не видит важный атрибут задачи при сканировании списка или roadmap-графа.
+
+## 4. Цели дизайна
+- Разделение ответственности: вычисление признака и текста подсказки держать во ViewModel, разметку - в `MainControl.axaml`.
+- Повторное использование: использовать один и тот же VM-контракт во всех списочных шаблонах.
+- Тестируемость: покрыть вычисляемые свойства VM и headless UI-проверкой хотя бы один общий/основной список.
+- Консистентность: пометка должна быть одинаковой в основном дереве, relation-деревьях, табличных списках вкладок и узлах карты.
+- Обратная совместимость: не менять формат хранения задач, повторений и существующие команды.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не менять алгоритм расчёта повторений и клонирования задач.
+- Не добавлять фильтр/сортировку по повторяемым задачам.
+- Не менять persisted DTO/domain-модели `TaskItem` и `RepeaterPattern`.
+- Не переразрабатывать строки списков и структуру вкладок.
+- Не менять UX выбора шаблона повторения в деталях задачи.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `TaskItemViewModel.cs` -> добавить вычисляемый display-контракт для списков: наличие пометки, символ пометки и tooltip/accessible text.
+- `MainControl.axaml` -> добавить компактный marker control рядом с заголовком задачи во всех списочных шаблонах.
+- `GraphControl.axaml` -> добавить тот же marker control рядом с заголовком задачи в узле карты.
+- `MainControlTreeCommandsUiTests.cs` или отдельный UI test file -> проверить, что marker появляется для задачи с активным repeater и отсутствует для обычной.
+- `TaskItemViewModel` tests -> проверить вычисляемые свойства и уведомления при смене `Repeater`/`Repeater.Type`.
+
+### 6.2 Детальный дизайн
+- Добавить во ViewModel вычисляемые свойства:
+  - использовать существующий `IsHaveRepeater` как единственный source of truth для видимости marker.
+  - `RepeaterListMarker` со значением `↻` для активного повторения и пустой строкой для отсутствия повторения.
+  - `RepeaterListMarkerToolTip` со значением `Repeater.Title` при активном повторении и `null`/пустым значением иначе.
+- Для `Repeater` добавить `AlsoNotifyFor(nameof(IsHaveRepeater), nameof(RepeaterListMarker), nameof(RepeaterListMarkerToolTip))` или эквивалентные явные `RaisePropertyChanged`.
+- Для вложенного `RepeaterPatternViewModel.PropertyChanged` завести отдельную заменяемую подписку (`SerialDisposable` или `Switch`-паттерн): при смене `Repeater` старая подписка должна быть disposed и не должна больше поднимать marker-уведомления.
+- При изменениях внутри текущего `RepeaterPatternViewModel` поднимать marker-уведомления сразу, без существующего throttling для сохранения, минимум для `Type`, `Period`, weekday-флагов и `AfterComplete`, чтобы tooltip и видимость обновлялись без пересоздания строки.
+- В XAML добавить компактный `TextBlock`/`Label` с `Text="{Binding ...RepeaterListMarker}"`, `IsVisible="{Binding ...IsHaveRepeater}"`, `ToolTip.Tip="{Binding ...RepeaterListMarkerToolTip}"` и отдельным automation id для UI-теста.
+- В inline-шаблонах вставить marker между emoji/date-блоком и `Title`, расширив `ColumnDefinitions` на один `Auto`.
+- В общем `DataTemplate` для `TaskItemViewModel` добавить marker перед `Title`; это покроет `AllTasksTree` и relation-деревья.
+- В `GraphControl.axaml` вставить marker между emoji и `TitleWithoutEmoji`, расширив `ColumnDefinitions` узла на один `Auto`.
+- Ошибки обработки не добавляются: marker полностью вычисляемый и не должен влиять на команды/drag-drop/selection.
+- Производительность: вычисление O(1), без обхода дерева и без синхронных операций на UI-потоке.
+
+## 7. Бизнес-правила / Алгоритмы
+| Условие | Пометка в списке/на карте | Tooltip |
+| --- | --- | --- |
+| `Repeater == null` | нет | нет |
+| `Repeater.Type == RepeaterType.None` | нет | нет |
+| `Repeater.Type != RepeaterType.None` | `↻` | локализованный `Repeater.Title` |
+
+## 8. Точки интеграции и триггеры
+- Загрузка/обновление задачи через `TaskItemViewModel.Update(TaskItem)` обязана обновлять marker после установки/сброса `Repeater`.
+- Изменение шаблона в деталях задачи через binding к `Repeater`/`RepeaterPatternViewModel` должно обновлять marker в списках.
+- Замена `Repeater` должна отписывать `TaskItemViewModel` от старого `RepeaterPatternViewModel`; изменения старого объекта после замены не являются триггером для текущей строки.
+- Все `TreeView` с `TaskWrapperViewModel` в `MainControl.axaml` должны использовать один и тот же признак `TaskItem.IsHaveRepeater`.
+- Узел задачи в `GraphControl.axaml` должен использовать тот же VM-контракт `IsHaveRepeater`/`RepeaterListMarker`/`RepeaterListMarkerToolTip`.
+
+## 9. Изменения модели данных / состояния
+- Новых persisted полей нет.
+- Новое состояние только вычисляемое во ViewModel.
+- Влияния на storage, миграции и remote model нет.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция не требуется.
+- Первый запуск после обновления покажет marker для уже существующих задач с `Repeater.Type != None`.
+- Rollback: удалить VM display-свойства/уведомления и XAML marker controls; данные задач не меняются.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  - В списках задач повторяемая задача получает компактную пометку рядом с заголовком.
+  - На карте задач повторяемая задача получает такую же компактную пометку рядом с заголовком узла.
+  - Задача без `Repeater` и задача с `RepeaterType.None` пометку не получает.
+  - Tooltip marker отражает текущий локализованный заголовок шаблона повторения.
+  - При изменении шаблона повторения в текущей задаче marker обновляется без перезапуска приложения.
+  - Существующие selection, drag/drop, remove button и tree commands не ломаются.
+- Автотесты:
+  - Unit: свойства marker в `TaskItemViewModel` для `null`, `None`, `Daily/Weekly`.
+  - Unit: `PropertyChanged` для marker-свойств при присваивании `Repeater` и изменении `Repeater.Type`.
+  - Unit: после замены `Repeater` изменение старого `RepeaterPatternViewModel` не поднимает marker-уведомления для текущей задачи.
+  - UI/headless: общий `DataTemplate` показывает marker в `AllTasksTree` для задачи с active repeater и не показывает для обычной задачи.
+  - UI/headless или структурный тест XAML: inline-шаблоны `LastCreatedTree`, `LastUpdatedTree`, `UnlockedTree`, `CompletedTree`, `ArchivedTree`, `LastOpenedTree` содержат marker рядом с `TaskItem.Title`.
+  - UI/headless или структурный тест XAML: шаблон узла `GraphControl.axaml` содержит marker рядом с `TitleWithoutEmoji`.
+- Команды для проверки:
+  - `rg -n "TaskItem.Title|TaskItem.GetAllEmoji|RepeaterListMarker|TitleWithoutEmoji" src/Unlimotion/Views/MainControl.axaml src/Unlimotion/Views/GraphControl.axaml`
+  - `dotnet build src/Unlimotion.sln`
+  - `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -- --treenode-filter "/*/*/TaskItemRepeaterListMarkerTests/*" --no-progress`
+  - `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -- --treenode-filter "/*/*/TaskListRepeaterMarkerUiTests/*" --no-progress`
+  - `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj`
+  - `dotnet test src/Unlimotion.sln --no-build`
+
+## 12. Риски и edge cases
+- Риск: existing computed property `IsHaveRepeater` может не уведомлять UI при изменении вложенного `Repeater.Type`. Смягчение: добавить явные уведомления marker-свойств из подписки на `RepeaterPatternViewModel.PropertyChanged`.
+- Риск: при замене `Repeater` старая подписка останется активной и будет поднимать ложные уведомления/сохранять задачу. Смягчение: отдельная заменяемая подписка с disposal старого repeater и regression-тестом.
+- Риск: inline-шаблонов несколько, можно обновить не все вкладки. Смягчение: после правки проверить поиском все `TaskItem.Title` в `MainControl.axaml`.
+- Риск: карта использует отдельный XAML-шаблон и может остаться без marker. Смягчение: добавить structural-тест на `GraphControl.axaml`.
+- Риск: marker сдвинет строки в плотных списках. Смягчение: использовать короткий `Auto`-столбец, небольшой margin и не менять размеры checkbox/date/title.
+- Риск: tooltip локализации не обновится при смене языка. Смягчение: использовать существующий `Repeater.Title`; при необходимости в EXEC добавить `RaisePropertyChanged` для tooltip в том же месте, где уже обновляются localized display definitions.
+
+## 13. План выполнения
+1. Добавить display-свойства marker в `TaskItemViewModel`, используя `IsHaveRepeater` как единственный признак видимости.
+2. Добавить безопасную заменяемую подписку на текущий `RepeaterPatternViewModel.PropertyChanged` и marker-уведомления.
+3. Добавить/обновить unit-тесты для marker-свойств, `PropertyChanged` и отписки от старого `Repeater`.
+4. Обновить общий `DataTemplate` и inline-шаблоны списков в `MainControl.axaml`.
+5. Обновить шаблон узла карты в `GraphControl.axaml`.
+6. Добавить headless UI-тест на наличие/отсутствие marker и structural/checklist-проверку всех inline-шаблонов и карты.
+7. Запустить targeted tests, затем build и полный тестовый прогон.
+8. Выполнить post-EXEC review и исправить найденные критичные проблемы.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов. Визуальную форму выбираю как компактный символ `↻` с tooltip, потому что это минимальное изменение, не требует новых ассетов и не расширяет строки текстовой меткой.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client`
+- Выполненные требования профиля:
+  - Изменение остаётся в Avalonia UI/ViewModel-слое.
+  - Долгих синхронных операций на UI-потоке нет.
+  - Стабильные selectors/automation-id будут сохранены; при добавлении marker для UI-теста использовать новый локальный automation id без изменения существующих.
+  - Перед завершением EXEC будут запущены `dotnet build` и `dotnet test`.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.ViewModel/TaskItemViewModel.cs` | Вычисляемые marker-свойства и уведомления | Единый source of truth для списков и карты |
+| `src/Unlimotion/Views/MainControl.axaml` | Marker controls в общем и inline-шаблонах задач | Видимая пометка в списках |
+| `src/Unlimotion/Views/GraphControl.axaml` | Marker control в шаблоне узла задачи | Видимая пометка на карте |
+| `src/Unlimotion.Test/*.cs` | Unit/UI regression tests | Проверить поведение и не допустить регрессии |
+| `specs/2026-04-22-repeater-list-badge.md` | Рабочая спецификация | QUEST gate |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Обычная задача в списке | Checkbox, emoji/date, title | Без изменений, marker скрыт |
+| Задача с active repeater | Визуально как обычная | Появляется `↻` рядом с title |
+| Задача с active repeater на карте | Визуально как обычная | Появляется `↻` рядом с `TitleWithoutEmoji` |
+| Данные задачи | Не меняются | Не меняются |
+| Детали задачи | Есть выбор repeater | Без изменения UX |
+
+## 18. Альтернативы и компромиссы
+- Вариант: добавлять текстовую метку `Repeat`.
+- Плюсы: очевидно при первом взгляде.
+- Минусы: расширяет строки, требует локализации видимого текста, хуже для плотных списков.
+- Почему выбранное решение лучше в контексте этой задачи: компактный символ с tooltip решает сканирование списка с минимальным визуальным шумом и без новых ресурсов.
+
+- Вариант: показывать полный `Repeater.Title` прямо в строке.
+- Плюсы: сразу видно тип повторения.
+- Минусы: длинные строки, риск переполнения, дублирование информации из деталей.
+- Почему выбранное решение лучше в контексте этой задачи: запрос просит дополнительную пометку, а не полное описание.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели и Non-Goals зафиксированы |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, интеграции, правила, данные и rollback описаны |
+| C. Безопасность изменений | 11-13 | PASS | Persisted model не меняется, rollback простой, риски перечислены |
+| D. Проверяемость | 14-16 | PASS | Acceptance Criteria, тесты и команды проверки указаны |
+| E. Готовность к автономной реализации | 17-19 | PASS | План пошаговый, блокирующих вопросов нет, масштаб small |
+| F. Соответствие профилю | 20 | PASS | Требования `dotnet-desktop-client` отражены |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Требуется только marker для повторяемых задач в списках |
+| 2. Понимание текущего состояния | 5 | Указаны VM, XAML-шаблоны и текущий repeater-контракт |
+| 3. Конкретность целевого дизайна | 5 | Описаны свойства, binding-и, шаблоны и уведомления |
+| 4. Безопасность (миграция, откат) | 5 | Нет изменения данных; rollback локальный |
+| 5. Тестируемость | 5 | Есть unit и headless UI checks плюс команды |
+| 6. Готовность к автономной реализации | 5 | Нет блокирующих вопросов, план малый и последовательный |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: добавлены edge cases для `RepeaterType.None`, вложенного `Repeater.Type`, отписки от старого `Repeater` и риска неполного обновления inline-шаблонов.
+- Что осталось на решение пользователя: только подтверждение перехода в EXEC фразой `Спеку подтверждаю`.
+
+### Post-EXEC Review
+- Статус: PASS с caveat по полному тестовому проекту.
+- Реализовано по спеки: VM display-контракт добавлен, старая подписка на repeater заменяется через `SerialDisposable`, общий `DataTemplate`, 6 inline-шаблонов и узел карты получили marker рядом с заголовком.
+- Проверки: `git diff --check` без ошибок; targeted unit/UI tests проходят, включая structural-проверку карты; `dotnet build src/Unlimotion.sln --no-restore` проходит.
+- Caveat: полный `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-build -- --no-progress` падает на 11 существующих/окруженческих проверках: 10 `BackupViaGitServiceTests` с `LibGit2SharpException: path too long` из-за длинного пути worktree и 1 `SettingsViewModelTests.BackupConnection_BecomesReadyForClone_WhenSshKeyIsSelected` с английской строкой при полном параллельном прогоне. Тот же settings-тест отдельно проходит.
+
+## Approval
+Получена фраза: `Спеку подтверждаю`
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Создание worktree и выбор instruction stack | 0.95 | Нет | Подготовить рабочую спецификацию | Нет | Нет | Worktree нужен по запросу пользователя; stack выбран как delivery-task для .NET desktop | `C:\Projects\Education\Unlimotion Space\Unlimotion-repeater-list-badge`, `feature/repeater-list-badge` |
+| SPEC | Анализ текущей реализации списков и repeater | 0.9 | Нет | Зафиксировать TO-BE и тест-план | Нет | Нет | Найдены общий `TaskItemViewModel` template, inline-шаблоны вкладок и `IsHaveRepeater` | `src/Unlimotion/Views/MainControl.axaml`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs`, `src/Unlimotion.ViewModel/RepeaterPatternViewModel.cs` |
+| SPEC | Quality gate и post-SPEC review | 0.92 | Нет | Запросить подтверждение спеки | Да | Нет | По `quest-mode` переход к EXEC возможен только после фразы пользователя `Спеку подтверждаю` | `specs/2026-04-22-repeater-list-badge.md` |
+| SPEC | Внесение исправлений по review спеки | 0.94 | Нет | Запросить подтверждение спеки | Да | Да, пользователь попросил внести исправления | Уточнён VM-контракт, lifecycle подписки и покрытие всех списочных шаблонов | `specs/2026-04-22-repeater-list-badge.md` |
+| EXEC | Подтверждение спеки и старт реализации | 0.95 | Нет | Добавить regression-тесты ViewModel | Нет | Да, пользователь написал `Спеку подтверждаю` | EXEC разрешён по `quest-mode`; начинаю с тестов для marker-контракта | `specs/2026-04-22-repeater-list-badge.md` |
+| EXEC | Реализация VM-контракта marker | 0.9 | Нет | Обновить XAML-шаблоны списков | Нет | Нет | Добавлены `RepeaterListMarker`, tooltip и заменяемая подписка на текущий `RepeaterPatternViewModel`; старый repeater больше не поднимает marker-уведомления | `src/Unlimotion.ViewModel/TaskItemViewModel.cs`, `src/Unlimotion.Test/TaskItemRepeaterListMarkerTests.cs` |
+| EXEC | Обновление XAML и UI/structural tests | 0.88 | Нет | Запустить targeted tests и build | Нет | Нет | Marker добавлен в общий `DataTemplate` и 6 inline-шаблонов; тест проверяет AllTasksTree и покрытие inline-шаблонов | `src/Unlimotion/Views/MainControl.axaml`, `src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs` |
+| EXEC | Verification | 0.86 | Полный тестовый проект имеет существующие окруженческие падения | Выполнить post-EXEC review | Нет | Нет | Targeted tests проходят, solution build проходит; полный `Unlimotion.Test` падает на `BackupViaGitServiceTests` path too long и нестабильную локаль в существующем settings-тесте | `src/Unlimotion.Test/Unlimotion.Test.csproj`, `src/Unlimotion.sln` |
+| EXEC | Post-EXEC review | 0.9 | Нет | Передать итог пользователю | Нет | Нет | Дифф проверен, XAML-покрытие всех inline-шаблонов подтверждено поиском, новые targeted tests и build проходят | `git diff --check`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs`, `src/Unlimotion/Views/MainControl.axaml`, `src/Unlimotion.Test/*Repeater*Tests.cs` |
+| EXEC | Расширение marker на карту | 0.9 | Нет | Передать итог пользователю | Нет | Да, пользователь попросил: `Ещё на карте тоже должно отображаться` | `GraphControl.axaml` использует отдельный шаблон узла, поэтому marker добавлен туда тем же VM-контрактом; targeted UI/structural tests, `git diff --check` и build проходят | `src/Unlimotion/Views/GraphControl.axaml`, `src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs`, `specs/2026-04-22-repeater-list-badge.md` |

--- a/src/Unlimotion.Test/TaskItemRepeaterListMarkerTests.cs
+++ b/src/Unlimotion.Test/TaskItemRepeaterListMarkerTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using DynamicData;
+using Unlimotion.Domain;
+using Unlimotion.TaskTree;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Test;
+
+public class TaskItemRepeaterListMarkerTests
+{
+    [Test]
+    public async Task RepeaterListMarker_ShowsOnlyForActiveRepeater()
+    {
+        using var taskWithoutRepeater = CreateTask(null);
+        using var taskWithNoneRepeater = CreateTask(new RepeaterPattern { Type = RepeaterType.None, Period = 1 });
+        using var taskWithDailyRepeater = CreateTask(new RepeaterPattern { Type = RepeaterType.Daily, Period = 1 });
+
+        await Assert.That(taskWithoutRepeater.IsHaveRepeater).IsFalse();
+        await Assert.That(taskWithoutRepeater.RepeaterListMarker).IsEqualTo(string.Empty);
+        await Assert.That(taskWithoutRepeater.RepeaterListMarkerToolTip).IsNull();
+
+        await Assert.That(taskWithNoneRepeater.IsHaveRepeater).IsFalse();
+        await Assert.That(taskWithNoneRepeater.RepeaterListMarker).IsEqualTo(string.Empty);
+        await Assert.That(taskWithNoneRepeater.RepeaterListMarkerToolTip).IsNull();
+
+        await Assert.That(taskWithDailyRepeater.IsHaveRepeater).IsTrue();
+        await Assert.That(taskWithDailyRepeater.RepeaterListMarker).IsEqualTo("↻");
+        await Assert.That(taskWithDailyRepeater.RepeaterListMarkerToolTip).IsEqualTo(taskWithDailyRepeater.Repeater.Title);
+    }
+
+    [Test]
+    public async Task RepeaterListMarker_NotifiesWhenRepeaterChanges()
+    {
+        using var task = CreateTask(null);
+        var changedProperties = TrackChangedProperties(task);
+
+        task.Repeater = new RepeaterPatternViewModel { Type = RepeaterType.Daily, Period = 1 };
+
+        await Assert.That(changedProperties).Contains(nameof(TaskItemViewModel.IsHaveRepeater));
+        await Assert.That(changedProperties).Contains(nameof(TaskItemViewModel.RepeaterListMarker));
+        await Assert.That(changedProperties).Contains(nameof(TaskItemViewModel.RepeaterListMarkerToolTip));
+    }
+
+    [Test]
+    public async Task RepeaterListMarker_NotifiesWhenCurrentRepeaterPatternChanges()
+    {
+        var repeater = new RepeaterPatternViewModel { Type = RepeaterType.None, Period = 1 };
+        using var task = CreateTask(null);
+        task.Repeater = repeater;
+        var changedProperties = TrackChangedProperties(task);
+
+        repeater.Type = RepeaterType.Daily;
+
+        await Assert.That(changedProperties).Contains(nameof(TaskItemViewModel.IsHaveRepeater));
+        await Assert.That(changedProperties).Contains(nameof(TaskItemViewModel.RepeaterListMarker));
+        await Assert.That(changedProperties).Contains(nameof(TaskItemViewModel.RepeaterListMarkerToolTip));
+    }
+
+    [Test]
+    public async Task RepeaterListMarker_IgnoresOldRepeaterPatternAfterReplacement()
+    {
+        var oldRepeater = new RepeaterPatternViewModel { Type = RepeaterType.None, Period = 1 };
+        var currentRepeater = new RepeaterPatternViewModel { Type = RepeaterType.Daily, Period = 1 };
+        using var task = CreateTask(null);
+        task.Repeater = oldRepeater;
+        task.Repeater = currentRepeater;
+        var changedProperties = TrackChangedProperties(task);
+
+        oldRepeater.Type = RepeaterType.Yearly;
+
+        await Assert.That(changedProperties).DoesNotContain(nameof(TaskItemViewModel.IsHaveRepeater));
+        await Assert.That(changedProperties).DoesNotContain(nameof(TaskItemViewModel.RepeaterListMarker));
+        await Assert.That(changedProperties).DoesNotContain(nameof(TaskItemViewModel.RepeaterListMarkerToolTip));
+    }
+
+    private static TaskItemViewModel CreateTask(RepeaterPattern? repeater)
+    {
+        var model = new TaskItem
+        {
+            Id = Guid.NewGuid().ToString(),
+            Title = "Task",
+            IsCompleted = false,
+            IsCanBeCompleted = true,
+            CreatedDateTime = DateTimeOffset.UtcNow
+        };
+
+        if (repeater != null)
+        {
+            model.Repeater = repeater;
+        }
+
+        return new TaskItemViewModel(model, new StubTaskStorage());
+    }
+
+    private static List<string?> TrackChangedProperties(TaskItemViewModel task)
+    {
+        var changedProperties = new List<string?>();
+        ((INotifyPropertyChanged)task).PropertyChanged += (_, args) => changedProperties.Add(args.PropertyName);
+        return changedProperties;
+    }
+
+    private sealed class StubTaskStorage : ITaskStorage
+    {
+        public SourceCache<TaskItemViewModel, string> Tasks { get; } = new(task => task.Id);
+        public ITaskRelationsIndex Relations => throw new NotSupportedException();
+        public TaskTreeManager TaskTreeManager => throw new NotSupportedException();
+        public event EventHandler<EventArgs>? Initiated
+        {
+            add { }
+            remove { }
+        }
+
+        public Task Init() => Task.CompletedTask;
+
+        public Task<TaskItemViewModel> Add(TaskItemViewModel? currentTask = null, bool isBlocked = false) =>
+            throw new NotSupportedException();
+
+        public Task<TaskItemViewModel> AddChild(TaskItemViewModel currentTask) =>
+            throw new NotSupportedException();
+
+        public Task<bool> Delete(TaskItemViewModel change, bool deleteInStorage = true) =>
+            throw new NotSupportedException();
+
+        public Task<bool> Delete(TaskItemViewModel change, TaskItemViewModel parent) =>
+            throw new NotSupportedException();
+
+        public Task<TaskItemViewModel> Update(TaskItemViewModel change) => Task.FromResult(change);
+
+        public Task<TaskItemViewModel> Update(TaskItem change) =>
+            throw new NotSupportedException();
+
+        public Task<TaskItemViewModel> Clone(TaskItemViewModel change, params TaskItemViewModel[]? additionalParents) =>
+            throw new NotSupportedException();
+
+        public Task<bool> CopyInto(TaskItemViewModel change, TaskItemViewModel[]? additionalParents) =>
+            throw new NotSupportedException();
+
+        public Task<bool> MoveInto(TaskItemViewModel change, TaskItemViewModel[] additionalParents, TaskItemViewModel? currentTask) =>
+            throw new NotSupportedException();
+
+        public Task<bool> Unblock(TaskItemViewModel taskToUnblock, TaskItemViewModel blockingTask) =>
+            throw new NotSupportedException();
+
+        public Task<bool> Block(TaskItemViewModel change, TaskItemViewModel currentTask) =>
+            throw new NotSupportedException();
+
+        public Task RemoveParentChildConnection(TaskItemViewModel parent, TaskItemViewModel child) =>
+            throw new NotSupportedException();
+    }
+}

--- a/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
+++ b/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Unlimotion;
+using Unlimotion.ViewModel;
+using Unlimotion.ViewModel.Localization;
+using Unlimotion.Views;
+
+namespace Unlimotion.Test;
+
+[NotInParallel]
+public class TaskListRepeaterMarkerUiTests
+{
+    [Test]
+    public async Task TaskListRepeaterMarker_AllTasksTree_ShowsMarkerForRepeaterTask()
+    {
+        var localization = LocalizationService.Current;
+        var culture = CultureSnapshot.Capture();
+
+        try
+        {
+            CultureSnapshot.Apply(CultureInfo.GetCultureInfo(LocalizationService.RussianLanguage));
+
+            using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await session.Dispatch(async () =>
+            {
+                var fixture = new MainWindowViewModelFixture();
+                Window? window = null;
+
+                try
+                {
+                    var vm = fixture.MainWindowViewModelTest;
+                    await vm.Connect();
+                    vm.AllTasksMode = true;
+
+                    var repeatedTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RepeateTask9Id);
+                    await Assert.That(repeatedTask).IsNotNull();
+                    await Assert.That(repeatedTask!.IsHaveRepeater).IsTrue();
+
+                    var view = new MainControl { DataContext = vm };
+                    window = CreateWindow(view);
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+
+                    TextBlock? marker = null;
+                    var markerReady = WaitFor(() =>
+                    {
+                        marker = view.GetVisualDescendants()
+                            .OfType<TextBlock>()
+                            .FirstOrDefault(textBlock =>
+                                AutomationProperties.GetAutomationId(textBlock) == "TaskRepeaterListMarker"
+                                && textBlock.DataContext is TaskItemViewModel task
+                                && task.Id == MainWindowViewModelFixture.RepeateTask9Id);
+
+                        return marker != null;
+                    });
+
+                    await Assert.That(markerReady).IsTrue();
+                    await Assert.That(marker!.Text).IsEqualTo("↻");
+                    await Assert.That(marker.IsVisible).IsTrue();
+                }
+                finally
+                {
+                    window?.Close();
+                    fixture.CleanTasks();
+                }
+            }, CancellationToken.None);
+        }
+        finally
+        {
+            LocalizationService.Current = localization;
+            culture.Restore();
+        }
+    }
+
+    [Test]
+    public async Task TaskListRepeaterMarker_XamlTemplates_AddMarkerBeforeEveryInlineTitle()
+    {
+        var xaml = File.ReadAllText(FindViewXamlPath("MainControl.axaml"));
+
+        var inlineTitleCount = CountOccurrences(xaml, "Content=\"{Binding TaskItem.Title}\"");
+        var inlineMarkerCount = CountOccurrences(xaml, "Text=\"{Binding TaskItem.RepeaterListMarker}\"");
+
+        await Assert.That(xaml).Contains("Text=\"{Binding RepeaterListMarker}\"");
+        await Assert.That(xaml).Contains("ToolTip.Tip=\"{Binding RepeaterListMarkerToolTip}\"");
+        await Assert.That(inlineTitleCount).IsEqualTo(6);
+        await Assert.That(inlineMarkerCount).IsEqualTo(inlineTitleCount);
+    }
+
+    [Test]
+    public async Task TaskRepeaterMarker_GraphTemplate_AddsMarkerBeforeTitle()
+    {
+        var xaml = File.ReadAllText(FindViewXamlPath("GraphControl.axaml"));
+
+        await Assert.That(xaml).Contains("Text=\"{Binding RepeaterListMarker}\"");
+        await Assert.That(xaml).Contains("IsVisible=\"{Binding IsHaveRepeater}\"");
+        await Assert.That(xaml).Contains("ToolTip.Tip=\"{Binding RepeaterListMarkerToolTip}\"");
+        await Assert.That(xaml).Contains("AutomationProperties.AutomationId=\"TaskRepeaterGraphMarker\"");
+        await Assert.That(xaml.IndexOf("Text=\"{Binding RepeaterListMarker}\"", StringComparison.Ordinal))
+            .IsLessThan(xaml.IndexOf("Text=\"{Binding TitleWithoutEmoji}\"", StringComparison.Ordinal));
+    }
+
+    private static Window CreateWindow(Control content)
+    {
+        return new Window
+        {
+            Width = 1400,
+            Height = 900,
+            Content = content
+        };
+    }
+
+    private static bool WaitFor(Func<bool> predicate, int timeoutMilliseconds = 2000)
+    {
+        return SpinWait.SpinUntil(() =>
+        {
+            Dispatcher.UIThread.RunJobs();
+            return predicate();
+        }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
+    }
+
+    private static string FindViewXamlPath(string fileName)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory != null)
+        {
+            var sourceRootCandidate = Path.Combine(directory.FullName, "src", "Unlimotion", "Views", fileName);
+            if (File.Exists(sourceRootCandidate))
+            {
+                return sourceRootCandidate;
+            }
+
+            var srcDirectoryCandidate = Path.Combine(directory.FullName, "Unlimotion", "Views", fileName);
+            if (File.Exists(srcDirectoryCandidate))
+            {
+                return srcDirectoryCandidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new FileNotFoundException($"Cannot find {fileName} from test output directory.");
+    }
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+    private sealed class CultureSnapshot
+    {
+        private readonly CultureInfo _currentCulture;
+        private readonly CultureInfo _currentUiCulture;
+        private readonly CultureInfo? _defaultThreadCurrentCulture;
+        private readonly CultureInfo? _defaultThreadCurrentUiCulture;
+
+        private CultureSnapshot()
+        {
+            _currentCulture = Thread.CurrentThread.CurrentCulture;
+            _currentUiCulture = Thread.CurrentThread.CurrentUICulture;
+            _defaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentCulture;
+            _defaultThreadCurrentUiCulture = CultureInfo.DefaultThreadCurrentUICulture;
+        }
+
+        public static CultureSnapshot Capture() => new();
+
+        public static void Apply(CultureInfo culture)
+        {
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            CultureInfo.DefaultThreadCurrentUICulture = culture;
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+        }
+
+        public void Restore()
+        {
+            CultureInfo.DefaultThreadCurrentCulture = _defaultThreadCurrentCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = _defaultThreadCurrentUiCulture;
+            Thread.CurrentThread.CurrentCulture = _currentCulture;
+            Thread.CurrentThread.CurrentUICulture = _currentUiCulture;
+        }
+    }
+}

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -4,7 +4,9 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Reactive;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -48,6 +50,7 @@ namespace Unlimotion.ViewModel
         private readonly ReadOnlyObservableCollection<TaskItemViewModel> _parentsTasks;
         private readonly ReadOnlyObservableCollection<TaskItemViewModel> _blocksTasks;
         private readonly ReadOnlyObservableCollection<TaskItemViewModel> _blockedByTasks;
+        private readonly SerialDisposable _repeaterPropertyChangedSubscription = new();
         public bool IsHighlighted { get; set; }
         private TimeSpan? plannedPeriod;
         private DateCommands commands;
@@ -57,6 +60,7 @@ namespace Unlimotion.ViewModel
 
         private void Init(ITaskStorage taskStorage)
         {
+            _repeaterPropertyChangedSubscription.AddToDispose(this);
             SetDurationCommands = new SetDurationCommands(this);
             SaveItemCommand = ReactiveCommand.CreateFromTask(async () =>
             {
@@ -234,40 +238,93 @@ namespace Unlimotion.ViewModel
             });            
 
             this.WhenAnyValue(t => t.Repeater)
-                .Subscribe(r =>
-                {
-                    if (r is INotifyPropertyChanged repeater)
-                    {
-                        Observable.FromEventPattern(repeater, nameof(INotifyPropertyChanged.PropertyChanged))
-                            .Where(changed =>
-                            {
-                                var args = changed.EventArgs as PropertyChangedEventArgs;
-                                switch (args.PropertyName)
-                                {
-                                    //case nameof(Repeater.Type)://TODO из интерфейса прилетает изменение при переключении
-                                    case nameof(Repeater.AfterComplete):
-                                    case nameof(Repeater.Period):
-                                    case nameof(Repeater.Monday):
-                                    case nameof(Repeater.Tuesday):
-                                    case nameof(Repeater.Wednesday):
-                                    case nameof(Repeater.Thursday):
-                                    case nameof(Repeater.Friday):
-                                    case nameof(Repeater.Saturday):
-                                    case nameof(Repeater.Sunday):
-                                        return true;
-                                }
-                                return false;
-                            })
-                            .Throttle(TimeSpan.FromSeconds(2))
-                            .Subscribe(x =>
-                            {
-                                if (MainWindowViewModel._isInited) SaveItemCommand.Execute();
-                            }
-                            )
-                            .AddToDispose(this);
-                    }
-                })
+                .Subscribe(RegisterRepeaterPropertyChangedSubscription)
                 .AddToDispose(this);
+        }
+
+        private void RegisterRepeaterPropertyChangedSubscription(RepeaterPatternViewModel? repeater)
+        {
+            NotifyRepeaterListMarkerChanged();
+
+            if (repeater is not INotifyPropertyChanged inpc)
+            {
+                _repeaterPropertyChangedSubscription.Disposable = Disposable.Empty;
+                return;
+            }
+
+            var repeaterChanges = Observable.FromEventPattern<PropertyChangedEventHandler, PropertyChangedEventArgs>(
+                handler => inpc.PropertyChanged += handler,
+                handler => inpc.PropertyChanged -= handler);
+
+            var markerSubscription = repeaterChanges
+                .Where(changed => IsRepeaterPatternMarkerProperty(changed.EventArgs.PropertyName))
+                .Subscribe(_ => NotifyRepeaterListMarkerChanged());
+
+            var saveSubscription = repeaterChanges
+                .Where(changed => IsRepeaterPatternPersistenceProperty(changed.EventArgs.PropertyName))
+                .Throttle(TimeSpan.FromSeconds(2))
+                .Subscribe(_ =>
+                {
+                    if (MainWindowViewModel._isInited) SaveItemCommand.Execute();
+                });
+
+            _repeaterPropertyChangedSubscription.Disposable = new CompositeDisposable(markerSubscription, saveSubscription);
+        }
+
+        private void NotifyRepeaterListMarkerChanged()
+        {
+            OnPropertyChanged(nameof(IsHaveRepeater));
+            OnPropertyChanged(nameof(RepeaterListMarker));
+            OnPropertyChanged(nameof(RepeaterListMarkerToolTip));
+        }
+
+        private void OnPropertyChanged(string propertyName)
+        {
+            if (this is not INotifyPropertyChanged propertyChangedSource)
+            {
+                return;
+            }
+
+            var propertyChangedHandler = propertyChangedSource
+                .GetType()
+                .GetField(
+                    nameof(INotifyPropertyChanged.PropertyChanged),
+                    BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                ?.GetValue(propertyChangedSource) as PropertyChangedEventHandler;
+
+            propertyChangedHandler?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private static bool IsRepeaterPatternMarkerProperty(string? propertyName)
+        {
+            return string.IsNullOrEmpty(propertyName) ||
+                   propertyName is nameof(RepeaterPatternViewModel.Type)
+                       or nameof(RepeaterPatternViewModel.SelectedRepeaterType)
+                       or nameof(RepeaterPatternViewModel.Period)
+                       or nameof(RepeaterPatternViewModel.WorkDays)
+                       or nameof(RepeaterPatternViewModel.Monday)
+                       or nameof(RepeaterPatternViewModel.Tuesday)
+                       or nameof(RepeaterPatternViewModel.Wednesday)
+                       or nameof(RepeaterPatternViewModel.Thursday)
+                       or nameof(RepeaterPatternViewModel.Friday)
+                       or nameof(RepeaterPatternViewModel.Saturday)
+                       or nameof(RepeaterPatternViewModel.Sunday)
+                       or nameof(RepeaterPatternViewModel.AfterComplete)
+                       or nameof(RepeaterPatternViewModel.Title);
+        }
+
+        private static bool IsRepeaterPatternPersistenceProperty(string? propertyName)
+        {
+            return string.IsNullOrEmpty(propertyName) ||
+                   propertyName is nameof(RepeaterPatternViewModel.AfterComplete)
+                       or nameof(RepeaterPatternViewModel.Period)
+                       or nameof(RepeaterPatternViewModel.Monday)
+                       or nameof(RepeaterPatternViewModel.Tuesday)
+                       or nameof(RepeaterPatternViewModel.Wednesday)
+                       or nameof(RepeaterPatternViewModel.Thursday)
+                       or nameof(RepeaterPatternViewModel.Friday)
+                       or nameof(RepeaterPatternViewModel.Saturday)
+                       or nameof(RepeaterPatternViewModel.Sunday);
         }
 
         public void ApplyRelations(
@@ -552,9 +609,14 @@ namespace Unlimotion.ViewModel
             return orderedParents;
         }
 
+        [AlsoNotifyFor(nameof(IsHaveRepeater), nameof(RepeaterListMarker), nameof(RepeaterListMarkerToolTip))]
         public RepeaterPatternViewModel Repeater { get; set; } = null!;
 
         public bool IsHaveRepeater => Repeater != null && Repeater.Type != RepeaterType.None;
+
+        public string RepeaterListMarker => IsHaveRepeater ? "↻" : string.Empty;
+
+        public string? RepeaterListMarkerToolTip => IsHaveRepeater ? Repeater.Title : null;
 
         public List<RepeaterPatternViewModel> Repeaters => new()
         {

--- a/src/Unlimotion/Views/GraphControl.axaml
+++ b/src/Unlimotion/Views/GraphControl.axaml
@@ -42,10 +42,17 @@
 							<avaloniaGraphControl:Connection Brush="Green" />
 						</DataTemplate>
 						<DataTemplate DataType="{x:Type viewModel:TaskItemViewModel}">
-							<Grid ColumnDefinitions="Auto, Auto, *" Margin="5,0" Background="Transparent" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" DoubleTapped="TaskTree_OnDoubleTapped">
+							<Grid ColumnDefinitions="Auto, Auto, Auto, *" Margin="5,0" Background="Transparent" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" DoubleTapped="TaskTree_OnDoubleTapped">
 								<CheckBox IsChecked="{Binding IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding IsCanBeCompleted}" />
 								<Label Grid.Column="1" Content="{Binding GetAllEmoji}" VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="2" Text="{Binding TitleWithoutEmoji}" TextWrapping="Wrap" MaxWidth="300"  VerticalAlignment="Center" Classes.highlighted="{Binding IsHighlighted}" Classes.IsCanBeCompleted="{Binding !IsCanBeCompleted}"/>
+                                <TextBlock Grid.Column="2"
+                                           Text="{Binding RepeaterListMarker}"
+                                           IsVisible="{Binding IsHaveRepeater}"
+                                           ToolTip.Tip="{Binding RepeaterListMarkerToolTip}"
+                                           AutomationProperties.AutomationId="TaskRepeaterGraphMarker"
+                                           Margin="4,0,4,0"
+                                           VerticalAlignment="Center" />
+                                <TextBlock Grid.Column="3" Text="{Binding TitleWithoutEmoji}" TextWrapping="Wrap" MaxWidth="300"  VerticalAlignment="Center" Classes.highlighted="{Binding IsHighlighted}" Classes.IsCanBeCompleted="{Binding !IsCanBeCompleted}"/>
 							</Grid>
 							<!--<Border BorderBrush="Gray" CornerRadius="4" BorderThickness="1" Background="Transparent" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed">
 								<Grid ColumnDefinitions="Auto, *" Margin="5,0">

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -88,9 +88,16 @@ x:Class="Unlimotion.Views.MainControl">
     </UserControl.Styles>
     <UserControl.DataTemplates>
         <DataTemplate DataType="viewModel:TaskItemViewModel">
-            <Grid ColumnDefinitions="Auto, *" Background="Transparent" DragDrop.AllowDrop="True">
+            <Grid ColumnDefinitions="Auto, Auto, *" Background="Transparent" DragDrop.AllowDrop="True">
                 <CheckBox IsChecked="{Binding IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding IsCanBeCompleted}" />
-                <TextBlock Grid.Column="1" Text="{Binding Title}" VerticalAlignment="Center" Classes.IsWanted="{Binding Wanted}" Classes.IsCanBeCompleted="{Binding !IsCanBeCompleted}"  />
+                <TextBlock Grid.Column="1"
+                           Text="{Binding RepeaterListMarker}"
+                           IsVisible="{Binding IsHaveRepeater}"
+                           ToolTip.Tip="{Binding RepeaterListMarkerToolTip}"
+                           AutomationProperties.AutomationId="TaskRepeaterListMarker"
+                           Margin="4,0,4,0"
+                           VerticalAlignment="Center" />
+                <TextBlock Grid.Column="2" Text="{Binding Title}" VerticalAlignment="Center" Classes.IsWanted="{Binding Wanted}" Classes.IsCanBeCompleted="{Binding !IsCanBeCompleted}"  />
             </Grid>
         </DataTemplate>
         <DataTemplate DataType="viewModel:TaskWrapperViewModel">
@@ -231,11 +238,18 @@ Content="❌"
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="viewModel:TaskWrapperViewModel" ItemsSource="{Binding SubTasks}">
                                         <Grid DoubleTapped="TaskTree_OnDoubleTapped" Background="Transparent">
-                                            <Grid ColumnDefinitions="Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
+                                            <Grid ColumnDefinitions="Auto, Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
                                                 <CheckBox IsChecked="{Binding TaskItem.IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding TaskItem.IsCanBeCompleted}" />
                                                 <Label Grid.Column="1" Content="{Binding TaskItem.CreatedDateTime, StringFormat={}{0:yyyy.MM.dd}}" Foreground="{StaticResource AccentButtonBackground}" FontFamily="Consolas" VerticalAlignment="Center" />
                                                 <Label Grid.Column="2" Content="{Binding TaskItem.GetAllEmoji}" VerticalAlignment="Center" />
-                                                <Label Grid.Column="3" Content="{Binding TaskItem.Title}" VerticalAlignment="Center" Classes.IsWanted="{Binding TaskItem.Wanted}"/>
+                                                <TextBlock Grid.Column="3"
+                                                           Text="{Binding TaskItem.RepeaterListMarker}"
+                                                           IsVisible="{Binding TaskItem.IsHaveRepeater}"
+                                                           ToolTip.Tip="{Binding TaskItem.RepeaterListMarkerToolTip}"
+                                                           AutomationProperties.AutomationId="TaskRepeaterListMarker"
+                                                           Margin="4,0,4,0"
+                                                           VerticalAlignment="Center" />
+                                                <Label Grid.Column="4" Content="{Binding TaskItem.Title}" VerticalAlignment="Center" Classes.IsWanted="{Binding TaskItem.Wanted}"/>
                                             </Grid>
                                             <Button Background="#00000000"
                                                     Content="❌"
@@ -282,11 +296,18 @@ Content="❌"
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="viewModel:TaskWrapperViewModel" ItemsSource="{Binding SubTasks}">
                                         <Grid DoubleTapped="TaskTree_OnDoubleTapped" Background="Transparent">
-                                            <Grid ColumnDefinitions="Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
+                                            <Grid ColumnDefinitions="Auto, Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
                                                 <CheckBox IsChecked="{Binding TaskItem.IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding TaskItem.IsCanBeCompleted}" />
                                                 <Label Grid.Column="1" Content="{Binding TaskItem.UpdatedDateTime, StringFormat={}{0:yyyy.MM.dd}}" Foreground="{StaticResource AccentButtonBackground}" FontFamily="Consolas" VerticalAlignment="Center" />
                                                 <Label Grid.Column="2" Content="{Binding TaskItem.GetAllEmoji}" VerticalAlignment="Center" />
-                                                <Label Grid.Column="3" Content="{Binding TaskItem.Title}" VerticalAlignment="Center" Classes.IsWanted="{Binding TaskItem.Wanted}"/>
+                                                <TextBlock Grid.Column="3"
+                                                           Text="{Binding TaskItem.RepeaterListMarker}"
+                                                           IsVisible="{Binding TaskItem.IsHaveRepeater}"
+                                                           ToolTip.Tip="{Binding TaskItem.RepeaterListMarkerToolTip}"
+                                                           AutomationProperties.AutomationId="TaskRepeaterListMarker"
+                                                           Margin="4,0,4,0"
+                                                           VerticalAlignment="Center" />
+                                                <Label Grid.Column="4" Content="{Binding TaskItem.Title}" VerticalAlignment="Center" Classes.IsWanted="{Binding TaskItem.Wanted}"/>
                                             </Grid>
                                             <Button Background="#00000000"
                                                     Content="❌"
@@ -323,10 +344,17 @@ Content="❌"
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="viewModel:TaskWrapperViewModel" ItemsSource="{Binding SubTasks}">
                                         <Grid DoubleTapped="TaskTree_OnDoubleTapped" Background="Transparent">
-                                            <Grid ColumnDefinitions="Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
+                                            <Grid ColumnDefinitions="Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
                                                 <CheckBox IsChecked="{Binding TaskItem.IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding TaskItem.IsCanBeCompleted}" />
                                                 <Label Grid.Column="1" Content="{Binding TaskItem.GetAllEmoji}" VerticalAlignment="Center" />
-                                                <Label Grid.Column="2" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
+                                                <TextBlock Grid.Column="2"
+                                                           Text="{Binding TaskItem.RepeaterListMarker}"
+                                                           IsVisible="{Binding TaskItem.IsHaveRepeater}"
+                                                           ToolTip.Tip="{Binding TaskItem.RepeaterListMarkerToolTip}"
+                                                           AutomationProperties.AutomationId="TaskRepeaterListMarker"
+                                                           Margin="4,0,4,0"
+                                                           VerticalAlignment="Center" />
+                                                <Label Grid.Column="3" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
                                             </Grid>
                                             <Button Background="#00000000"
                                                     Content="❌"
@@ -371,12 +399,19 @@ Content="❌"
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="viewModel:TaskWrapperViewModel" ItemsSource="{Binding SubTasks}">
                                         <Grid DoubleTapped="TaskTree_OnDoubleTapped" Background="Transparent">
-                                            <Grid ColumnDefinitions="Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
+                                            <Grid ColumnDefinitions="Auto, Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
                                                 <CheckBox IsChecked="{Binding TaskItem.IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding TaskItem.IsCanBeCompleted}" />
                                                 <Label Grid.Column="1" Content="{Binding TaskItem.CompletedDateTime, StringFormat={}{0:yyyy.MM.dd}}" Foreground="{StaticResource AccentButtonBackground}" FontFamily="Consolas" VerticalAlignment="Center" />
                                                 <Label Grid.Column="1" Content="{Binding TaskItem.ArchiveDateTime, StringFormat={}{0:yyyy.MM.dd}}" Foreground="{StaticResource AccentButtonBackground}" FontFamily="Consolas" VerticalAlignment="Center" />
                                                 <Label Grid.Column="2" Content="{Binding TaskItem.GetAllEmoji}" VerticalAlignment="Center" />
-                                                <Label Grid.Column="3" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
+                                                <TextBlock Grid.Column="3"
+                                                           Text="{Binding TaskItem.RepeaterListMarker}"
+                                                           IsVisible="{Binding TaskItem.IsHaveRepeater}"
+                                                           ToolTip.Tip="{Binding TaskItem.RepeaterListMarkerToolTip}"
+                                                           AutomationProperties.AutomationId="TaskRepeaterListMarker"
+                                                           Margin="4,0,4,0"
+                                                           VerticalAlignment="Center" />
+                                                <Label Grid.Column="4" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
                                             </Grid>
                                             <Button Background="#00000000"
                                                     Content="❌"
@@ -421,12 +456,19 @@ Content="❌"
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="viewModel:TaskWrapperViewModel" ItemsSource="{Binding SubTasks}">
                                         <Grid DoubleTapped="TaskTree_OnDoubleTapped" Background="Transparent">
-                                            <Grid ColumnDefinitions="Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
+                                            <Grid ColumnDefinitions="Auto, Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
                                                 <CheckBox IsChecked="{Binding TaskItem.IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding TaskItem.IsCanBeCompleted}" />
                                                 <Label Grid.Column="1" Content="{Binding TaskItem.CompletedDateTime, StringFormat={}{0:yyyy.MM.dd}}" Foreground="{StaticResource AccentButtonBackground}" FontFamily="Consolas" VerticalAlignment="Center" />
                                                 <Label Grid.Column="1" Content="{Binding TaskItem.ArchiveDateTime, StringFormat={}{0:yyyy.MM.dd}}" Foreground="{StaticResource AccentButtonBackground}" FontFamily="Consolas" VerticalAlignment="Center" />
                                                 <Label Grid.Column="2" Content="{Binding TaskItem.GetAllEmoji}" VerticalAlignment="Center" />
-                                                <Label Grid.Column="3" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
+                                                <TextBlock Grid.Column="3"
+                                                           Text="{Binding TaskItem.RepeaterListMarker}"
+                                                           IsVisible="{Binding TaskItem.IsHaveRepeater}"
+                                                           ToolTip.Tip="{Binding TaskItem.RepeaterListMarkerToolTip}"
+                                                           AutomationProperties.AutomationId="TaskRepeaterListMarker"
+                                                           Margin="4,0,4,0"
+                                                           VerticalAlignment="Center" />
+                                                <Label Grid.Column="4" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
                                             </Grid>
                                             <Button Background="#00000000"
                                                     Content="❌"
@@ -455,11 +497,18 @@ Content="❌"
                                 <TreeView.ItemTemplate>
                                     <TreeDataTemplate DataType="viewModel:TaskWrapperViewModel" ItemsSource="{Binding SubTasks}">
                                         <Grid DoubleTapped="TaskTree_OnDoubleTapped" Background="Transparent">
-                                            <Grid ColumnDefinitions="Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
+                                            <Grid ColumnDefinitions="Auto, Auto, Auto, Auto,*" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed" PointerMoved="InputElement_OnPointerMoved" PointerReleased="InputElement_OnPointerReleased">
                                                 <CheckBox IsChecked="{Binding TaskItem.IsCompleted}" VerticalAlignment="Center" IsEnabled="{Binding TaskItem.IsCanBeCompleted}" />
                                                 <Label Grid.Column="1" Content="{Binding SpecialDateTime, StringFormat={}{0:yyyy.MM.dd HH:mm:ss}}" Foreground="{StaticResource AccentButtonBackground}" FontFamily="Consolas" VerticalAlignment="Center" />
                                                 <Label Grid.Column="2" Content="{Binding TaskItem.GetAllEmoji}" VerticalAlignment="Center" />
-                                                <Label Grid.Column="3" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
+                                                <TextBlock Grid.Column="3"
+                                                           Text="{Binding TaskItem.RepeaterListMarker}"
+                                                           IsVisible="{Binding TaskItem.IsHaveRepeater}"
+                                                           ToolTip.Tip="{Binding TaskItem.RepeaterListMarkerToolTip}"
+                                                           AutomationProperties.AutomationId="TaskRepeaterListMarker"
+                                                           Margin="4,0,4,0"
+                                                           VerticalAlignment="Center" />
+                                                <Label Grid.Column="4" Content="{Binding TaskItem.Title}" VerticalAlignment="Center"  Classes.IsWanted="{Binding TaskItem.Wanted}"/>
                                             </Grid>
                                             <Button Background="#00000000"
                                                     Content="❌"


### PR DESCRIPTION
## Summary

Adds a compact repeater marker next to task titles so recurring tasks are visible while scanning task lists and the roadmap graph.

## Changes

- Adds `TaskItemViewModel` display properties for repeater marker text and tooltip.
- Keeps the existing `PropertyChanged.Fody` pattern on `TaskItemViewModel` and updates computed marker properties when the active repeater pattern changes.
- Shows the marker in the main task tree, inline list templates, relation trees, and graph nodes.
- Adds VM and headless/structural tests for marker visibility, notification behavior, stale repeater unsubscription, list templates, and graph template coverage.

## Validation

- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-restore --no-build -- --treenode-filter "/*/*/TaskItemRepeaterListMarkerTests/*" --no-progress`
- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-restore --no-build -- --treenode-filter "/*/*/TaskListRepeaterMarkerUiTests/*" --no-progress`

Both targeted suites pass locally.