### PR TITLE
Preserve task multiselect during drag

### DIFF
--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -966,24 +966,45 @@ public class MainControlTreeCommandsUiTests
                 await Assert.That(root1Item.IsSelected).IsTrue();
                 await Assert.That(root3Item.IsSelected).IsTrue();
 
+                var collectionChangeCount = 0;
+                var mouseIsDown = false;
                 var selectedItemsNotifier = allTasksTree.SelectedItems as INotifyCollectionChanged;
                 await Assert.That(selectedItemsNotifier).IsNotNull();
-
-                var ensureSelectionMethod = typeof(MainControl).GetMethod(
-                    "EnsureTreeSelectionForDragStart",
-                    BindingFlags.Instance | BindingFlags.NonPublic);
-                await Assert.That(ensureSelectionMethod).IsNotNull();
-
-                var collectionChangeCount = 0;
                 NotifyCollectionChangedEventHandler handler = (_, _) => collectionChangeCount++;
                 selectedItemsNotifier!.CollectionChanged += handler;
                 try
                 {
-                    ensureSelectionMethod!.Invoke(view, [allTasksTree, selectedBefore, true]);
+                    var startPoint = GetControlCenterPoint(window, root1Control);
+                    var movePoint = new Point(startPoint.X + 12, startPoint.Y + 12);
+
+                    window.MouseDown(startPoint, MouseButton.Left, RawInputModifiers.None);
+                    mouseIsDown = true;
+                    Dispatcher.UIThread.RunJobs();
+
+                    await Assert.That(GetSelectedWrappers(allTasksTree).Count).IsEqualTo(2);
+                    await Assert.That(root1Item.IsSelected).IsTrue();
+                    await Assert.That(root3Item.IsSelected).IsTrue();
+
+                    window.MouseMove(movePoint, RawInputModifiers.LeftMouseButton);
+                    Dispatcher.UIThread.RunJobs();
+
+                    await Assert.That(GetSelectedWrappers(allTasksTree).Count).IsEqualTo(2);
+                    await Assert.That(root1Item.IsSelected).IsTrue();
+                    await Assert.That(root3Item.IsSelected).IsTrue();
+
+                    window.MouseUp(movePoint, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+                    mouseIsDown = false;
                     Dispatcher.UIThread.RunJobs();
                 }
                 finally
                 {
+                    if (mouseIsDown && window is { } topLevel)
+                    {
+                        var releasePoint = GetControlCenterPoint(topLevel, root1Control);
+                        topLevel.MouseUp(releasePoint, MouseButton.Left, RawInputModifiers.None);
+                        Dispatcher.UIThread.RunJobs();
+                    }
+
                     selectedItemsNotifier.CollectionChanged -= handler;
                 }
 
@@ -1016,19 +1037,25 @@ public class MainControlTreeCommandsUiTests
         MouseButton button = MouseButton.Left,
         RawInputModifiers modifiers = RawInputModifiers.None)
     {
+        var point = GetControlCenterPoint(window, control);
+        window.MouseDown(point, button, modifiers);
+        window.MouseUp(point, button, modifiers);
+        Dispatcher.UIThread.RunJobs();
+        await Task.CompletedTask;
+    }
+
+    private static Point GetControlCenterPoint(Visual relativeTo, Control control)
+    {
         var point = control.TranslatePoint(
             new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
-            window);
+            relativeTo);
 
         if (!point.HasValue)
         {
             throw new InvalidOperationException($"Cannot translate point for control {control.GetType().Name}.");
         }
 
-        window.MouseDown(point.Value, button, modifiers);
-        window.MouseUp(point.Value, button, modifiers);
-        Dispatcher.UIThread.RunJobs();
-        await Task.CompletedTask;
+        return point.Value;
     }
 
     private static void PressHotkey(Window window, Key key, PhysicalKey physicalKey, RawInputModifiers modifiers)

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -249,6 +249,12 @@ namespace Unlimotion.Views
             {
                 selectionSnapshot = [wrapper];
             }
+            else if (selectionSnapshot.Count > 1)
+            {
+                // Prevent TreeView from collapsing an existing multi-selection to the drag source
+                // before the drag gesture crosses the threshold.
+                e.Handled = true;
+            }
 
             _pendingTreeDrag = new PendingTreeDragContext(
                 control,


### PR DESCRIPTION
## What changed
- preserved existing multi-selection visual state when drag starts from an already selected task
- updated the headless UI test to simulate a real mouse drag sequence instead of only invoking the internal helper

## Why
When several tasks were selected and drag started from one of them, `TreeView` collapsed the visual selection to the drag source on pointer press before the drag threshold was crossed. The drag operation itself still worked, but the UI highlight became misleading.

## Impact
- selected tasks now stay visibly selected during drag preparation and drag start
- regression coverage now checks the real pointer flow for this scenario

## Root cause
`PointerPressed` on an already selected item in a multi-selection was still being handled by `TreeView`, which reset the visual selection to a single item before drag initialization completed.

## Validation
- `src\\Unlimotion.Test\\bin\\Debug\\net10.0\\Unlimotion.Test.exe --output Detailed`
- 202 tests passed