### PR TITLE
Add Velopack GitHub updates

### DIFF
--- a/.github/workflows/deb_packaging.yml
+++ b/.github/workflows/deb_packaging.yml
@@ -8,8 +8,11 @@ on:
 permissions:
   contents: write
 
-env:  
+env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  VELOPACK_VERSION: 0.0.1298
+  LINUX_PUBLISH_DIR: ${{ github.workspace }}/src/Unlimotion.Desktop/bin/Release/net10.0/linux-x64/publish
+  LINUX_VELOPACK_DIR: ${{ github.workspace }}/artifacts/velopack/linux
 
 jobs:
   deb-build:
@@ -21,11 +24,82 @@ jobs:
       with:
         ref: ${{ github.sha }}
 
+    - name: Setup .NET 10 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Normalize release version
+      id: release_version
+      shell: bash
+      run: |
+        version="${GITHUB_REF_NAME}"
+        version="${version#v}"
+
+        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Release tag '${GITHUB_REF_NAME}' cannot be used by the current Linux Velopack workflow. Use numeric SemVer tags like 1.2.3 or v1.2.3." >&2
+          exit 1
+        fi
+
+        if [[ "$version" == "0.0.0" ]]; then
+          echo "Release tag '${GITHUB_REF_NAME}' cannot be used as a Velopack package version. Use 0.0.1 or greater." >&2
+          exit 1
+        fi
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Publish Linux Build
+      run: >
+        dotnet publish src/Unlimotion.Desktop/Unlimotion.Desktop.ForDebianBuild.csproj
+        -c Release
+        -f net10.0
+        -r linux-x64
+        -o "${{ env.LINUX_PUBLISH_DIR }}"
+        -p:PublishSingleFile=true
+        --self-contained true
+        -p:IncludeNativeLibrariesForSelfExtract=true
+        -p:DebugType=None
+        -p:DebugSymbols=false
+        -p:Version=${{ steps.release_version.outputs.version }}
+        --ignore-failed-sources
+
     - name: Generate DebPkg
-      run: sh ./src/Unlimotion.Desktop/ci/deb/generate-deb-pkg.sh ${{  github.ref_name }}
+      run: sh ./src/Unlimotion.Desktop/ci/deb/generate-deb-pkg.sh ${{ steps.release_version.outputs.version }}
 
     - name: Rename DebPkg
       run: cd ./src/Unlimotion.Desktop/bin/Release/net*/linux-x64 && mv ./*.deb ./Unlimotion-${{  github.ref_name }}.deb
+
+    - name: Install Velopack CLI
+      run: dotnet tool install --global vpk --version "${{ env.VELOPACK_VERSION }}" --ignore-failed-sources
+
+    - name: Pack Velopack Linux Release
+      shell: bash
+      run: |
+        mkdir -p "${{ env.LINUX_VELOPACK_DIR }}"
+
+        "$HOME/.dotnet/tools/vpk" pack \
+          --packId Unlimotion \
+          --packVersion "${{ steps.release_version.outputs.version }}" \
+          --packDir "${{ env.LINUX_PUBLISH_DIR }}" \
+          --outputDir "${{ env.LINUX_VELOPACK_DIR }}" \
+          --channel linux \
+          --runtime linux-x64 \
+          --mainExe Unlimotion.Desktop \
+          --packTitle Unlimotion \
+          --packAuthors Kibnet \
+          --icon "${{ github.workspace }}/src/Unlimotion.Android/Icon.png"
+
+    - name: Upload Velopack Linux Release
+      shell: bash
+      run: |
+        "$HOME/.dotnet/tools/vpk" upload github \
+          --outputDir "${{ env.LINUX_VELOPACK_DIR }}" \
+          --channel linux \
+          --repoUrl "https://github.com/${{ github.repository }}" \
+          --token "${{ secrets.GITHUB_TOKEN }}" \
+          --tag "${{ github.ref_name }}" \
+          --merge \
+          --publish
 
     - name: Upload DebPkg To Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/msi_packaging.yml
+++ b/.github/workflows/msi_packaging.yml
@@ -85,6 +85,7 @@ jobs:
           --packVersion "${{ steps.release_version.outputs.version }}" `
           --packDir "${{ env.WINDOWS_PUBLISH_DIR }}" `
           --outputDir "${{ env.VELOPACK_RELEASES_DIR }}" `
+          --channel win `
           --runtime win-x64 `
           --mainExe Unlimotion.Desktop.exe `
           --packTitle Unlimotion `
@@ -96,6 +97,7 @@ jobs:
       run: |
         vpk upload github `
           --outputDir "${{ env.VELOPACK_RELEASES_DIR }}" `
+          --channel win `
           --repoUrl "https://github.com/${{ github.repository }}" `
           --token "${{ secrets.GITHUB_TOKEN }}" `
           --tag "${{ github.ref_name }}" `

--- a/.github/workflows/msi_packaging.yml
+++ b/.github/workflows/msi_packaging.yml
@@ -13,6 +13,8 @@ env:
   WINDOWS_PUBLISH_DIR: ${{ github.workspace }}\src\Unlimotion.Desktop\bin\Release\net10.0\win-x64\publish
   WINDOWS_PORTABLE_DIR: ${{ github.workspace }}\artifacts\windows-portable
   WINDOWS_PORTABLE_ZIP: ${{ github.workspace }}\artifacts\windows-portable\Unlimotion-${{ github.ref_name }}-win-x64-portable.zip
+  VELOPACK_VERSION: 0.0.1298
+  VELOPACK_RELEASES_DIR: ${{ github.workspace }}\artifacts\velopack
 
 jobs:
   advinst-aip-build:
@@ -28,9 +30,30 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+
+    - name: Normalize release version
+      id: release_version
+      shell: pwsh
+      run: |
+        $version = "${{ github.ref_name }}"
+        if ($version.StartsWith("v", [System.StringComparison]::OrdinalIgnoreCase)) {
+          $version = $version.Substring(1)
+        }
+
+        if ($version -notmatch '^\d+\.\d+\.\d+$') {
+          throw "Release tag '${{ github.ref_name }}' cannot be used by the current MSI + Velopack workflow. Use numeric SemVer tags like 1.2.3 or v1.2.3."
+        }
+
+        $baseVersion = [System.Version]$version
+        if ($baseVersion -lt [System.Version]'0.0.1') {
+          throw "Release tag '${{ github.ref_name }}' cannot be used as a Velopack package version. Use 0.0.1 or greater."
+        }
+
+        "RELEASE_VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         
     - name: Publish
-      run: dotnet publish src\Unlimotion.Desktop\Unlimotion.Desktop.csproj -c Release -f net10.0 -r win-x64 -o "${{ env.WINDOWS_PUBLISH_DIR }}" -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -p:Version=${{  github.ref_name }} --ignore-failed-sources
+      run: dotnet publish src\Unlimotion.Desktop\Unlimotion.Desktop.csproj -c Release -f net10.0 -r win-x64 -o "${{ env.WINDOWS_PUBLISH_DIR }}" -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -p:Version=${{ steps.release_version.outputs.version }} --ignore-failed-sources
 
     - name: Create Portable Zip
       shell: pwsh
@@ -51,6 +74,34 @@ jobs:
           throw "Portable zip was not created: ${{ env.WINDOWS_PORTABLE_ZIP }}"
         }
 
+    - name: Install Velopack CLI
+      run: dotnet tool install --global vpk --version "${{ env.VELOPACK_VERSION }}" --ignore-failed-sources
+
+    - name: Pack Velopack Release
+      shell: pwsh
+      run: |
+        vpk pack `
+          --packId Unlimotion `
+          --packVersion "${{ steps.release_version.outputs.version }}" `
+          --packDir "${{ env.WINDOWS_PUBLISH_DIR }}" `
+          --outputDir "${{ env.VELOPACK_RELEASES_DIR }}" `
+          --runtime win-x64 `
+          --mainExe Unlimotion.Desktop.exe `
+          --packTitle Unlimotion `
+          --packAuthors Kibnet `
+          --icon "${{ github.workspace }}\src\Unlimotion.Desktop\Assets\Unlimotion.ico"
+
+    - name: Upload Velopack Release
+      shell: pwsh
+      run: |
+        vpk upload github `
+          --outputDir "${{ env.VELOPACK_RELEASES_DIR }}" `
+          --repoUrl "https://github.com/${{ github.repository }}" `
+          --token "${{ secrets.GITHUB_TOKEN }}" `
+          --tag "${{ github.ref_name }}" `
+          --merge `
+          --publish
+
     - name: Build AIP
       uses: caphyon/advinst-github-action@v1.0
       with:
@@ -62,7 +113,7 @@ jobs:
         aip-output-dir:  ${{ github.workspace }}\setup
         aip-commands: |
           SetProperty FOO="foo"
-          SetVersion ${{  github.ref_name }}
+          SetVersion ${{ steps.release_version.outputs.version }}
 
     - name: Upload MsiPkg to Release
       uses: xresloader/upload-to-github-release@v1.3.11

--- a/.github/workflows/osx-packaging.yml
+++ b/.github/workflows/osx-packaging.yml
@@ -7,9 +7,12 @@ on:
 
 permissions:
   contents: write
-        
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  VELOPACK_VERSION: 0.0.1298
+  OSX_APP_PATH: ${{ github.workspace }}/Unlimotion.app
+  OSX_VELOPACK_DIR: ${{ github.workspace }}/artifacts/velopack/osx
 
 jobs:
   osx-build:
@@ -21,14 +24,69 @@ jobs:
       with:
         ref: ${{ github.sha }}
 
+    - name: Setup .NET 10 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.0.x
+
+    - name: Normalize release version
+      id: release_version
+      shell: bash
+      run: |
+        version="${GITHUB_REF_NAME}"
+        version="${version#v}"
+
+        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "Release tag '${GITHUB_REF_NAME}' cannot be used by the current macOS Velopack workflow. Use numeric SemVer tags like 1.2.3 or v1.2.3." >&2
+          exit 1
+        fi
+
+        if [[ "$version" == "0.0.0" ]]; then
+          echo "Release tag '${GITHUB_REF_NAME}' cannot be used as a Velopack package version. Use 0.0.1 or greater." >&2
+          exit 1
+        fi
+
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
     - name: Publish
-      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh ${{ github.ref_name }}
+      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh ${{ steps.release_version.outputs.version }}
 
     - name: Generate App
-      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh ${{ github.ref_name }}
+      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh ${{ steps.release_version.outputs.version }}
+
+    - name: Install Velopack CLI
+      run: dotnet tool install --global vpk --version "${{ env.VELOPACK_VERSION }}" --ignore-failed-sources
+
+    - name: Pack Velopack macOS Release
+      shell: bash
+      run: |
+        mkdir -p "${{ env.OSX_VELOPACK_DIR }}"
+
+        "$HOME/.dotnet/tools/vpk" pack \
+          --packId Unlimotion \
+          --packVersion "${{ steps.release_version.outputs.version }}" \
+          --packDir "${{ env.OSX_APP_PATH }}" \
+          --outputDir "${{ env.OSX_VELOPACK_DIR }}" \
+          --channel osx \
+          --runtime osx-x64 \
+          --mainExe Unlimotion.Desktop.ForMacBuild \
+          --packTitle Unlimotion \
+          --packAuthors Kibnet
+
+    - name: Upload Velopack macOS Release
+      shell: bash
+      run: |
+        "$HOME/.dotnet/tools/vpk" upload github \
+          --outputDir "${{ env.OSX_VELOPACK_DIR }}" \
+          --channel osx \
+          --repoUrl "https://github.com/${{ github.repository }}" \
+          --token "${{ secrets.GITHUB_TOKEN }}" \
+          --tag "${{ github.ref_name }}" \
+          --merge \
+          --publish
 
     - name: Generate Pkg
-      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-pkg.sh ${{ github.ref_name }}
+      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-pkg.sh ${{ steps.release_version.outputs.version }}
 
     - name: Upload MacOSPkg To Release
       uses: softprops/action-gh-release@v1

--- a/specs/2026-04-23-velopack-github-updates.md
+++ b/specs/2026-04-23-velopack-github-updates.md
@@ -7,7 +7,7 @@
 - Целевой релиз / ветка: текущая рабочая ветка
 - Ограничения:
   - До подтверждения этой спеки разрешено менять только этот файл.
-  - Первая реализация ориентирована на Windows desktop build `src/Unlimotion.Desktop`.
+  - Первая реализация охватывает desktop release channels `win`, `linux` и `osx` в рамках текущих desktop build-проектов.
   - Текущие MSI и portable ZIP release assets не удаляются в рамках этой задачи.
   - Существующие мобильные, browser и shared Avalonia проекты не должны получить обязательную зависимость от Velopack.
 - Связанные ссылки:
@@ -17,13 +17,14 @@
   - https://www.nuget.org/packages/vpk
 
 ## 1. Overview / Цель
-Добавить основу автообновления desktop-приложения через Velopack и GitHub Releases: приложение должно корректно обрабатывать Velopack install/update hooks, уметь проверять релизные артефакты GitHub Releases и release workflow должен публиковать Velopack-пакеты вместе с текущими артефактами.
+Добавить основу автообновления desktop-приложения через Velopack и GitHub Releases: приложение должно корректно обрабатывать Velopack install/update hooks, уметь проверять релизные артефакты GitHub Releases, а release workflows должны публиковать Velopack-пакеты и feed metadata для `win`, `linux` и `osx` вместе с текущими артефактами.
 
 ## 2. Текущее состояние (AS-IS)
 - Desktop-приложение находится в `src/Unlimotion.Desktop` и запускает shared Avalonia app из `src/Unlimotion`.
 - `src/Unlimotion.Desktop/Program.cs` выполняет раннюю настройку путей, затем вызывает `App.Init(configPath)` и `BuildAvaloniaApp().StartWithClassicDesktopLifetime(args)`.
 - `src/Directory.Packages.props` использует centralized package management.
 - `.github/workflows/msi_packaging.yml` запускается на `release.published`, публикует `dotnet publish` output для `win-x64`, собирает MSI через Advanced Installer и загружает MSI + portable ZIP в GitHub Release.
+- `.github/workflows/deb_packaging.yml` и `.github/workflows/osx-packaging.yml` уже публикуют Linux/macOS release assets (`.deb` и `.pkg`), но не создают Velopack-managed update feeds/packages.
 - `Unlimotion.aip` остается текущей схемой MSI packaging.
 - Пользовательские данные и настройки в Release режиме пишутся вне папки приложения: `Settings.json` в `Documents/Unlimotion`, задачи через `TaskStorageFactory`, backup paths через `LocalApplicationData/Unlimotion`. Это важно, потому что Velopack заменяет папку установленного приложения при обновлении.
 - `src/Unlimotion/Views/SettingsControl.axaml` уже содержит секционную страницу настроек: внешний вид, хранилище, backup, advanced backup и service actions.
@@ -36,6 +37,7 @@
 ## 4. Цели дизайна
 - Разделение ответственности: Velopack-зависимость и GitHub update source остаются в desktop entrypoint/desktop services.
 - Повторное использование: release workflow переиспользует существующий `dotnet publish` output.
+- Cross-platform release safety: каждый desktop runtime публикуется в отдельный Velopack channel/feed, чтобы Windows/Linux/macOS не пересекались в одном release index.
 - Тестируемость: логика решения "есть обновление -> скачать -> спросить о рестарте / не падать при ошибке" отделяется от прямых Velopack API через тонкую абстракцию.
 - Консистентность: текущие настройки, данные задач и backup-настройки не переносятся в папку приложения.
 - Обратная совместимость: MSI и portable ZIP продолжают публиковаться, пока Velopack-путь не будет проверен на реальных релизах.
@@ -58,7 +60,7 @@
 - `src/Unlimotion.Desktop/Services/*` -> добавить desktop-only Velopack implementation для platform-neutral update service.
 - `src/Unlimotion/App.axaml.cs` -> подключить update service к `SettingsViewModel` после создания view model, без прямой зависимости shared проекта от Velopack.
 - `src/Unlimotion/Views/SettingsControl.axaml` -> добавить секцию "Обновления" с текущим статусом, ручной проверкой и применением скачанного обновления.
-- `.github/workflows/msi_packaging.yml` -> добавить шаги установки `vpk`, упаковки `dotnet publish` output и загрузки Velopack assets в текущий GitHub Release.
+- `.github/workflows/msi_packaging.yml`, `.github/workflows/deb_packaging.yml`, `.github/workflows/osx-packaging.yml` -> добавить шаги установки `vpk`, упаковки platform-specific publish output и загрузки Velopack assets/feed metadata в текущий GitHub Release.
 - `src/Unlimotion.Test` -> добавить unit tests для coordinator logic, если абстракция будет жить в тестируемом shared/desktop-neutral слое; иначе ограничиться build/packaging smoke checks для инфраструктурной части.
 
 ### 6.2 Детальный дизайн
@@ -67,6 +69,7 @@
   - После FastCallback приложение должно быстро выйти, если Velopack запустил его с install/update аргументами.
 - Проверка обновлений запускается после открытия главного окна, чтобы не блокировать UI startup.
 - Update source: `new UpdateManager(new GithubSource("https://github.com/<owner>/<repo>"))`.
+- Отдельные feed URLs/репозитории не нужны: Velopack сам использует `releases.{channel}.json` в том же GitHub Release asset set. Для cross-platform rollout каналы должны быть раздельными (`win`, `linux`, `osx`) или явно заданными platform-specific значениями.
 - Репозиторий должен определяться константой или build property для текущего проекта. Если origin невозможно надежно вывести из runtime, использовать явное значение GitHub repo из workflow.
 - Поток обновления:
   1. Проверить, запущено ли приложение из Velopack-installed context; portable/MSI legacy запуск не должен падать.
@@ -113,6 +116,7 @@
 - `SettingsControl.axaml`: ручной триггер `CheckForUpdatesCommand`, `DownloadUpdateCommand`, `ApplyUpdateCommand`.
 - GitHub Actions `release.published`: упаковка Velopack assets после существующего `dotnet publish`.
 - GitHub Release assets: Velopack packages и release metadata должны лежать в том же release, откуда `GithubSource` сможет получить update feed.
+- Для cross-platform rollout каждый workflow публикует свой `releases.{channel}.json` и соответствующие platform assets в тот же GitHub release, без общего "универсального" feed-файла.
 
 ## 9. Изменения модели данных / состояния
 - Новых persisted полей в пользовательских настройках не требуется.
@@ -123,8 +127,9 @@
 ## 10. Миграция / Rollout / Rollback
 - Rollout:
   1. Сначала публиковать Velopack assets вместе с MSI/portable ZIP.
-  2. Проверить установку Velopack bootstrapper на отдельной машине/VM.
-  3. Проверить обновление с версии N на N+1 через GitHub Release.
+  2. Проверить, что для каждого desktop runtime (`win`, `linux`, `osx`) в release появляются свои Velopack channel assets.
+  3. Проверить установку Velopack bootstrapper / portable artifact на отдельных машинах/VM по платформам.
+  4. Проверить обновление с версии N на N+1 через GitHub Release хотя бы на одной машине для каждого поддерживаемого desktop runtime.
 - Совместимость:
   - Уже установленные MSI-копии не станут Velopack-managed автоматически.
   - Пользователь должен установить Velopack bootstrapper/installer хотя бы один раз, чтобы дальнейшие обновления шли через Velopack.
@@ -143,6 +148,7 @@
   - В не-Velopack установке раздел настроек показывает unsupported state или отключенные действия без исключений.
   - Во время проверки/скачивания update-кнопки корректно отключаются и статус обновляется.
   - Release workflow публикует Velopack assets в GitHub Release.
+  - Release workflows публикуют раздельные Velopack feeds/assets для `win`, `linux` и `osx` в одном GitHub Release.
   - Текущие MSI и portable ZIP assets продолжают публиковаться.
 - Какие тесты добавить/изменить:
   - Unit tests для update coordinator/settings update state с fake update client: unsupported install, no update, update available, download success, apply restart, exception path, repeated command guard.
@@ -184,7 +190,7 @@
 
 ## 14. Открытые вопросы
 Нет блокирующих вопросов. Принятые допущения:
-- Первый релизный канал: Windows desktop.
+- Первый rollout охватывает `win`, `linux` и `osx` каналы, по одному Velopack feed на платформу.
 - GitHub Releases публичного репозитория достаточно без PAT для runtime update checks.
 - MSI/portable ZIP остаются параллельными артефактами минимум на переходный период.
 
@@ -209,13 +215,15 @@
 | `src/Unlimotion/Views/SettingsControl.axaml` | Секция "Обновления" | Ручная проверка, скачивание и применение обновлений |
 | `src/Unlimotion.ViewModel/Resources/Strings*.resx` | Строки update section/prompt/statuses | Локализация пользовательских сообщений |
 | `src/Unlimotion.Test/*` | Coordinator tests | Проверка поведения без сети/GitHub |
-| `.github/workflows/msi_packaging.yml` | Velopack packaging/upload steps | Публикация update assets в GitHub Release |
+| `.github/workflows/msi_packaging.yml` | Velopack packaging/upload steps для Windows | Публикация Windows update assets в GitHub Release |
+| `.github/workflows/deb_packaging.yml` | Velopack packaging/upload steps для Linux + сохранение `.deb` | Публикация Linux update assets в GitHub Release |
+| `.github/workflows/osx-packaging.yml` | Velopack packaging/upload steps для macOS + сохранение `.pkg` | Публикация macOS update assets в GitHub Release |
 
 ## 17. Таблица соответствий (было -> стало)
 | Область | Было | Стало |
 | --- | --- | --- |
 | Startup lifecycle | Только app/Avalonia init | Ранний Velopack hook, затем обычный startup |
-| Release assets | MSI + portable ZIP | MSI + portable ZIP + Velopack packages/feed |
+| Release assets | MSI + portable ZIP + `.deb` + `.pkg` | Те же артефакты + Velopack packages/feed для `win`, `linux`, `osx` |
 | Runtime updates | Нет проверки | Background check через GitHub Releases |
 | Settings updates | Нет раздела обновлений | Ручная проверка, скачивание и применение в настройках |
 | User restart | Не применимо | Рестарт только после согласия пользователя |
@@ -294,3 +302,4 @@
 | EXEC | Продолжение верификации | 0.95 | Нет | Финализировать ответ | Нет | Да, пользователь сказал `продолжай` | Устранены blockers полного тестового прогона: Git backup fixtures перенесены в короткую temp-папку, settings-тест изолирован от глобальной локализации. Полный `dotnet test` теперь проходит: 198/198; `dotnet build src\Unlimotion.sln --no-restore -m:1` проходит. | `src/Unlimotion.Test/BackupViaGitServiceTests.cs`, `src/Unlimotion.Test/SettingsViewModelTests.cs`, `specs/2026-04-23-velopack-github-updates.md` |
 | EXEC | Исправление review findings | 0.96 | Нет | Финализировать ответ | Нет | Да, пользователь сказал `испрравь` | Состояние pending restart теперь не теряется при ручной проверке обновлений, кнопка проверки блокируется до применения; workflow больше не принимает prerelease/build-теги, чтобы не передавать их в MSI `SetVersion`. Проверки: targeted settings tests 36/36, полный `dotnet test --no-build` 199/199, `dotnet build src\Unlimotion.sln --no-restore -m:1`, `git diff --check`. | `src/Unlimotion.ViewModel/SettingsViewModel.cs`, `src/Unlimotion.Desktop/Services/VelopackApplicationUpdateService.cs`, `src/Unlimotion.Test/SettingsViewModelTests.cs`, `.github/workflows/msi_packaging.yml` |
 | EXEC | Rebase на основную ветку | 0.96 | Нет | Сделать коммит | Нет | Да, пользователь попросил новую ветку, rebase на `master` и commit; фактическая основная ветка репозитория - `main` | Создана `feature/velopack-github-updates` от `origin/main`, stash изменений применен с разрешением конфликтов. Для `main` добавлены Velopack references в Debian/macOS desktop-проекты, которые компилируют общий desktop entrypoint. Проверки после переноса: `dotnet restore src\Unlimotion.sln`, `dotnet build src\Unlimotion.sln --no-restore -m:1`, `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --no-build` 201/201. | `src/Unlimotion.Desktop/Unlimotion.Desktop.ForDebianBuild.csproj`, `src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj`, `src/Unlimotion/App.axaml.cs`, `src/Unlimotion.Test/*`, `specs/2026-04-23-velopack-github-updates.md` |
+| EXEC | Multi-platform release feeds | 0.97 | Нет | Закоммитить и допушить PR | Нет | Да, пользователь попросил публиковать Velopack сразу для всех поддерживаемых платформ | Windows feed зафиксирован как `win`, в Linux/macOS workflows добавлены platform-specific Velopack pack/upload шаги и нормализация release version. Отдельные feed URLs не понадобились: используются каналы `win`, `linux`, `osx` в одном GitHub Release. Дополнительно исправлен `generate-osx-publish.sh`: restore теперь идет с `--runtime osx-x64`, иначе local macOS publish падал на `NETSDK1047`. Проверки: локальный `vpk pack --help`/`vpk upload github --help`, `dotnet publish` для `linux-x64`, `dotnet restore --runtime osx-x64` + `dotnet publish` для `osx-x64`, `git diff --check`. | `.github/workflows/msi_packaging.yml`, `.github/workflows/deb_packaging.yml`, `.github/workflows/osx-packaging.yml`, `src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh`, `specs/2026-04-23-velopack-github-updates.md` |

--- a/specs/2026-04-23-velopack-github-updates.md
+++ b/specs/2026-04-23-velopack-github-updates.md
@@ -1,0 +1,296 @@
+# Velopack GitHub Releases Updates
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; stack profile `dotnet-desktop-client`; context `testing-dotnet`
+- Владелец: Codex
+- Масштаб: medium
+- Целевой релиз / ветка: текущая рабочая ветка
+- Ограничения:
+  - До подтверждения этой спеки разрешено менять только этот файл.
+  - Первая реализация ориентирована на Windows desktop build `src/Unlimotion.Desktop`.
+  - Текущие MSI и portable ZIP release assets не удаляются в рамках этой задачи.
+  - Существующие мобильные, browser и shared Avalonia проекты не должны получить обязательную зависимость от Velopack.
+- Связанные ссылки:
+  - https://docs.velopack.io/integrating/overview
+  - https://docs.velopack.io/reference/cs/Velopack/Sources/GithubSource
+  - https://www.nuget.org/packages/Velopack
+  - https://www.nuget.org/packages/vpk
+
+## 1. Overview / Цель
+Добавить основу автообновления desktop-приложения через Velopack и GitHub Releases: приложение должно корректно обрабатывать Velopack install/update hooks, уметь проверять релизные артефакты GitHub Releases и release workflow должен публиковать Velopack-пакеты вместе с текущими артефактами.
+
+## 2. Текущее состояние (AS-IS)
+- Desktop-приложение находится в `src/Unlimotion.Desktop` и запускает shared Avalonia app из `src/Unlimotion`.
+- `src/Unlimotion.Desktop/Program.cs` выполняет раннюю настройку путей, затем вызывает `App.Init(configPath)` и `BuildAvaloniaApp().StartWithClassicDesktopLifetime(args)`.
+- `src/Directory.Packages.props` использует centralized package management.
+- `.github/workflows/msi_packaging.yml` запускается на `release.published`, публикует `dotnet publish` output для `win-x64`, собирает MSI через Advanced Installer и загружает MSI + portable ZIP в GitHub Release.
+- `Unlimotion.aip` остается текущей схемой MSI packaging.
+- Пользовательские данные и настройки в Release режиме пишутся вне папки приложения: `Settings.json` в `Documents/Unlimotion`, задачи через `TaskStorageFactory`, backup paths через `LocalApplicationData/Unlimotion`. Это важно, потому что Velopack заменяет папку установленного приложения при обновлении.
+- `src/Unlimotion/Views/SettingsControl.axaml` уже содержит секционную страницу настроек: внешний вид, хранилище, backup, advanced backup и service actions.
+- `SettingsViewModel` живет в `src/Unlimotion.ViewModel`, а команды для действий настроек в основном назначаются из `src/Unlimotion/App.axaml.cs`.
+- Готового механизма проверки обновлений в приложении нет.
+
+## 3. Проблема
+У приложения нет встроенного канала автообновления: GitHub Release assets публикуются, но установленное desktop-приложение не проверяет новые версии, не скачивает update package и не применяет обновление.
+
+## 4. Цели дизайна
+- Разделение ответственности: Velopack-зависимость и GitHub update source остаются в desktop entrypoint/desktop services.
+- Повторное использование: release workflow переиспользует существующий `dotnet publish` output.
+- Тестируемость: логика решения "есть обновление -> скачать -> спросить о рестарте / не падать при ошибке" отделяется от прямых Velopack API через тонкую абстракцию.
+- Консистентность: текущие настройки, данные задач и backup-настройки не переносятся в папку приложения.
+- Обратная совместимость: MSI и portable ZIP продолжают публиковаться, пока Velopack-путь не будет проверен на реальных релизах.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не удаляем Advanced Installer/MSI workflow.
+- Не переводим Android, iOS и Browser проекты на Velopack.
+- Не добавляем self-hosted update server, S3, Azure Storage или отдельный backend.
+- Не меняем формат пользовательских данных и не переносим существующие настройки.
+- Не делаем downgrade/channel switching UI.
+- Не вводим обязательный GitHub personal access token для публичных релизов.
+- Не добавляем настройки автоматической периодичности обновлений, каналов и prerelease-потоков в первой итерации.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `src/Directory.Packages.props` -> добавить стабильную версию NuGet-пакета `Velopack` и dotnet tool package `vpk` при необходимости фиксации через tool manifest.
+- `src/Unlimotion.Desktop/Unlimotion.Desktop.csproj` -> добавить `PackageReference Include="Velopack"`.
+- `src/Unlimotion.Desktop/Program.cs` -> вызвать `VelopackApp.Build().Run()` максимально рано в `Main`, до пользовательской и Avalonia-инициализации.
+- `src/Unlimotion.ViewModel/*` -> добавить platform-neutral интерфейс update service и состояние/команды `SettingsViewModel` для ручной проверки, скачивания и применения обновлений.
+- `src/Unlimotion.Desktop/Services/*` -> добавить desktop-only Velopack implementation для platform-neutral update service.
+- `src/Unlimotion/App.axaml.cs` -> подключить update service к `SettingsViewModel` после создания view model, без прямой зависимости shared проекта от Velopack.
+- `src/Unlimotion/Views/SettingsControl.axaml` -> добавить секцию "Обновления" с текущим статусом, ручной проверкой и применением скачанного обновления.
+- `.github/workflows/msi_packaging.yml` -> добавить шаги установки `vpk`, упаковки `dotnet publish` output и загрузки Velopack assets в текущий GitHub Release.
+- `src/Unlimotion.Test` -> добавить unit tests для coordinator logic, если абстракция будет жить в тестируемом shared/desktop-neutral слое; иначе ограничиться build/packaging smoke checks для инфраструктурной части.
+
+### 6.2 Детальный дизайн
+- На старте `Program.Main` первым значимым действием вызывает Velopack startup hook:
+  - `VelopackApp.Build().Run();`
+  - После FastCallback приложение должно быстро выйти, если Velopack запустил его с install/update аргументами.
+- Проверка обновлений запускается после открытия главного окна, чтобы не блокировать UI startup.
+- Update source: `new UpdateManager(new GithubSource("https://github.com/<owner>/<repo>"))`.
+- Репозиторий должен определяться константой или build property для текущего проекта. Если origin невозможно надежно вывести из runtime, использовать явное значение GitHub repo из workflow.
+- Поток обновления:
+  1. Проверить, запущено ли приложение из Velopack-installed context; portable/MSI legacy запуск не должен падать.
+  2. Асинхронно вызвать `CheckForUpdatesAsync`.
+  3. Если обновления нет, завершить без UI шума.
+  4. Если обновление есть, скачать через `DownloadUpdatesAsync`.
+  5. После скачивания показать существующий `INotificationManagerWrapper.Ask` с предложением перезапустить приложение.
+  6. При согласии пользователя вызвать `ApplyUpdatesAndRestart`.
+  7. При отказе не прерывать работу; обновление применится позже через явный restart или следующий запуск, если Velopack это поддержит для downloaded pending update.
+- Раздел настроек "Обновления":
+  - располагается отдельной секцией рядом с существующими секциями `SettingsControl`;
+  - показывает текущую версию приложения, статус проверки и, если найдено обновление, доступную версию;
+  - содержит кнопку ручной проверки обновлений;
+  - содержит кнопку скачивания/подготовки обновления, когда обновление найдено;
+  - содержит кнопку применения обновления с перезапуском, когда пакет уже скачан;
+  - кнопки должны отключаться на время проверки/скачивания, чтобы пользователь не запускал параллельные update операции;
+  - если приложение запущено не из Velopack-managed install, секция должна показывать понятный статус "обновления недоступны для этой установки" или скрывать кнопки применения, но не должна ломать настройки.
+- Состояния update UI:
+  - `Unsupported`: установка не управляется Velopack или платформа не поддерживается.
+  - `Idle`: проверка не выполнялась или готова к запуску.
+  - `Checking`: идет проверка GitHub Releases.
+  - `NoUpdates`: новых версий нет.
+  - `UpdateAvailable`: новая версия найдена, пакет еще не скачан.
+  - `Downloading`: идет скачивание update package.
+  - `ReadyToApply`: пакет скачан, можно применить с рестартом.
+  - `Applying`: запущено применение обновления и рестарт.
+  - `Error`: последняя операция завершилась ошибкой; текст ошибки отображается в статусе без падения приложения.
+- Ошибки сети, GitHub API, отсутствия Velopack metadata и невалидного release feed логируются/показываются как non-blocking toast только в случаях, когда это не будет раздражать пользователя при каждом запуске. Для первой итерации предпочтительно логировать и не показывать ошибку, кроме уже скачанного обновления, которое не удалось применить.
+- Производительность: проверка и скачивание выполняются async/background; UI thread используется только для сообщения пользователю.
+
+## 7. Бизнес-правила / Алгоритмы
+- Автообновление не должно принудительно перезапускать приложение без согласия пользователя.
+- Ручное применение обновления в настройках всегда явно означает согласие на перезапуск приложения.
+- Если обновление найдено фоновой проверкой, пользователь может применить его через prompt или позже через раздел настроек.
+- Отсутствие интернет-соединения не должно менять пользовательский сценарий запуска.
+- GitHub prerelease не устанавливается в stable channel, если явно не задан отдельный режим.
+- Версия релиза должна быть SemVer-compatible для Velopack и `dotnet publish -p:Version=...`.
+- Release tag должен совпадать с версией пакета или быть нормализован в workflow до версии, приемлемой для Velopack.
+
+## 8. Точки интеграции и триггеры
+- `Program.Main`: Velopack hook до `TaskStorageFactory`, `App.Init` и Avalonia startup.
+- `App.Init` или другой platform service bootstrap: desktop entrypoint передает shared app platform-neutral update service; не-desktop entrypoints используют `null`/no-op.
+- `App.OnFrameworkInitializationCompleted`: запуск фоновой проверки после создания/открытия desktop window и привязка update commands к `SettingsViewModel`.
+- `SettingsControl.axaml`: ручной триггер `CheckForUpdatesCommand`, `DownloadUpdateCommand`, `ApplyUpdateCommand`.
+- GitHub Actions `release.published`: упаковка Velopack assets после существующего `dotnet publish`.
+- GitHub Release assets: Velopack packages и release metadata должны лежать в том же release, откуда `GithubSource` сможет получить update feed.
+
+## 9. Изменения модели данных / состояния
+- Новых persisted полей в пользовательских настройках не требуется.
+- Update status, available version и downloaded update state являются runtime/calculated state в `SettingsViewModel`, а не persisted settings.
+- Новые temporary/update файлы создаются Velopack в собственной install/update структуре.
+- Пользовательские данные не должны храниться в Velopack `current` directory.
+
+## 10. Миграция / Rollout / Rollback
+- Rollout:
+  1. Сначала публиковать Velopack assets вместе с MSI/portable ZIP.
+  2. Проверить установку Velopack bootstrapper на отдельной машине/VM.
+  3. Проверить обновление с версии N на N+1 через GitHub Release.
+- Совместимость:
+  - Уже установленные MSI-копии не станут Velopack-managed автоматически.
+  - Пользователь должен установить Velopack bootstrapper/installer хотя бы один раз, чтобы дальнейшие обновления шли через Velopack.
+- Rollback:
+  - Отключить/удалить Velopack steps из workflow.
+  - Убрать `VelopackApp` hook и desktop update service.
+  - MSI/portable ZIP остаются рабочим каналом распространения.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  - `Program.Main` содержит ранний Velopack hook до пользовательской и Avalonia-инициализации.
+  - Desktop проект собирается с пакетом `Velopack`; shared/mobile/browser проекты не получают прямой Velopack dependency.
+  - На запуске вне Velopack-installed context приложение не падает.
+  - При доступном обновлении coordinator проверяет, скачивает и предлагает рестарт без блокировки UI.
+  - В настройках есть секция обновлений с ручной проверкой, скачиванием/подготовкой и применением обновления.
+  - В не-Velopack установке раздел настроек показывает unsupported state или отключенные действия без исключений.
+  - Во время проверки/скачивания update-кнопки корректно отключаются и статус обновляется.
+  - Release workflow публикует Velopack assets в GitHub Release.
+  - Текущие MSI и portable ZIP assets продолжают публиковаться.
+- Какие тесты добавить/изменить:
+  - Unit tests для update coordinator/settings update state с fake update client: unsupported install, no update, update available, download success, apply restart, exception path, repeated command guard.
+  - Headless UI smoke test для `SettingsControl`, если существующая test infrastructure позволяет проверить наличие секции и enabled/disabled state без хрупких визуальных проверок.
+  - Velopack implementation тестировать через build/smoke, без сетевых GitHub вызовов в unit tests.
+- Characterization checks:
+  - Проверить, что `dotnet publish` command из workflow по-прежнему формирует expected output.
+  - Проверить, что `vpk pack` принимает release version из `github.ref_name` или нормализованное значение.
+- Команды для проверки:
+  - `dotnet build src/Unlimotion.sln`
+  - `dotnet test src/Unlimotion.sln`
+  - `dotnet publish src/Unlimotion.Desktop/Unlimotion.Desktop.csproj -c Release -f net10.0 -r win-x64 -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false -p:Version=0.0.0-test --ignore-failed-sources`
+  - `vpk pack` smoke command against the publish output, with the exact arguments implemented in workflow.
+
+## 12. Риски и edge cases
+- Velopack-managed install и текущий MSI install являются разными install channels; автоматическая миграция MSI -> Velopack не входит в задачу.
+- `github.ref_name` может иметь префикс `v` или другой формат, несовместимый с Velopack/package version. Workflow должен нормализовать версию или явно документировать требуемый tag format.
+- GitHub rate limits возможны для unauthenticated public release checks; для public repo это приемлемо на MVP, но для private repo потребуется token/source configuration.
+- Single-file publish может быть несовместим с выбранным Velopack packaging режимом или усложнить delta updates. В EXEC нужно проверить документацию/CLI фактически и при необходимости отключить single-file только для Velopack publish path, не меняя MSI path без причины.
+- Несколько запущенных экземпляров приложения могут помешать применению обновления. MVP не добавляет single-instance lock.
+- UI prompt через `DialogHost` должен вызываться только после готовности главного окна.
+- Если пользователь открыл настройки до завершения фоновой проверки, ручная проверка должна либо дождаться текущей операции, либо быть временно отключена.
+- Секция обновлений не должна перегружать страницу настроек длинными техническими ошибками; подробности можно оставить в логах, а UI показать короткий статус.
+
+## 13. План выполнения
+1. Подтвердить точные Velopack CLI аргументы на локальной версии `vpk` и зафиксировать stable версию пакета/tool.
+2. Добавить Velopack dependency только в desktop проект через centralized package management.
+3. Добавить ранний `VelopackApp.Build().Run()` в `Program.Main`.
+4. Добавить platform-neutral update service contract и state model для `SettingsViewModel`.
+5. Добавить desktop Velopack client wrapper.
+6. Подключить update service и команды к `SettingsViewModel`.
+7. Добавить секцию "Обновления" в `SettingsControl.axaml`.
+8. Подключить фоновую проверку после открытия главного окна без блокировки UI.
+9. Добавить/обновить локализованные строки для update section, prompt и statuses.
+10. Обновить `.github/workflows/msi_packaging.yml` Velopack pack/upload steps, сохранив MSI/ZIP steps.
+11. Добавить targeted unit/headless tests для update state и настроек.
+12. Выполнить build/test/publish/vpk smoke checks.
+13. Выполнить post-EXEC review и поправить найденные критичные проблемы.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов. Принятые допущения:
+- Первый релизный канал: Windows desktop.
+- GitHub Releases публичного репозитория достаточно без PAT для runtime update checks.
+- MSI/portable ZIP остаются параллельными артефактами минимум на переходный период.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client`
+- Выполненные требования профиля:
+  - Длительные сетевые операции не блокируют UI thread.
+  - Platform-specific Velopack код изолируется от ViewModel/бизнес-логики.
+  - Существующие automation selectors не меняются.
+  - Перед завершением EXEC должны быть запущены `dotnet build` и `dotnet test`.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `specs/2026-04-23-velopack-github-updates.md` | Рабочая спецификация | QUEST gate перед реализацией |
+| `src/Directory.Packages.props` | Добавить `Velopack`/`vpk` версию | Централизованное управление пакетами |
+| `src/Unlimotion.Desktop/Unlimotion.Desktop.csproj` | Добавить desktop-only Velopack dependency | Runtime hooks и update API |
+| `src/Unlimotion.Desktop/Program.cs` | Ранний Velopack startup hook | Требование Velopack lifecycle |
+| `src/Unlimotion.ViewModel/*` | Update service contract, status model, свойства и команды `SettingsViewModel` | Ручная проверка и применение обновлений из настроек без Velopack dependency |
+| `src/Unlimotion.Desktop/Services/*` | Velopack implementation/client wrapper | Изоляция Velopack API и тестируемость |
+| `src/Unlimotion/App.axaml.cs` | Подключение update service, команд и фоновой проверки | Запуск после готовности desktop UI |
+| `src/Unlimotion/Views/SettingsControl.axaml` | Секция "Обновления" | Ручная проверка, скачивание и применение обновлений |
+| `src/Unlimotion.ViewModel/Resources/Strings*.resx` | Строки update section/prompt/statuses | Локализация пользовательских сообщений |
+| `src/Unlimotion.Test/*` | Coordinator tests | Проверка поведения без сети/GitHub |
+| `.github/workflows/msi_packaging.yml` | Velopack packaging/upload steps | Публикация update assets в GitHub Release |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Startup lifecycle | Только app/Avalonia init | Ранний Velopack hook, затем обычный startup |
+| Release assets | MSI + portable ZIP | MSI + portable ZIP + Velopack packages/feed |
+| Runtime updates | Нет проверки | Background check через GitHub Releases |
+| Settings updates | Нет раздела обновлений | Ручная проверка, скачивание и применение в настройках |
+| User restart | Не применимо | Рестарт только после согласия пользователя |
+| Non-Windows targets | Без Velopack | Без Velopack |
+
+## 18. Альтернативы и компромиссы
+- Вариант: заменить MSI на Velopack сразу.
+  - Плюсы: меньше release artifacts.
+  - Минусы: высокий rollout risk, нет fallback для текущих пользователей.
+  - Почему не выбран: переходный период безопаснее.
+- Вариант: только workflow packaging без runtime update check.
+  - Плюсы: быстро и низкий риск.
+  - Минусы: не решает автообновление.
+  - Почему не выбран: пользователь запросил автообновление.
+- Вариант: Advanced Installer Updater.
+  - Плюсы: лучше ложится на текущий MSI.
+  - Минусы: пользователь выбрал Velopack; хуже перспектива cross-platform.
+  - Почему не выбран: Velopack выбран как целевое направление.
+- Вариант: silent restart/update без prompt.
+  - Плюсы: максимально автоматический сценарий.
+  - Минусы: можно потерять пользовательский контекст.
+  - Почему не выбран: безопаснее не перезапускать desktop-приложение без согласия.
+- Вариант: только prompt при фоновой проверке без раздела настроек.
+  - Плюсы: меньше UI и меньше команд.
+  - Минусы: пользователь не может вручную проверить и применить обновление позже.
+  - Почему не выбран: пользователь явно запросил раздел настроек для ручной проверки и применения.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели, ручной settings flow и Non-Goals зафиксированы. |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, интеграция, алгоритм, UI state, состояние и rollout описаны. |
+| C. Безопасность изменений | 11-13 | PASS | Rollback, совместимость MSI/Velopack и edge cases отражены. |
+| D. Проверяемость | 14-16 | PASS | Acceptance criteria, тесты и команды проверки указаны. |
+| E. Готовность к автономной реализации | 17-19 | PASS | План этапов есть, блокирующих вопросов нет. |
+| F. Соответствие профилю | 20 | PASS | Требования `dotnet-desktop-client` явно учтены. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Цель и Non-Goals определяют Windows-first Velopack MVP с ручным settings flow. |
+| 2. Понимание текущего состояния | 5 | Зафиксированы Desktop entrypoint, shared app, settings structure и release workflow. |
+| 3. Конкретность целевого дизайна | 5 | Есть lifecycle hook, update flow, settings UI state, workflow и точки интеграции. |
+| 4. Безопасность (миграция, откат) | 5 | MSI fallback, rollback и несовместимость MSI -> Velopack отражены. |
+| 5. Тестируемость | 5 | Указаны unit tests, build/test/publish/pack checks. |
+| 6. Готовность к автономной реализации | 5 | План выполним без дополнительных решений пользователя. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: после уточнения пользователя добавлены раздел настроек, manual check/apply flow, runtime update states и no-op/unsupported поведение для не-Velopack установок.
+- Что осталось на решение пользователя: требуется только подтверждение спеки фразой ниже.
+
+## Approval
+Ожидается фраза: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+Заполняется инкрементально после каждого значимого блока работ. Одна строка = один завершённый значимый блок.
+
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Сбор контекста | 0.9 | Нет | Создать SPEC | Нет | Нет | Найдены Avalonia Desktop entrypoint, centralized packages и текущий MSI/ZIP release workflow. | `src/Unlimotion.Desktop/Program.cs`, `.github/workflows/msi_packaging.yml`, `src/Directory.Packages.props` |
+| SPEC | Проектирование | 0.85 | Нужна фактическая проверка CLI на EXEC | Запросить подтверждение | Да | Да, ожидается фраза `Спеку подтверждаю` | Velopack требует ранний startup hook и публикацию update assets; MSI канал сохранен как fallback. | `specs/2026-04-23-velopack-github-updates.md` |
+| SPEC | Уточнение требований | 0.9 | Нет | Запросить подтверждение обновленной спеки | Да | Да, пользователь запросил раздел настроек для ручной проверки и применения | Расширил MVP: settings section, manual commands, update UI states и unsupported handling. | `specs/2026-04-23-velopack-github-updates.md`, `src/Unlimotion/Views/SettingsControl.axaml`, `src/Unlimotion.ViewModel/SettingsViewModel.cs` |
+| EXEC | Старт реализации | 0.9 | Нужна фактическая проверка Velopack API/CLI | Проверить API и внести изменения | Нет | Да, пользователь подтвердил спеку фразой `Спеку подтверждаю` | Переход в EXEC разрешен по QUEST gate. | `specs/2026-04-23-velopack-github-updates.md` |
+| EXEC | Реализация core/update UI | 0.85 | Нужны результаты build/test | Запустить проверки | Нет | Нет | Добавлены update contract, состояния `SettingsViewModel`, секция настроек, локализация, Velopack desktop wrapper, startup hook и workflow pack/upload. | `src/Unlimotion.ViewModel/*`, `src/Unlimotion/Views/SettingsControl.axaml`, `src/Unlimotion.Desktop/*`, `.github/workflows/msi_packaging.yml`, `src/Unlimotion.Test/SettingsViewModelTests.cs` |
+| EXEC | Верификация | 0.9 | Нет | Провести post-EXEC review | Нет | Нет | `dotnet build src\Unlimotion.sln --no-restore -m:1`, desktop build, targeted `SettingsViewModelTests`, Release publish и `vpk pack` прошли; полный `dotnet test --no-build` блокируется существующими `BackupViaGitServiceTests` из-за Windows path-too-long, два соседних сбоя проходят изолированно. | `src/Unlimotion.sln`, `src/Unlimotion.Test/SettingsViewModelTests.cs`, `artifacts/velopack-smoke/*` |
+| EXEC | Post-EXEC review/fix | 0.92 | Нет | Финализировать ответ | Нет | Нет | После ревью добавлен fallback версии приложения для не-Velopack запусков и исправлена PowerShell-валидация workflow: отсекается `0.0.0*`, используется корректный `-split`. | `src/Unlimotion.Desktop/Services/VelopackApplicationUpdateService.cs`, `.github/workflows/msi_packaging.yml` |
+| EXEC | Продолжение верификации | 0.95 | Нет | Финализировать ответ | Нет | Да, пользователь сказал `продолжай` | Устранены blockers полного тестового прогона: Git backup fixtures перенесены в короткую temp-папку, settings-тест изолирован от глобальной локализации. Полный `dotnet test` теперь проходит: 198/198; `dotnet build src\Unlimotion.sln --no-restore -m:1` проходит. | `src/Unlimotion.Test/BackupViaGitServiceTests.cs`, `src/Unlimotion.Test/SettingsViewModelTests.cs`, `specs/2026-04-23-velopack-github-updates.md` |
+| EXEC | Исправление review findings | 0.96 | Нет | Финализировать ответ | Нет | Да, пользователь сказал `испрравь` | Состояние pending restart теперь не теряется при ручной проверке обновлений, кнопка проверки блокируется до применения; workflow больше не принимает prerelease/build-теги, чтобы не передавать их в MSI `SetVersion`. Проверки: targeted settings tests 36/36, полный `dotnet test --no-build` 199/199, `dotnet build src\Unlimotion.sln --no-restore -m:1`, `git diff --check`. | `src/Unlimotion.ViewModel/SettingsViewModel.cs`, `src/Unlimotion.Desktop/Services/VelopackApplicationUpdateService.cs`, `src/Unlimotion.Test/SettingsViewModelTests.cs`, `.github/workflows/msi_packaging.yml` |
+| EXEC | Rebase на основную ветку | 0.96 | Нет | Сделать коммит | Нет | Да, пользователь попросил новую ветку, rebase на `master` и commit; фактическая основная ветка репозитория - `main` | Создана `feature/velopack-github-updates` от `origin/main`, stash изменений применен с разрешением конфликтов. Для `main` добавлены Velopack references в Debian/macOS desktop-проекты, которые компилируют общий desktop entrypoint. Проверки после переноса: `dotnet restore src\Unlimotion.sln`, `dotnet build src\Unlimotion.sln --no-restore -m:1`, `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --no-build` 201/201. | `src/Unlimotion.Desktop/Unlimotion.Desktop.ForDebianBuild.csproj`, `src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj`, `src/Unlimotion/App.axaml.cs`, `src/Unlimotion.Test/*`, `specs/2026-04-23-velopack-github-updates.md` |

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -33,6 +33,7 @@
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="Telegram.Bot" Version="16.0.2" />
+    <PackageVersion Include="Velopack" Version="0.0.1298" />
     <PackageVersion Include="ServiceStack.Interfaces" Version="6.4.0" />
     <PackageVersion Include="ServiceStack.Server" Version="6.4.0" />
     <PackageVersion Include="AutoMapper" Version="13.0.1" />

--- a/src/Unlimotion.Desktop/Program.cs
+++ b/src/Unlimotion.Desktop/Program.cs
@@ -5,7 +5,9 @@ using Avalonia;
 using Avalonia.Logging;
 using Avalonia.ReactiveUI;
 using ServiceStack;
+using Unlimotion.Desktop.Services;
 using Unlimotion.Services;
+using Velopack;
 
 namespace Unlimotion.Desktop
 {
@@ -21,6 +23,9 @@ namespace Unlimotion.Desktop
         [STAThread]
         public static void Main(string[] args)
         {
+            VelopackApp.Build().Run();
+            App.ConfigureUpdateService(new VelopackApplicationUpdateService());
+
             //Задание дефолтного пути для хранения задач
 #if DEBUG
             TaskStorageFactory.DefaultStoragePath = TasksFolderName;

--- a/src/Unlimotion.Desktop/Services/VelopackApplicationUpdateService.cs
+++ b/src/Unlimotion.Desktop/Services/VelopackApplicationUpdateService.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Unlimotion.ViewModel;
+using Velopack;
+using Velopack.Sources;
+
+namespace Unlimotion.Desktop.Services;
+
+public sealed class VelopackApplicationUpdateService : IApplicationUpdateService
+{
+    private const string ReleasesRepositoryUrl = "https://github.com/Kibnet/Unlimotion";
+
+    private readonly UpdateManager _updateManager;
+    private UpdateInfo? _lastUpdateInfo;
+
+    public VelopackApplicationUpdateService()
+        : this(ReleasesRepositoryUrl)
+    {
+    }
+
+    public VelopackApplicationUpdateService(string repositoryUrl)
+    {
+        var source = new GithubSource(repositoryUrl, accessToken: null, prerelease: false, downloader: null);
+        _updateManager = new UpdateManager(source);
+    }
+
+    public bool IsSupported => _updateManager.IsInstalled;
+
+    public string CurrentVersion
+    {
+        get
+        {
+            try
+            {
+                return _updateManager.CurrentVersion?.ToString() ?? GetEntryAssemblyVersion();
+            }
+            catch
+            {
+                return GetEntryAssemblyVersion();
+            }
+        }
+    }
+
+    public ApplicationUpdateInfo? PendingUpdate =>
+        _updateManager.UpdatePendingRestart != null
+            ? ToApplicationUpdateInfo(_updateManager.UpdatePendingRestart)
+            : null;
+
+    public async Task<ApplicationUpdateInfo?> CheckForUpdatesAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureSupported();
+
+        if (_updateManager.UpdatePendingRestart != null)
+        {
+            return ToApplicationUpdateInfo(_updateManager.UpdatePendingRestart);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        _lastUpdateInfo = await _updateManager.CheckForUpdatesAsync();
+
+        return _lastUpdateInfo == null
+            ? null
+            : ToApplicationUpdateInfo(_lastUpdateInfo.TargetFullRelease);
+    }
+
+    public async Task DownloadUpdateAsync(CancellationToken cancellationToken = default)
+    {
+        EnsureSupported();
+
+        if (_lastUpdateInfo == null)
+        {
+            if (_updateManager.UpdatePendingRestart != null)
+            {
+                return;
+            }
+
+            throw new InvalidOperationException("No update was selected for download.");
+        }
+
+        await _updateManager.DownloadUpdatesAsync(_lastUpdateInfo, progress: null, cancelToken: cancellationToken);
+    }
+
+    public void ApplyUpdateAndRestart()
+    {
+        EnsureSupported();
+
+        var release = _lastUpdateInfo?.TargetFullRelease ?? _updateManager.UpdatePendingRestart;
+        if (release == null)
+        {
+            throw new InvalidOperationException("No downloaded update is ready to apply.");
+        }
+
+        _updateManager.ApplyUpdatesAndRestart(release);
+    }
+
+    private void EnsureSupported()
+    {
+        if (!IsSupported)
+        {
+            throw new InvalidOperationException("The current application instance is not managed by Velopack.");
+        }
+    }
+
+    private static ApplicationUpdateInfo ToApplicationUpdateInfo(VelopackAsset asset)
+    {
+        return new ApplicationUpdateInfo(
+            asset.Version?.ToString() ?? string.Empty,
+            asset.NotesMarkdown);
+    }
+
+    private static string GetEntryAssemblyVersion()
+    {
+        return Assembly.GetEntryAssembly()?.GetName().Version?.ToString()
+               ?? typeof(VelopackApplicationUpdateService).Assembly.GetName().Version?.ToString()
+               ?? string.Empty;
+    }
+}

--- a/src/Unlimotion.Desktop/Unlimotion.Desktop.ForDebianBuild.csproj
+++ b/src/Unlimotion.Desktop/Unlimotion.Desktop.ForDebianBuild.csproj
@@ -22,6 +22,7 @@
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
 		<PackageReference Include="Packaging.Targets" PrivateAssets="all" />
+		<PackageReference Include="Velopack" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Unlimotion\Unlimotion.csproj" />

--- a/src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj
+++ b/src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj
@@ -34,6 +34,7 @@
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
 		<PackageReference Include="Dotnet.Bundle" />
+		<PackageReference Include="Velopack" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Unlimotion\Unlimotion.csproj" />

--- a/src/Unlimotion.Desktop/Unlimotion.Desktop.csproj
+++ b/src/Unlimotion.Desktop/Unlimotion.Desktop.csproj
@@ -21,6 +21,7 @@
 			<IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
 			<PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Velopack" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh
+++ b/src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh
@@ -2,6 +2,5 @@
 
 CSPROJ_PATH="./src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj"
 
-dotnet restore $CSPROJ_PATH --ignore-failed-sources
+dotnet restore $CSPROJ_PATH --runtime osx-x64 --ignore-failed-sources
 dotnet publish $CSPROJ_PATH -c Release -f net10.0 -r osx-x64 -p:Version=$1 -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false --ignore-failed-sources
-

--- a/src/Unlimotion.Test/BackupViaGitServiceTests.cs
+++ b/src/Unlimotion.Test/BackupViaGitServiceTests.cs
@@ -16,7 +16,7 @@ public sealed class BackupViaGitServiceTests : IDisposable
 
     public BackupViaGitServiceTests()
     {
-        _rootPath = Path.Combine(Path.GetTempPath(), "UnlimotionGit", Guid.NewGuid().ToString("N"));
+        _rootPath = Path.Combine(Path.GetTempPath(), $"ug-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_rootPath);
         _configPath = Path.Combine(_rootPath, "settings.json");
         File.WriteAllText(_configPath, "{}");

--- a/src/Unlimotion.Test/SettingsViewModelTests.cs
+++ b/src/Unlimotion.Test/SettingsViewModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Unlimotion.Services;
 using Unlimotion.ViewModel;
@@ -55,6 +56,121 @@ public class SettingsViewModelTests : IDisposable
                 .GetSection(AppearanceSettings.ThemeKey)
                 .Get<string>())
             .IsEqualTo(AppearanceSettings.SystemTheme);
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task Updates_AreDisabled_WhenUpdateServiceIsUnsupported()
+    {
+        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        var updateService = new FakeApplicationUpdateService { IsSupported = false };
+        var settings = CreateSettingsViewModel(configuration);
+
+        settings.ConfigureUpdateService(updateService);
+
+        await Assert.That(settings.UpdateState).IsEqualTo(ApplicationUpdateState.Unsupported);
+        await Assert.That(settings.CurrentApplicationVersion).IsEqualTo("1.0.0");
+        await Assert.That(settings.CanCheckForUpdates).IsFalse();
+        await Assert.That(settings.CanDownloadUpdate).IsFalse();
+        await Assert.That(settings.CanApplyUpdate).IsFalse();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task CheckForUpdatesAsync_SetsNoUpdatesState_WhenNoUpdateExists()
+    {
+        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        var updateService = new FakeApplicationUpdateService();
+        var settings = CreateSettingsViewModel(configuration);
+        settings.ConfigureUpdateService(updateService);
+
+        await settings.CheckForUpdatesAsync();
+
+        await Assert.That(updateService.CheckCalls).IsEqualTo(1);
+        await Assert.That(settings.UpdateState).IsEqualTo(ApplicationUpdateState.NoUpdates);
+        await Assert.That(settings.CanCheckForUpdates).IsTrue();
+        await Assert.That(settings.CanDownloadUpdate).IsFalse();
+        await Assert.That(settings.CanApplyUpdate).IsFalse();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task CheckForUpdatesAsync_UsesPendingUpdateBeforeNetworkCheck()
+    {
+        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        var updateService = new FakeApplicationUpdateService();
+        var settings = CreateSettingsViewModel(configuration);
+        settings.ConfigureUpdateService(updateService);
+
+        updateService.PendingUpdate = new ApplicationUpdateInfo("2.0.0");
+
+        await settings.CheckForUpdatesAsync();
+
+        await Assert.That(updateService.CheckCalls).IsEqualTo(0);
+        await Assert.That(settings.UpdateState).IsEqualTo(ApplicationUpdateState.ReadyToApply);
+        await Assert.That(settings.AvailableUpdateVersion).IsEqualTo("2.0.0");
+        await Assert.That(settings.CanCheckForUpdates).IsFalse();
+        await Assert.That(settings.CanApplyUpdate).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task DownloadUpdateAsync_SetsReadyToApply_WhenUpdateWasFound()
+    {
+        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        var updateService = new FakeApplicationUpdateService
+        {
+            NextUpdate = new ApplicationUpdateInfo("2.0.0")
+        };
+        var settings = CreateSettingsViewModel(configuration);
+        settings.ConfigureUpdateService(updateService);
+
+        await settings.CheckForUpdatesAsync();
+        await settings.DownloadUpdateAsync();
+
+        await Assert.That(settings.UpdateState).IsEqualTo(ApplicationUpdateState.ReadyToApply);
+        await Assert.That(settings.AvailableUpdateVersion).IsEqualTo("2.0.0");
+        await Assert.That(updateService.DownloadCalls).IsEqualTo(1);
+        await Assert.That(settings.CanApplyUpdate).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task ApplyUpdateAsync_CallsUpdateServiceRestart_WhenUpdateIsReady()
+    {
+        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        var updateService = new FakeApplicationUpdateService
+        {
+            NextUpdate = new ApplicationUpdateInfo("2.0.0")
+        };
+        var settings = CreateSettingsViewModel(configuration);
+        settings.ConfigureUpdateService(updateService);
+
+        await settings.CheckForUpdatesAsync();
+        await settings.DownloadUpdateAsync();
+        await settings.ApplyUpdateAsync();
+
+        await Assert.That(updateService.ApplyCalls).IsEqualTo(1);
+        await Assert.That(settings.UpdateState).IsEqualTo(ApplicationUpdateState.Applying);
+        await Assert.That(settings.CanApplyUpdate).IsFalse();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task CheckForUpdatesAsync_IgnoresRepeatedCalls_WhileBusy()
+    {
+        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        var updateService = new FakeApplicationUpdateService
+        {
+            CheckCompletion = new System.Threading.Tasks.TaskCompletionSource<ApplicationUpdateInfo?>()
+        };
+        var settings = CreateSettingsViewModel(configuration);
+        settings.ConfigureUpdateService(updateService);
+
+        var firstCheck = settings.CheckForUpdatesAsync();
+        var secondCheck = settings.CheckForUpdatesAsync();
+
+        await Assert.That(updateService.CheckCalls).IsEqualTo(1);
+
+        updateService.CheckCompletion.SetResult(null);
+        await firstCheck;
+        await secondCheck;
+
+        await Assert.That(settings.UpdateState).IsEqualTo(ApplicationUpdateState.NoUpdates);
     }
 
     [Test]
@@ -593,6 +709,74 @@ public class SettingsViewModelTests : IDisposable
         public BackupRepositoryConnectPreview PreviewConnectRepository() => throw new NotSupportedException();
         public void ConnectRepository(bool allowMergeWithNonEmptyRemote) => throw new NotSupportedException();
         public void CloneOrUpdateRepo() => throw new NotSupportedException();
+    }
+
+    private static SettingsViewModel CreateSettingsViewModel(IConfiguration configuration)
+    {
+        return new SettingsViewModel(configuration, localizationService: new FakeLocalizationService());
+    }
+
+    private sealed class FakeLocalizationService : ILocalizationService
+    {
+        public event EventHandler? CultureChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public System.Globalization.CultureInfo CurrentCulture { get; } =
+            System.Globalization.CultureInfo.GetCultureInfo("en");
+
+        public string LanguageMode { get; private set; } = LocalizationService.EnglishLanguage;
+
+        public IReadOnlyList<LanguageOption> SupportedLanguages { get; } =
+        [
+            new LanguageOption(LocalizationService.EnglishLanguage, "English")
+        ];
+
+        public void SetLanguage(string? languageMode)
+        {
+            LanguageMode = string.IsNullOrWhiteSpace(languageMode)
+                ? LocalizationService.EnglishLanguage
+                : languageMode;
+        }
+
+        public string Get(string key) => key;
+
+        public string Format(string key, params object?[] args) => $"{key}: {string.Join(", ", args)}";
+
+        public IReadOnlyCollection<string> GetResourceKeys(System.Globalization.CultureInfo culture) =>
+            Array.Empty<string>();
+    }
+
+    private sealed class FakeApplicationUpdateService : IApplicationUpdateService
+    {
+        public bool IsSupported { get; set; } = true;
+        public string CurrentVersion { get; set; } = "1.0.0";
+        public ApplicationUpdateInfo? PendingUpdate { get; set; }
+        public ApplicationUpdateInfo? NextUpdate { get; set; }
+        public System.Threading.Tasks.TaskCompletionSource<ApplicationUpdateInfo?>? CheckCompletion { get; set; }
+        public int CheckCalls { get; private set; }
+        public int DownloadCalls { get; private set; }
+        public int ApplyCalls { get; private set; }
+
+        public System.Threading.Tasks.Task<ApplicationUpdateInfo?> CheckForUpdatesAsync(
+            CancellationToken cancellationToken = default)
+        {
+            CheckCalls++;
+            return CheckCompletion?.Task ?? System.Threading.Tasks.Task.FromResult(NextUpdate);
+        }
+
+        public System.Threading.Tasks.Task DownloadUpdateAsync(CancellationToken cancellationToken = default)
+        {
+            DownloadCalls++;
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        public void ApplyUpdateAndRestart()
+        {
+            ApplyCalls++;
+        }
     }
 
     private sealed class FakeSystemCultureProvider : ILocalizationSystemCultureProvider

--- a/src/Unlimotion.ViewModel/ApplicationUpdateInfo.cs
+++ b/src/Unlimotion.ViewModel/ApplicationUpdateInfo.cs
@@ -1,0 +1,3 @@
+namespace Unlimotion.ViewModel;
+
+public sealed record ApplicationUpdateInfo(string Version, string? ReleaseNotes = null);

--- a/src/Unlimotion.ViewModel/ApplicationUpdateState.cs
+++ b/src/Unlimotion.ViewModel/ApplicationUpdateState.cs
@@ -1,0 +1,14 @@
+namespace Unlimotion.ViewModel;
+
+public enum ApplicationUpdateState
+{
+    Unsupported,
+    Idle,
+    Checking,
+    NoUpdates,
+    UpdateAvailable,
+    Downloading,
+    ReadyToApply,
+    Applying,
+    Error
+}

--- a/src/Unlimotion.ViewModel/IApplicationUpdateService.cs
+++ b/src/Unlimotion.ViewModel/IApplicationUpdateService.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Unlimotion.ViewModel;
+
+public interface IApplicationUpdateService
+{
+    bool IsSupported { get; }
+
+    string CurrentVersion { get; }
+
+    ApplicationUpdateInfo? PendingUpdate { get; }
+
+    Task<ApplicationUpdateInfo?> CheckForUpdatesAsync(CancellationToken cancellationToken = default);
+
+    Task DownloadUpdateAsync(CancellationToken cancellationToken = default);
+
+    void ApplyUpdateAndRestart();
+}

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -274,6 +274,28 @@
   <data name="TwoDays" xml:space="preserve"><value>2 days</value></data>
   <data name="TwoHours" xml:space="preserve"><value>2 hours</value></data>
   <data name="Unknown" xml:space="preserve"><value>Unknown</value></data>
+  <data name="UpdateApply" xml:space="preserve"><value>Apply and restart</value></data>
+  <data name="UpdateApplyFailedWithError" xml:space="preserve"><value>Could not apply the update: {0}</value></data>
+  <data name="UpdateAvailableVersion" xml:space="preserve"><value>Available version</value></data>
+  <data name="UpdateCheckFailed" xml:space="preserve"><value>Could not check for updates.</value></data>
+  <data name="UpdateCheckFailedWithError" xml:space="preserve"><value>Could not check for updates: {0}</value></data>
+  <data name="UpdateCurrentVersion" xml:space="preserve"><value>Current version</value></data>
+  <data name="UpdateDownload" xml:space="preserve"><value>Download update</value></data>
+  <data name="UpdateDownloadFailedWithError" xml:space="preserve"><value>Could not download the update: {0}</value></data>
+  <data name="UpdateReadyHeader" xml:space="preserve"><value>Update ready</value></data>
+  <data name="UpdateReadyMessage" xml:space="preserve"><value>Version {0} is ready to install. Restart the app now?</value></data>
+  <data name="UpdatesCheckNow" xml:space="preserve"><value>Check for updates</value></data>
+  <data name="UpdatesHint" xml:space="preserve"><value>Check GitHub Releases for a new desktop version and apply a downloaded update when you are ready to restart.</value></data>
+  <data name="UpdatesTitle" xml:space="preserve"><value>Updates</value></data>
+  <data name="UpdateStatusApplying" xml:space="preserve"><value>Applying update and restarting...</value></data>
+  <data name="UpdateStatusAvailable" xml:space="preserve"><value>Version {0} is available.</value></data>
+  <data name="UpdateStatusChecking" xml:space="preserve"><value>Checking for updates...</value></data>
+  <data name="UpdateStatusDownloading" xml:space="preserve"><value>Downloading version {0}...</value></data>
+  <data name="UpdateStatusError" xml:space="preserve"><value>Update operation failed.</value></data>
+  <data name="UpdateStatusIdle" xml:space="preserve"><value>Ready to check for updates.</value></data>
+  <data name="UpdateStatusNoUpdates" xml:space="preserve"><value>You are using the latest version.</value></data>
+  <data name="UpdateStatusReadyToApply" xml:space="preserve"><value>Version {0} is downloaded and ready to apply.</value></data>
+  <data name="UpdateStatusUnsupported" xml:space="preserve"><value>Updates are unavailable for this installation.</value></data>
   <data name="UnarchiveContainedTasksHeader" xml:space="preserve"><value>Unarchive contained tasks</value></data>
   <data name="UnarchiveContainedTasksMessage" xml:space="preserve"><value>Are you sure you want to unarchive the {0} contained tasks from "{1}"?</value></data>
   <data name="Unlocked" xml:space="preserve"><value>Unlocked</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -274,6 +274,28 @@
   <data name="TwoDays" xml:space="preserve"><value>2 дня</value></data>
   <data name="TwoHours" xml:space="preserve"><value>2 часа</value></data>
   <data name="Unknown" xml:space="preserve"><value>Неизвестно</value></data>
+  <data name="UpdateApply" xml:space="preserve"><value>Применить и перезапустить</value></data>
+  <data name="UpdateApplyFailedWithError" xml:space="preserve"><value>Не удалось применить обновление: {0}</value></data>
+  <data name="UpdateAvailableVersion" xml:space="preserve"><value>Доступная версия</value></data>
+  <data name="UpdateCheckFailed" xml:space="preserve"><value>Не удалось проверить обновления.</value></data>
+  <data name="UpdateCheckFailedWithError" xml:space="preserve"><value>Не удалось проверить обновления: {0}</value></data>
+  <data name="UpdateCurrentVersion" xml:space="preserve"><value>Текущая версия</value></data>
+  <data name="UpdateDownload" xml:space="preserve"><value>Скачать обновление</value></data>
+  <data name="UpdateDownloadFailedWithError" xml:space="preserve"><value>Не удалось скачать обновление: {0}</value></data>
+  <data name="UpdateReadyHeader" xml:space="preserve"><value>Обновление готово</value></data>
+  <data name="UpdateReadyMessage" xml:space="preserve"><value>Версия {0} готова к установке. Перезапустить приложение сейчас?</value></data>
+  <data name="UpdatesCheckNow" xml:space="preserve"><value>Проверить обновления</value></data>
+  <data name="UpdatesHint" xml:space="preserve"><value>Проверьте GitHub Releases на новую desktop-версию и примените скачанное обновление, когда будете готовы перезапустить приложение.</value></data>
+  <data name="UpdatesTitle" xml:space="preserve"><value>Обновления</value></data>
+  <data name="UpdateStatusApplying" xml:space="preserve"><value>Применение обновления и перезапуск...</value></data>
+  <data name="UpdateStatusAvailable" xml:space="preserve"><value>Доступна версия {0}.</value></data>
+  <data name="UpdateStatusChecking" xml:space="preserve"><value>Проверка обновлений...</value></data>
+  <data name="UpdateStatusDownloading" xml:space="preserve"><value>Скачивание версии {0}...</value></data>
+  <data name="UpdateStatusError" xml:space="preserve"><value>Операция обновления завершилась ошибкой.</value></data>
+  <data name="UpdateStatusIdle" xml:space="preserve"><value>Готово к проверке обновлений.</value></data>
+  <data name="UpdateStatusNoUpdates" xml:space="preserve"><value>Установлена последняя версия.</value></data>
+  <data name="UpdateStatusReadyToApply" xml:space="preserve"><value>Версия {0} скачана и готова к применению.</value></data>
+  <data name="UpdateStatusUnsupported" xml:space="preserve"><value>Обновления недоступны для этой установки.</value></data>
   <data name="UnarchiveContainedTasksHeader" xml:space="preserve"><value>Разархивировать вложенные задачи</value></data>
   <data name="UnarchiveContainedTasksMessage" xml:space="preserve"><value>Разархивировать {0} вложенных задач из "{1}"?</value></data>
   <data name="Unlocked" xml:space="preserve"><value>Разблокированные</value></data>

--- a/src/Unlimotion.ViewModel/SettingsViewModel.cs
+++ b/src/Unlimotion.ViewModel/SettingsViewModel.cs
@@ -4,6 +4,8 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Microsoft.Extensions.Configuration;
 using PropertyChanged;
@@ -27,6 +29,9 @@ public class SettingsViewModel
     private readonly ILocalizationService _localization;
     private readonly bool _defaultIsDarkTheme;
     private readonly Func<string?>? _defaultTaskStoragePathProvider;
+    private IApplicationUpdateService? _applicationUpdateService;
+    private ApplicationUpdateInfo? _availableUpdate;
+    private string? _updateStatusOverride;
 
     private ThemeMode _themeMode;
     private string? _taskStoragePath;
@@ -117,6 +122,9 @@ public class SettingsViewModel
     public ICommand? RefreshSshKeysCommand { get; set; }
     public ICommand? RefreshGitMetadataCommand { get; set; }
     public ICommand? CopySelectedSshKeyCommand { get; set; }
+    public ICommand? CheckForUpdatesCommand { get; set; }
+    public ICommand? DownloadUpdateCommand { get; set; }
+    public ICommand? ApplyUpdateCommand { get; set; }
 
     public ThemeMode ThemeMode
     {
@@ -527,6 +535,24 @@ public class SettingsViewModel
 
     public bool ShowServiceActions { get; set; }
 
+    public ApplicationUpdateState UpdateState { get; private set; } = ApplicationUpdateState.Unsupported;
+
+    public string CurrentApplicationVersion { get; private set; } = string.Empty;
+
+    public string? AvailableUpdateVersion { get; private set; }
+
+    public string UpdateStatusText { get; private set; } = string.Empty;
+
+    public bool IsUpdateBusy { get; private set; }
+
+    public bool HasAvailableUpdate { get; private set; }
+
+    public bool CanCheckForUpdates { get; private set; }
+
+    public bool CanDownloadUpdate { get; private set; }
+
+    public bool CanApplyUpdate { get; private set; }
+
     public string GitBackupOnboardingHint =>
         _localization.Get("BackupOnboardingHint");
 
@@ -603,6 +629,139 @@ public class SettingsViewModel
         RefreshBackupActionAvailability();
     }
 
+    public void ConfigureUpdateService(IApplicationUpdateService? updateService)
+    {
+        _applicationUpdateService = updateService;
+        CurrentApplicationVersion = updateService?.CurrentVersion ?? _localization.Get("Unknown");
+
+        if (updateService?.IsSupported != true)
+        {
+            _availableUpdate = null;
+            AvailableUpdateVersion = null;
+            SetUpdateState(ApplicationUpdateState.Unsupported);
+            return;
+        }
+
+        _availableUpdate = updateService.PendingUpdate;
+        AvailableUpdateVersion = _availableUpdate?.Version;
+        SetUpdateState(_availableUpdate == null
+            ? ApplicationUpdateState.Idle
+            : ApplicationUpdateState.ReadyToApply);
+    }
+
+    public async Task CheckForUpdatesAsync(
+        bool silent = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!CanCheckForUpdates && UpdateState != ApplicationUpdateState.Error)
+        {
+            return;
+        }
+
+        var updateService = _applicationUpdateService;
+        if (updateService?.IsSupported != true)
+        {
+            SetUpdateState(ApplicationUpdateState.Unsupported);
+            return;
+        }
+
+        var pendingUpdate = updateService.PendingUpdate;
+        if (pendingUpdate != null)
+        {
+            _availableUpdate = pendingUpdate;
+            AvailableUpdateVersion = pendingUpdate.Version;
+            SetUpdateState(ApplicationUpdateState.ReadyToApply);
+            return;
+        }
+
+        SetUpdateState(ApplicationUpdateState.Checking);
+
+        try
+        {
+            _availableUpdate = await updateService.CheckForUpdatesAsync(cancellationToken);
+            AvailableUpdateVersion = _availableUpdate?.Version;
+            SetUpdateState(_availableUpdate == null
+                ? ApplicationUpdateState.NoUpdates
+                : ApplicationUpdateState.UpdateAvailable);
+        }
+        catch (OperationCanceledException)
+        {
+            SetUpdateState(ApplicationUpdateState.Idle);
+        }
+        catch (Exception ex)
+        {
+            var status = silent
+                ? _localization.Get("UpdateCheckFailed")
+                : _localization.Format("UpdateCheckFailedWithError", ex.Message);
+            SetUpdateState(ApplicationUpdateState.Error, status);
+        }
+    }
+
+    public async Task DownloadUpdateAsync(CancellationToken cancellationToken = default)
+    {
+        if (!CanDownloadUpdate)
+        {
+            return;
+        }
+
+        var updateService = _applicationUpdateService;
+        if (updateService?.IsSupported != true)
+        {
+            SetUpdateState(ApplicationUpdateState.Unsupported);
+            return;
+        }
+
+        SetUpdateState(ApplicationUpdateState.Downloading);
+
+        try
+        {
+            await updateService.DownloadUpdateAsync(cancellationToken);
+            SetUpdateState(ApplicationUpdateState.ReadyToApply);
+        }
+        catch (OperationCanceledException)
+        {
+            SetUpdateState(_availableUpdate == null
+                ? ApplicationUpdateState.Idle
+                : ApplicationUpdateState.UpdateAvailable);
+        }
+        catch (Exception ex)
+        {
+            SetUpdateState(
+                ApplicationUpdateState.Error,
+                _localization.Format("UpdateDownloadFailedWithError", ex.Message));
+        }
+    }
+
+    public Task ApplyUpdateAsync()
+    {
+        if (!CanApplyUpdate)
+        {
+            return Task.CompletedTask;
+        }
+
+        var updateService = _applicationUpdateService;
+        if (updateService?.IsSupported != true)
+        {
+            SetUpdateState(ApplicationUpdateState.Unsupported);
+            return Task.CompletedTask;
+        }
+
+        SetUpdateState(ApplicationUpdateState.Applying);
+
+        try
+        {
+            updateService.ApplyUpdateAndRestart();
+        }
+        catch (Exception ex)
+        {
+            SetUpdateState(
+                ApplicationUpdateState.Error,
+                _localization.Format("UpdateApplyFailedWithError", ex.Message));
+        }
+
+        return Task.CompletedTask;
+    }
+
     public void MarkSignedOut()
     {
         ConnectedServerLogin = null;
@@ -615,6 +774,7 @@ public class SettingsViewModel
         RefreshBackupAuthMode();
         RefreshStorageStatusText();
         RefreshBackupState();
+        RefreshUpdateStatusText();
     }
 
     private void RefreshLanguageOptions()
@@ -932,6 +1092,62 @@ public class SettingsViewModel
 
         CanConnectRepository = !IsBackupBusy && hasRemoteUrl && (hasReadyTokenAuth || hasReadySshAuth);
         CanSyncRepository = !IsBackupBusy && hasReadySyncTarget;
+    }
+
+    private void SetUpdateState(ApplicationUpdateState state, string? statusText = null)
+    {
+        UpdateState = state;
+        _updateStatusOverride = statusText;
+        IsUpdateBusy = state is ApplicationUpdateState.Checking
+            or ApplicationUpdateState.Downloading
+            or ApplicationUpdateState.Applying;
+        HasAvailableUpdate = _availableUpdate != null;
+        RefreshUpdateStatusText();
+        RefreshUpdateActionAvailability();
+    }
+
+    private void RefreshUpdateStatusText()
+    {
+        if (!string.IsNullOrWhiteSpace(_updateStatusOverride))
+        {
+            UpdateStatusText = _updateStatusOverride;
+            return;
+        }
+
+        UpdateStatusText = UpdateState switch
+        {
+            ApplicationUpdateState.Idle => _localization.Get("UpdateStatusIdle"),
+            ApplicationUpdateState.Checking => _localization.Get("UpdateStatusChecking"),
+            ApplicationUpdateState.NoUpdates => _localization.Get("UpdateStatusNoUpdates"),
+            ApplicationUpdateState.UpdateAvailable => _localization.Format(
+                "UpdateStatusAvailable",
+                AvailableUpdateVersion ?? _localization.Get("Unknown")),
+            ApplicationUpdateState.Downloading => _localization.Format(
+                "UpdateStatusDownloading",
+                AvailableUpdateVersion ?? _localization.Get("Unknown")),
+            ApplicationUpdateState.ReadyToApply => _localization.Format(
+                "UpdateStatusReadyToApply",
+                AvailableUpdateVersion ?? _localization.Get("Unknown")),
+            ApplicationUpdateState.Applying => _localization.Get("UpdateStatusApplying"),
+            ApplicationUpdateState.Error => _localization.Get("UpdateStatusError"),
+            _ => _localization.Get("UpdateStatusUnsupported")
+        };
+    }
+
+    private void RefreshUpdateActionAvailability()
+    {
+        var isSupported = _applicationUpdateService?.IsSupported == true;
+        CanCheckForUpdates = isSupported &&
+                             !IsUpdateBusy &&
+                             UpdateState != ApplicationUpdateState.ReadyToApply;
+        CanDownloadUpdate = isSupported &&
+                            !IsUpdateBusy &&
+                            UpdateState == ApplicationUpdateState.UpdateAvailable &&
+                            _availableUpdate != null;
+        CanApplyUpdate = isSupported &&
+                         !IsUpdateBusy &&
+                         UpdateState == ApplicationUpdateState.ReadyToApply &&
+                         _availableUpdate != null;
     }
 
     private BackupAuthMode ResolveBackupAuthMode()

--- a/src/Unlimotion/App.axaml.cs
+++ b/src/Unlimotion/App.axaml.cs
@@ -53,6 +53,7 @@ public class App : Application
     private static INotificationMessageManager? _notificationMessageManager;
     private static INotificationManagerWrapper? _notificationManager;
     private static IRemoteBackupService? _backupService;
+    private static IApplicationUpdateService? _applicationUpdateService;
     private static IAppNameDefinitionService? _appNameService;
     private static ITaskStorageFactory? _storageFactory;
     private static IScheduler? _scheduler;
@@ -107,6 +108,7 @@ public class App : Application
             _backupService,
             GetCurrentThemeIsDark(),
             () => TaskStorageFactory.DefaultStoragePath);
+        settingsViewModel.ConfigureUpdateService(_applicationUpdateService);
 
         // Create GraphViewModel
         var graphViewModel = new GraphViewModel();
@@ -473,6 +475,10 @@ public class App : Application
             await topLevel.Clipboard.SetTextAsync(keyContent);
             _notificationManager?.SuccessToast(L10n.Get("SshKeyCopied"));
         });
+
+        settings.CheckForUpdatesCommand = ReactiveCommand.CreateFromTask(() => settings.CheckForUpdatesAsync());
+        settings.DownloadUpdateCommand = ReactiveCommand.CreateFromTask(() => settings.DownloadUpdateAsync());
+        settings.ApplyUpdateCommand = ReactiveCommand.CreateFromTask(() => settings.ApplyUpdateAsync());
     }
 
     private async Task ConnectBackupRepositoryAsync(
@@ -654,6 +660,8 @@ public class App : Application
                     {
                         // Existing startup behavior ignored connect failures here.
                     }
+
+                    _ = CheckForUpdatesOnStartupAsync(vm.Settings);
                 };
             }
         }
@@ -706,6 +714,34 @@ public class App : Application
     public App()
     {
         DataContext = new ApplicationViewModel();
+    }
+
+    public static void ConfigureUpdateService(IApplicationUpdateService? updateService)
+    {
+        _applicationUpdateService = updateService;
+        _mainWindowViewModel?.Settings.ConfigureUpdateService(updateService);
+    }
+
+    private async Task CheckForUpdatesOnStartupAsync(SettingsViewModel settings)
+    {
+        await settings.CheckForUpdatesAsync(silent: true);
+
+        if (settings.UpdateState != ApplicationUpdateState.UpdateAvailable)
+        {
+            return;
+        }
+
+        await settings.DownloadUpdateAsync();
+
+        if (settings.UpdateState != ApplicationUpdateState.ReadyToApply)
+        {
+            return;
+        }
+
+        _notificationManager?.Ask(
+            L10n.Get("UpdateReadyHeader"),
+            L10n.Format("UpdateReadyMessage", settings.AvailableUpdateVersion ?? L10n.Get("Unknown")),
+            () => _ = settings.ApplyUpdateAsync());
     }
 
     private const bool ShouldLogStartup = false;

--- a/src/Unlimotion/Views/SettingsControl.axaml
+++ b/src/Unlimotion/Views/SettingsControl.axaml
@@ -88,6 +88,44 @@
 
             <Border Classes="SettingsSection">
                 <StackPanel>
+                    <TextBlock Classes="SectionTitle" Text="{DynamicResource UpdatesTitle}" />
+                    <TextBlock Classes="SectionHint" Text="{DynamicResource UpdatesHint}" />
+
+                    <Grid Classes="FieldRow" ColumnDefinitions="220,*" RowDefinitions="Auto,Auto">
+                        <TextBlock VerticalAlignment="Center" Text="{DynamicResource UpdateCurrentVersion}" />
+                        <TextBlock Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   Text="{Binding CurrentApplicationVersion}" />
+
+                        <TextBlock Grid.Row="1"
+                                   VerticalAlignment="Center"
+                                   Text="{DynamicResource UpdateAvailableVersion}"
+                                   IsVisible="{Binding HasAvailableUpdate}" />
+                        <TextBlock Grid.Row="1"
+                                   Grid.Column="1"
+                                   VerticalAlignment="Center"
+                                   Text="{Binding AvailableUpdateVersion}"
+                                   IsVisible="{Binding HasAvailableUpdate}" />
+                    </Grid>
+
+                    <TextBlock Classes="StatusText" Text="{Binding UpdateStatusText}" />
+
+                    <WrapPanel Margin="0,12,0,0">
+                        <Button Content="{DynamicResource UpdatesCheckNow}"
+                                Command="{Binding CheckForUpdatesCommand}"
+                                IsEnabled="{Binding CanCheckForUpdates}" />
+                        <Button Content="{DynamicResource UpdateDownload}"
+                                Command="{Binding DownloadUpdateCommand}"
+                                IsEnabled="{Binding CanDownloadUpdate}" />
+                        <Button Content="{DynamicResource UpdateApply}"
+                                Command="{Binding ApplyUpdateCommand}"
+                                IsEnabled="{Binding CanApplyUpdate}" />
+                    </WrapPanel>
+                </StackPanel>
+            </Border>
+
+            <Border Classes="SettingsSection">
+                <StackPanel>
                     <TextBlock Classes="SectionTitle" Text="{DynamicResource StorageTitle}" />
                     <TextBlock Classes="SectionHint" Text="{DynamicResource StorageHint}" />
 


### PR DESCRIPTION
## Summary
- add Velopack-based GitHub Releases update integration for the desktop app
- add an Updates section in settings for manual check, download, and apply flows
- publish Velopack artifacts in the GitHub release workflow while keeping the existing packaging flow
- publish separate Velopack channels/feeds for `win`, `linux`, and `osx` in the same GitHub release
- keep the existing MSI, portable ZIP, `.deb`, and `.pkg` artifacts alongside the Velopack-managed assets
- cover the new update states with tests and keep the Git backup fixture path short enough for Windows test runs
- fix the macOS publish script to restore with `--runtime osx-x64`, which is required for the cross-platform release flow

## Why
The app did not have a GitHub Releases update channel. The requested change was to ship updates through Velopack, expose a manual update flow in settings, and make release publication produce Velopack-managed feeds for every supported desktop platform instead of only Windows.

## Impact
Desktop builds now initialize Velopack early, can detect/download/apply updates from GitHub Releases, and surface update state in settings. Release publication now produces separate `releases.win.json`, `releases.linux.json`, and `releases.osx.json` asset sets in the same GitHub release while preserving the existing installer artifacts.

## Validation
- `dotnet restore src\Unlimotion.sln`
- `dotnet build src\Unlimotion.sln --no-restore -m:1`
- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --no-build`
- `dotnet publish src\Unlimotion.Desktop\Unlimotion.Desktop.ForDebianBuild.csproj -c Release -f net10.0 -r linux-x64 ...`
- `dotnet restore src\Unlimotion.Desktop\Unlimotion.Desktop.ForMacBuild.csproj --runtime osx-x64 --ignore-failed-sources`
- `dotnet publish src\Unlimotion.Desktop\Unlimotion.Desktop.ForMacBuild.csproj -c Release -f net10.0 -r osx-x64 ...`
- `vpk pack --help`
- `vpk upload github --help`
