### PR TITLE
Fix date quick selection localization

### DIFF
--- a/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
+++ b/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Unlimotion.ViewModel.Localization;
+using Unlimotion.Views;
+
+namespace Unlimotion.Test;
+
+[NotInParallel]
+public class MainControlDateQuickSelectionUiTests
+{
+    [Test]
+    public async Task DateQuickSelectionUi_UsesLocalizedTodayAndTomorrowLabels()
+    {
+        var previousLocalization = LocalizationService.Current;
+        try
+        {
+            var localization = new LocalizationService(new FakeSystemCultureProvider("ru-RU"));
+            LocalizationService.Current = localization;
+            localization.SetLanguage(LocalizationService.RussianLanguage);
+
+            using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await session.Dispatch(async () =>
+            {
+                MainWindowViewModelFixture? fixture = null;
+                Window? window = null;
+
+                try
+                {
+                    fixture = new MainWindowViewModelFixture();
+                    var vm = fixture.MainWindowViewModelTest;
+                    await vm.Connect();
+                    vm.AllTasksMode = true;
+                    vm.DetailsAreOpen = true;
+                    TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask2Id);
+
+                    var view = new MainControl { DataContext = vm };
+                    window = CreateWindow(view);
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+
+                    var beginButton = GetDropDownButton(view, localization.Get("SetBegin"));
+                    var endButton = GetDropDownButton(view, localization.Get("SetEnd"));
+
+                    await AssertMenuHeaders(beginButton, "Сегодня", "Завтра");
+                    await AssertMenuHeaders(endButton, "Сегодня", "Завтра");
+                }
+                finally
+                {
+                    window?.Close();
+                    fixture?.CleanTasks();
+                }
+            }, CancellationToken.None);
+        }
+        finally
+        {
+            LocalizationService.Current = previousLocalization;
+        }
+    }
+
+    private static async Task AssertMenuHeaders(DropDownButton button, string expectedToday, string expectedTomorrow)
+    {
+        var flyout = button.Flyout as MenuFlyout;
+        await Assert.That(flyout).IsNotNull();
+
+        var items = flyout!.Items.OfType<MenuItem>().ToArray();
+        await Assert.That(items.Length).IsGreaterThanOrEqualTo(2);
+        await Assert.That(items[0].Header?.ToString()).IsEqualTo(expectedToday);
+        await Assert.That(items[1].Header?.ToString()).IsEqualTo(expectedTomorrow);
+    }
+
+    private static DropDownButton GetDropDownButton(Control root, string content)
+    {
+        var button = root.GetVisualDescendants()
+            .OfType<DropDownButton>()
+            .FirstOrDefault(candidate => string.Equals(candidate.Content?.ToString(), content, StringComparison.Ordinal));
+
+        if (button == null)
+        {
+            throw new InvalidOperationException($"DropDownButton with content '{content}' was not found.");
+        }
+
+        return button;
+    }
+
+    private static Window CreateWindow(Control content)
+    {
+        return new Window
+        {
+            Width = 1600,
+            Height = 2200,
+            Content = content
+        };
+    }
+
+    private sealed class FakeSystemCultureProvider : ILocalizationSystemCultureProvider
+    {
+        public FakeSystemCultureProvider(string cultureName)
+        {
+            SystemUICulture = CultureInfo.GetCultureInfo(cultureName);
+        }
+
+        public CultureInfo SystemUICulture { get; }
+    }
+}

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -269,6 +269,8 @@
   <data name="To" xml:space="preserve"><value>To</value></data>
   <data name="Token" xml:space="preserve"><value>Token</value></data>
   <data name="TokenAccess" xml:space="preserve"><value>Access token</value></data>
+  <data name="Today" xml:space="preserve"><value>Today</value></data>
+  <data name="Tomorrow" xml:space="preserve"><value>Tomorrow</value></data>
   <data name="Tuesday" xml:space="preserve"><value>Tuesday</value></data>
   <data name="TwentyMinutes" xml:space="preserve"><value>20 minutes</value></data>
   <data name="TwoDays" xml:space="preserve"><value>2 days</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -269,6 +269,8 @@
   <data name="To" xml:space="preserve"><value>По</value></data>
   <data name="Token" xml:space="preserve"><value>Токен</value></data>
   <data name="TokenAccess" xml:space="preserve"><value>Токен доступа</value></data>
+  <data name="Today" xml:space="preserve"><value>Сегодня</value></data>
+  <data name="Tomorrow" xml:space="preserve"><value>Завтра</value></data>
   <data name="Tuesday" xml:space="preserve"><value>Вторник</value></data>
   <data name="TwentyMinutes" xml:space="preserve"><value>20 минут</value></data>
   <data name="TwoDays" xml:space="preserve"><value>2 дня</value></data>


### PR DESCRIPTION
## What changed
- added missing `Today` and `Tomorrow` localization keys to the shared and Russian resource dictionaries
- added a headless UI test that verifies the quick date selection flyout shows `Сегодня` and `Завтра` in Russian locale

## Why
The quick date selection menu in the task details used `DynamicResource Today` and `DynamicResource Tomorrow`, but those resource keys were missing from the localization dictionaries. As a result, the labels for "today" and "tomorrow" did not appear in the quick picker.

## Impact
The quick date selection menu now shows localized labels correctly, and the new UI test guards against regression.

## Validation
- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --filter-uid "Unlimotion.Test.MainControlDateQuickSelectionUiTests.1.1.DateQuickSelectionUi_UsesLocalizedTodayAndTomorrowLabels.1.1.0" --minimum-expected-tests 1`
- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --filter-uid "Unlimotion.Test.LocalizationSettingsTests.1.1.RussianResources_HaveSameKeysAsFallbackResources.1.1.0" --minimum-expected-tests 1`