### PR TITLE
Fix Android startup flow

### DIFF
--- a/src/Unlimotion.Android/MainActivity.cs
+++ b/src/Unlimotion.Android/MainActivity.cs
@@ -2,18 +2,15 @@
 
 using System;
 using System.IO;
-using Android;
+using System.Runtime.Versioning;
 using Android.App;
-using Android.Content.PM;
-using Android.Views;
 using Android.Content;
+using Android.Content.PM;
 using Android.OS;
 using Android.Provider;
-using Android.Widget;
 using Android.Util;
+using Android.Views;
 using Android.Runtime;
-using AndroidX.Core.App;
-using AndroidX.Core.Content;
 using Avalonia;
 using Avalonia.Android;
 using Avalonia.ReactiveUI;
@@ -37,80 +34,61 @@ public class MainActivity : AvaloniaMainActivity<App>
         base.OnCreate(savedInstanceState);
 
         HookCrashLogging();
-        EnsureAllFilesAccessIfNeeded();
-    }
-
-    protected override void OnResume()
-    {
-        base.OnResume();
-
-        EnsureAllFilesAccessIfNeeded();
     }
 
     private const string DefaultConfigName = "Settings.json";
     private const string TasksFolderName = "Tasks";
-    const int RequestStorageId = 0;
-    private bool _requestedAllFilesAccess;
-    private bool _requestedLegacyStorageAccess;
 
     protected override AppBuilder CustomizeAppBuilder(AppBuilder builder)
     {
-    try
-    {
-
-        if (Build.VERSION.SdkInt < BuildVersionCodes.R)
+        try
         {
-            var needsWrite = ContextCompat.CheckSelfPermission(this, Manifest.Permission.WriteExternalStorage) != Permission.Granted;
-            var needsRead = ContextCompat.CheckSelfPermission(this, Manifest.Permission.ReadExternalStorage) != Permission.Granted;
-            if (needsWrite || needsRead)
+            var dataDir = ResolveDataDirectory();
+            Directory.CreateDirectory(dataDir);
+
+            BackupViaGitService.GetAbsolutePath = path => Path.Combine(dataDir, path);
+
+            EnsureGitSafeDirectory(dataDir);
+            EnsureGitSslCertBundle(dataDir);
+
+            TaskStorageFactory.DefaultStoragePath = Path.Combine(dataDir, TasksFolderName);
+
+            var configPath = Path.Combine(dataDir, DefaultConfigName);
+            if (!File.Exists(configPath))
             {
-                ActivityCompat.RequestPermissions(this, new[] { Manifest.Permission.ReadExternalStorage, Manifest.Permission.WriteExternalStorage }, RequestStorageId);
+                using var stream = File.CreateText(configPath);
+                stream.Write(@"{}");
             }
-            else
-            {
-                AccessExternalStorage();
-            }
-        }
 
-        string dataDir;
-        if (ContextCompat.CheckSelfPermission(this, Manifest.Permission.WriteExternalStorage) != Permission.Granted)
-        {
-            dataDir = ApplicationContext.FilesDir.AbsolutePath;
-        }
-        else
-        {
-            dataDir = ApplicationContext.GetExternalFilesDir(null)?.AbsolutePath;
-        }
+            App.Init(configPath);
 
-        BackupViaGitService.GetAbsolutePath = path => Path.Combine(dataDir, path);
-
-        EnsureGitSafeDirectory(dataDir);
-        EnsureGitSslCertBundle(dataDir);
-
-        //Задание дефолтного пути для хранения задач
-        TaskStorageFactory.DefaultStoragePath = Path.Combine(dataDir, TasksFolderName);
-
-        //Задание дефолтного пути для хранения настроек
-        var configPath = Path.Combine(dataDir, DefaultConfigName);
-        if (!File.Exists(configPath))
-        {
-            var stream = File.CreateText(configPath);
-            stream.Write(@"{}");
-            stream.Close();
-        }
-
-        App.Init(configPath);
-
-        return base.CustomizeAppBuilder(builder)
+            return base.CustomizeAppBuilder(builder)
                 .WithCustomFont()
                 .UseReactiveUI();
-    }
-    catch (Exception ex)
-    {
-        WriteStartupError(ex);
-        throw;
+        }
+        catch (Exception ex)
+        {
+            WriteStartupError(ex);
+            throw;
+        }
     }
 
+    private string ResolveDataDirectory()
+    {
+        // App-private storage works on modern Android without broad filesystem permissions.
+        var externalFilesDir = GetExternalFilesDir(null)?.AbsolutePath;
+        if (!string.IsNullOrWhiteSpace(externalFilesDir))
+        {
+            return externalFilesDir;
+        }
+
+        var internalFilesDir = ApplicationContext?.FilesDir;
+        if (internalFilesDir != null)
+        {
+            return internalFilesDir.AbsolutePath;
+        }
+
+        throw new InvalidOperationException("Could not resolve app data directory.");
     }
 
     private static void WriteStartupError(Exception ex)
@@ -121,6 +99,11 @@ public class MainActivity : AvaloniaMainActivity<App>
             if (!TryWriteStartupErrorToDownloads(ex.ToString()))
             {
                 var dir = global::Android.App.Application.Context.FilesDir;
+                if (dir == null)
+                {
+                    return;
+                }
+
                 var path = Path.Combine(dir.AbsolutePath, "startup-error.txt");
                 File.AppendAllText(path, ex + System.Environment.NewLine);
             }
@@ -157,6 +140,24 @@ public class MainActivity : AvaloniaMainActivity<App>
     {
         try
         {
+            if (!OperatingSystem.IsAndroidVersionAtLeast(29))
+            {
+                return false;
+            }
+
+            return TryWriteStartupErrorToDownloadsQ(text);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("android29.0")]
+    private static bool TryWriteStartupErrorToDownloadsQ(string text)
+    {
+        try
+        {
             var resolver = global::Android.App.Application.Context.ContentResolver;
             if (resolver == null)
             {
@@ -189,89 +190,6 @@ public class MainActivity : AvaloniaMainActivity<App>
         catch
         {
             return false;
-        }
-    }
-
-    public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
-    {
-        base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
-
-        if (requestCode == RequestStorageId)
-        {
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.R)
-            {
-                return;
-            }
-
-            if (grantResults.Length > 0 && grantResults[0] == Permission.Granted)
-            {
-                // Разрешение предоставлено, продолжаем работу
-                AccessExternalStorage();
-            }
-            else
-            {
-                // Разрешение не предоставлено, уведомляем пользователя
-                Toast.MakeText(this, "Разрешение на доступ к внешнему хранилищу не предоставлено", ToastLength.Short)?.Show();
-            }
-        }
-    }
-
-    private void EnsureAllFilesAccessIfNeeded()
-    {
-        if (Build.VERSION.SdkInt >= BuildVersionCodes.R)
-        {
-            if (global::Android.OS.Environment.IsExternalStorageManager)
-            {
-                return;
-            }
-
-            if (_requestedAllFilesAccess)
-            {
-                return;
-            }
-
-            _requestedAllFilesAccess = true;
-            Toast.MakeText(this, "Нужно разрешение \"Доступ ко всем файлам\" для работы с папкой задач", ToastLength.Long)?.Show();
-
-            var handler = new Handler(Looper.MainLooper);
-            handler.Post(() =>
-            {
-                try
-                {
-                    var intent = new Intent(Settings.ActionManageAppAllFilesAccessPermission);
-                    intent.SetData(global::Android.Net.Uri.Parse($"package:{PackageName}"));
-                    StartActivity(intent);
-                }
-                catch
-                {
-                    try
-                    {
-                        var intent = new Intent(Settings.ActionManageAllFilesAccessPermission);
-                        StartActivity(intent);
-                    }
-                    catch
-                    {
-                        var intent = new Intent(Settings.ActionApplicationDetailsSettings);
-                        intent.SetData(global::Android.Net.Uri.Parse($"package:{PackageName}"));
-                        StartActivity(intent);
-                    }
-                }
-            });
-
-            return;
-        }
-
-        if (_requestedLegacyStorageAccess)
-        {
-            return;
-        }
-
-        var needsWrite = ContextCompat.CheckSelfPermission(this, Manifest.Permission.WriteExternalStorage) != Permission.Granted;
-        var needsRead = ContextCompat.CheckSelfPermission(this, Manifest.Permission.ReadExternalStorage) != Permission.Granted;
-        if (needsWrite || needsRead)
-        {
-            _requestedLegacyStorageAccess = true;
-            ActivityCompat.RequestPermissions(this, new[] { Manifest.Permission.ReadExternalStorage, Manifest.Permission.WriteExternalStorage }, RequestStorageId);
         }
     }
 
@@ -314,12 +232,5 @@ public class MainActivity : AvaloniaMainActivity<App>
         catch
         {
         }
-    }
-
-    private void AccessExternalStorage()
-    {
-        // Здесь ваш код для доступа к внешнему хранилищу
-        var externalDataDir = GetExternalFilesDir(null)?.AbsolutePath;
-        Toast.MakeText(this, $"Путь внешнего хранилища: {externalDataDir}", ToastLength.Long)?.Show();
     }
 }

--- a/src/Unlimotion.Android/Properties/AndroidManifest.xml
+++ b/src/Unlimotion.Android/Properties/AndroidManifest.xml
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
 	<uses-permission android:name="android.permission.INTERNET" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
-	<application android:label="Unlimotion" android:icon="@drawable/icon" android:requestLegacyExternalStorage="true" />
+	<application android:label="Unlimotion" android:icon="@drawable/icon" />
 </manifest>

--- a/src/Unlimotion/App.axaml.cs
+++ b/src/Unlimotion/App.axaml.cs
@@ -165,8 +165,7 @@ public class App : Application
             catch (Exception ex)
             {
                 settings.SetStorageConnectionState(SettingsConnectionState.Error);
-                var hint = OperatingSystem.IsAndroid() ? L10n.Get("AndroidAllFilesHint") : string.Empty;
-                _notificationManager?.ErrorToast(L10n.Format("ConnectStorageFailed", ex.Message, hint));
+                _notificationManager?.ErrorToast(L10n.Format("ConnectStorageFailed", ex.Message, string.Empty));
             }
         });
 

--- a/tests/Unlimotion.UiTests.Authoring/Tests/MainWindowScenariosBase.cs
+++ b/tests/Unlimotion.UiTests.Authoring/Tests/MainWindowScenariosBase.cs
@@ -12,6 +12,19 @@ public abstract partial class MainWindowScenariosBase<TSession> : UiTestBase<TSe
 {
     [Test]
     [NotInParallel(DesktopUiConstraint)]
+    public async Task Main_window_loads_current_task_on_launch()
+    {
+        using (Assert.Multiple())
+        {
+            await Assert.That(Page.MainTabs.AutomationId).IsEqualTo("MainTabs");
+            await UiAssert.TextEqualsAsync(
+                () => Page.CurrentTaskTitleTextBox.Text,
+                UnlimotionAppLaunchHost.CurrentTaskTitle);
+        }
+    }
+
+    [Test]
+    [NotInParallel(DesktopUiConstraint)]
     public async Task Card_relation_picker_can_be_opened_from_task_card()
     {
         await Assert.That(Page.MainTabs.AutomationId).IsEqualTo("MainTabs");


### PR DESCRIPTION
## What changed

This change removes the Android startup dependency on broad external storage permissions and moves startup storage initialization to the app-private directories that Android already provides.

It also removes the manifest declarations for `READ_EXTERNAL_STORAGE`, `WRITE_EXTERNAL_STORAGE`, and `MANAGE_EXTERNAL_STORAGE`, drops the stale all-files-access hint from the shared error path, and adds a headless UI smoke test that verifies the main window loads the current task on launch.

## Why it changed

The app was starting by immediately requesting all-files access from `MainActivity`. On modern Android that redirected startup into the system settings flow, which looked like an instant crash to the user and blocked the normal first-run path.

The app does not need that permission for its default task/config storage because it can use `GetExternalFilesDir()` or `FilesDir()`.

## Impact

Android builds now open directly into the app instead of bouncing users into the manage-files permission screen on launch.

Developers also get explicit startup coverage for the main window load path in the shared UI test suite.

## Validation

- `dotnet test tests\Unlimotion.UiTests.Headless\Unlimotion.UiTests.Headless.csproj`
- `dotnet build src\Unlimotion.Android\Unlimotion.Android.csproj -c Debug -f net10.0-android`

During local debugging before publish, the updated APK resumed `com.Kibnet.Unlimotion/...MainActivity` on the connected Android device without redirecting into `AppManageExternalStorageActivity`. A final post-rebase reinstall check could not be repeated because the device disconnected from `adb`.