### PR TITLE
Inherit blocker availability to descendant tasks

### DIFF
--- a/src/Unlimotion.TaskTreeManager/TaskTreeManager.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskTreeManager.cs
@@ -130,7 +130,7 @@ public class TaskTreeManager
     public async Task<List<TaskItem>> DeleteTask(TaskItem change, bool deleteInStorage = true)
     {
         var result = new Dictionary<string, TaskItem>();
-        var tasksToRecalculate = new List<TaskItem>();
+        var taskIdsToRecalculate = new HashSet<string>(StringComparer.Ordinal);
 
         await IsCompletedAsync(async () =>
         {
@@ -141,10 +141,20 @@ public class TaskTreeManager
                 {
                     foreach (var parentId in change.ParentTasks)
                     {
-                        var parentItem = await Storage.Load(parentId);
-                        if (parentItem != null)
+                        if (!string.IsNullOrWhiteSpace(parentId))
                         {
-                            tasksToRecalculate.Add(parentItem);
+                            taskIdsToRecalculate.Add(parentId);
+                        }
+                    }
+                }
+
+                if (change.ContainsTasks?.Any() == true)
+                {
+                    foreach (var childId in change.ContainsTasks)
+                    {
+                        if (!string.IsNullOrWhiteSpace(childId))
+                        {
+                            taskIdsToRecalculate.Add(childId);
                         }
                     }
                 }
@@ -153,10 +163,9 @@ public class TaskTreeManager
                 {
                     foreach (var blockedId in change.BlocksTasks)
                     {
-                        var blockedItem = await Storage.Load(blockedId);
-                        if (blockedItem != null)
+                        if (!string.IsNullOrWhiteSpace(blockedId))
                         {
-                            tasksToRecalculate.Add(blockedItem);
+                            taskIdsToRecalculate.Add(blockedId);
                         }
                     }
                 }
@@ -253,13 +262,6 @@ public class TaskTreeManager
                     }
                 }
 
-                // Recalculate availability for affected tasks
-                foreach (var taskToRecalc in tasksToRecalculate)
-                {
-                    result.AddOrUpdateRange(
-                        await CalculateAndUpdateAvailability(taskToRecalc));
-                }
-
                 // Удаление самой задачи
                 if (deleteInStorage)
                 {
@@ -268,6 +270,18 @@ public class TaskTreeManager
                     // Удаляем из результата
                     result.Remove(change.Id);
                     await Storage.Remove(change.Id);
+                }
+
+                // Recalculate availability after relations are updated using freshly loaded
+                // tasks so detached storage implementations see the final graph state.
+                foreach (var taskIdToRecalculate in taskIdsToRecalculate)
+                {
+                    var taskToRecalculate = await Storage.Load(taskIdToRecalculate);
+                    if (taskToRecalculate != null)
+                    {
+                        result.AddOrUpdateRange(
+                            await CalculateAndUpdateAvailability(taskToRecalculate));
+                    }
                 }
 
                 return true;
@@ -514,6 +528,8 @@ public class TaskTreeManager
 
                 result.AddOrUpdateRange(
                     await CalculateAndUpdateAvailability(parent));
+                result.AddOrUpdateRange(
+                    await CalculateAndUpdateAvailability(child));
 
                 return true;
             }
@@ -737,41 +753,12 @@ public class TaskTreeManager
     {
         var result = new Dictionary<string, TaskItem>();
 
-        // Calculate IsCanBeCompleted based on business rules:
-        // 1. All contained tasks must be completed (IsCompleted != false)
-        // 2. All blocking tasks must be completed (IsCompleted != false)
-        bool allContainsCompleted = true;
-        bool allBlockersCompleted = true;
-
-        // Check all contained tasks
-        if (task.ContainsTasks?.Any() == true)
-        {
-            foreach (var childId in task.ContainsTasks)
-            {
-                var childTask = await Storage.Load(childId);
-                if (childTask != null && childTask.IsCompleted == false)
-                {
-                    allContainsCompleted = false;
-                    break;
-                }
-            }
-        }
-
-        // Check all blocking tasks
-        if (task.BlockedByTasks?.Any() == true)
-        {
-            foreach (var blockerId in task.BlockedByTasks)
-            {
-                var blockerTask = await Storage.Load(blockerId);
-                if (blockerTask != null && blockerTask.IsCompleted == false)
-                {
-                    allBlockersCompleted = false;
-                    break;
-                }
-            }
-        }
-
-        bool newIsCanBeCompleted = allContainsCompleted && allBlockersCompleted;
+        // Availability combines local child completion with blockers inherited
+        // through the whole parent chain.
+        var allContainsCompleted = await AreContainedTasksCompleted(task);
+        var hasIncompleteBlockerInTaskOrAncestors =
+            await HasIncompleteBlockerInTaskOrAncestors(task, new HashSet<string>(StringComparer.Ordinal));
+        bool newIsCanBeCompleted = allContainsCompleted && !hasIncompleteBlockerInTaskOrAncestors;
 
         var oldIsCanBeCompleted = task.IsCanBeCompleted;
         var oldUnlockedDateTime = task.UnlockedDateTime;
@@ -828,6 +815,24 @@ public class TaskTreeManager
             }
         }
 
+        // Collect all contained tasks because inherited blockers propagate from
+        // parents down to all descendants.
+        if (task.ContainsTasks?.Any() == true)
+        {
+            foreach (var childId in task.ContainsTasks)
+            {
+                if (!processedIds.Contains(childId))
+                {
+                    var childTask = await Storage.Load(childId);
+                    if (childTask != null)
+                    {
+                        affectedTasks.Add(childTask);
+                        processedIds.Add(childId);
+                    }
+                }
+            }
+        }
+
         // Collect all tasks blocked by this task (because their availability depends on this task)
         if (task.BlocksTasks?.Any() == true)
         {
@@ -846,6 +851,76 @@ public class TaskTreeManager
         }
 
         return affectedTasks;
+    }
+
+    private async Task<bool> AreContainedTasksCompleted(TaskItem task)
+    {
+        if (task.ContainsTasks?.Any() != true)
+        {
+            return true;
+        }
+
+        foreach (var childId in task.ContainsTasks)
+        {
+            var childTask = await Storage.Load(childId);
+            if (childTask != null && childTask.IsCompleted == false)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> HasIncompleteBlockerInTaskOrAncestors(
+        TaskItem task,
+        ISet<string> visitedTaskIds)
+    {
+        if (task == null || string.IsNullOrWhiteSpace(task.Id) || !visitedTaskIds.Add(task.Id))
+        {
+            return false;
+        }
+
+        if (await HasIncompleteDirectBlocker(task))
+        {
+            return true;
+        }
+
+        if (task.ParentTasks?.Any() != true)
+        {
+            return false;
+        }
+
+        foreach (var parentId in task.ParentTasks)
+        {
+            var parentTask = await Storage.Load(parentId);
+            if (parentTask != null &&
+                await HasIncompleteBlockerInTaskOrAncestors(parentTask, visitedTaskIds))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private async Task<bool> HasIncompleteDirectBlocker(TaskItem task)
+    {
+        if (task.BlockedByTasks?.Any() != true)
+        {
+            return false;
+        }
+
+        foreach (var blockerId in task.BlockedByTasks)
+        {
+            var blockerTask = await Storage.Load(blockerId);
+            if (blockerTask != null && blockerTask.IsCompleted == false)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
+++ b/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Unlimotion.ViewModel;
+using Unlimotion.Views;
+
+namespace Unlimotion.Test;
+
+[NotInParallel]
+public class MainControlAvailabilityUiTests
+{
+    [Test]
+    public async Task DescendantCheckbox_ShouldBeDisabled_WhenAncestorHasIncompleteBlocker()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(GetDesktopAppEntryPointType());
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+
+                var blockerTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
+                var parentTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
+                var childTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.SubTask22Id);
+
+                await Assert.That(blockerTask).IsNotNull();
+                await Assert.That(parentTask).IsNotNull();
+                await Assert.That(childTask).IsNotNull();
+                await Assert.That(childTask!.IsCanBeCompleted).IsTrue();
+
+                await vm.taskRepository!.Block(parentTask!, blockerTask!);
+
+                var rootWrapper = vm.FindTaskWrapperViewModel(parentTask, vm.CurrentAllTasksItems);
+                await Assert.That(rootWrapper).IsNotNull();
+                rootWrapper!.IsExpanded = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
+                await Assert.That(allTasksTree).IsNotNull();
+
+                var childCheckBox = WaitForTaskCheckBox(allTasksTree!, MainWindowViewModelFixture.SubTask22Id);
+                var storedChild = TestHelpers.GetStorageTaskItem(
+                    fixture.DefaultTasksFolderPath,
+                    MainWindowViewModelFixture.SubTask22Id);
+
+                await Assert.That(childCheckBox.IsEnabled).IsFalse();
+                await Assert.That(storedChild).IsNotNull();
+                await Assert.That(storedChild!.IsCanBeCompleted).IsFalse();
+                await Assert.That(storedChild.BlockedByTasks).DoesNotContain(blockerTask.Id);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    private static Window CreateWindow(Control content)
+    {
+        return new Window
+        {
+            Width = 1400,
+            Height = 900,
+            Content = content
+        };
+    }
+
+    private static CheckBox WaitForTaskCheckBox(TreeView tree, string taskId, int timeoutMilliseconds = 2000)
+    {
+        CheckBox? checkBox = null;
+        var ready = SpinWait.SpinUntil(() =>
+        {
+            Dispatcher.UIThread.RunJobs();
+            checkBox = tree.GetVisualDescendants()
+                .OfType<CheckBox>()
+                .FirstOrDefault(control => control.DataContext is TaskItemViewModel task && task.Id == taskId);
+            return checkBox != null;
+        }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
+
+        if (!ready || checkBox == null)
+        {
+            throw new InvalidOperationException($"Checkbox for task '{taskId}' was not found.");
+        }
+
+        return checkBox;
+    }
+
+    private static Type GetDesktopAppEntryPointType()
+    {
+        return Type.GetType("Unlimotion.Desktop.Program, Unlimotion.Desktop") ??
+               throw new InvalidOperationException("Unable to locate Unlimotion.Desktop.Program.");
+    }
+}

--- a/src/Unlimotion.Test/TaskAvailabilityCalculationTests.cs
+++ b/src/Unlimotion.Test/TaskAvailabilityCalculationTests.cs
@@ -611,6 +611,296 @@ namespace Unlimotion.Test
         }
 
         [Test]
+        public async Task ChildTask_ShouldBecomeUnavailable_WhenParentHasIncompleteBlocker()
+        {
+            var storage = new InMemoryStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var blocker = new TaskItem
+            {
+                Id = "blocker",
+                IsCompleted = false,
+                BlocksTasks = new List<string> { "parent" }
+            };
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ContainsTasks = new List<string> { "child" },
+                BlockedByTasks = new List<string> { "blocker" }
+            };
+            var child = new TaskItem
+            {
+                Id = "child",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ParentTasks = new List<string> { "parent" }
+            };
+
+            await storage.Save(blocker);
+            await storage.Save(parent);
+            await storage.Save(child);
+
+            await manager.CalculateAndUpdateAvailability(parent);
+
+            var updatedChild = await storage.Load("child");
+
+            await Assert.That(updatedChild).IsNotNull();
+            await Assert.That(updatedChild.IsCanBeCompleted).IsFalse();
+            await Assert.That(updatedChild.UnlockedDateTime).IsNull();
+            await Assert.That(updatedChild.BlockedByTasks).IsEmpty();
+        }
+
+        [Test]
+        public async Task Grandchild_ShouldInheritIncompleteBlockerFromAncestor()
+        {
+            var storage = new InMemoryStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var blocker = new TaskItem
+            {
+                Id = "blocker",
+                IsCompleted = false,
+                BlocksTasks = new List<string> { "parent" }
+            };
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ContainsTasks = new List<string> { "child" },
+                BlockedByTasks = new List<string> { "blocker" }
+            };
+            var child = new TaskItem
+            {
+                Id = "child",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ContainsTasks = new List<string> { "grandchild" },
+                ParentTasks = new List<string> { "parent" }
+            };
+            var grandchild = new TaskItem
+            {
+                Id = "grandchild",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ParentTasks = new List<string> { "child" }
+            };
+
+            await storage.Save(blocker);
+            await storage.Save(parent);
+            await storage.Save(child);
+            await storage.Save(grandchild);
+
+            await manager.CalculateAndUpdateAvailability(parent);
+
+            var updatedChild = await storage.Load("child");
+            var updatedGrandchild = await storage.Load("grandchild");
+
+            await Assert.That(updatedChild).IsNotNull();
+            await Assert.That(updatedGrandchild).IsNotNull();
+            await Assert.That(updatedChild.IsCanBeCompleted).IsFalse();
+            await Assert.That(updatedGrandchild.IsCanBeCompleted).IsFalse();
+            await Assert.That(updatedChild.UnlockedDateTime).IsNull();
+            await Assert.That(updatedGrandchild.UnlockedDateTime).IsNull();
+        }
+
+        [Test]
+        public async Task Sibling_ShouldRemainAvailable_WhenParentIsUnavailableOnlyBecauseOfAnotherIncompleteChild()
+        {
+            var storage = new InMemoryStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ContainsTasks = new List<string> { "blocking-child", "sibling" }
+            };
+            var blockingChild = new TaskItem
+            {
+                Id = "blocking-child",
+                IsCompleted = false,
+                ParentTasks = new List<string> { "parent" }
+            };
+            var sibling = new TaskItem
+            {
+                Id = "sibling",
+                IsCompleted = false,
+                IsCanBeCompleted = false,
+                UnlockedDateTime = null,
+                ParentTasks = new List<string> { "parent" }
+            };
+
+            await storage.Save(parent);
+            await storage.Save(blockingChild);
+            await storage.Save(sibling);
+
+            await manager.CalculateAndUpdateAvailability(parent);
+
+            var updatedParent = await storage.Load("parent");
+            var updatedSibling = await storage.Load("sibling");
+
+            await Assert.That(updatedParent).IsNotNull();
+            await Assert.That(updatedSibling).IsNotNull();
+            await Assert.That(updatedParent.IsCanBeCompleted).IsFalse();
+            await Assert.That(updatedSibling.IsCanBeCompleted).IsTrue();
+            await Assert.That(updatedSibling.UnlockedDateTime).IsNotNull();
+        }
+
+        [Test]
+        public async Task Descendants_ShouldBecomeAvailable_WhenAncestorBlockerIsCompleted()
+        {
+            var storage = new InMemoryStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var blocker = new TaskItem
+            {
+                Id = "blocker",
+                IsCompleted = false,
+                BlocksTasks = new List<string> { "parent" }
+            };
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ContainsTasks = new List<string> { "child" },
+                BlockedByTasks = new List<string> { "blocker" }
+            };
+            var child = new TaskItem
+            {
+                Id = "child",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ParentTasks = new List<string> { "parent" }
+            };
+
+            await storage.Save(blocker);
+            await storage.Save(parent);
+            await storage.Save(child);
+
+            await manager.CalculateAndUpdateAvailability(parent);
+
+            blocker.IsCompleted = true;
+            await manager.UpdateTask(blocker);
+
+            var updatedChild = await storage.Load("child");
+
+            await Assert.That(updatedChild).IsNotNull();
+            await Assert.That(updatedChild.IsCanBeCompleted).IsTrue();
+            await Assert.That(updatedChild.UnlockedDateTime).IsNotNull();
+        }
+
+        [Test]
+        public async Task MultiParentTask_ShouldBecomeUnavailable_WhenAnyAncestorHasIncompleteBlocker()
+        {
+            var storage = new InMemoryStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var blocker = new TaskItem
+            {
+                Id = "blocker",
+                IsCompleted = false,
+                BlocksTasks = new List<string> { "parent-a" }
+            };
+            var blockedParent = new TaskItem
+            {
+                Id = "parent-a",
+                IsCompleted = false,
+                ContainsTasks = new List<string> { "shared-child" },
+                BlockedByTasks = new List<string> { "blocker" }
+            };
+            var freeParent = new TaskItem
+            {
+                Id = "parent-b",
+                IsCompleted = false,
+                ContainsTasks = new List<string> { "shared-child" }
+            };
+            var sharedChild = new TaskItem
+            {
+                Id = "shared-child",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ParentTasks = new List<string> { "parent-a", "parent-b" }
+            };
+
+            await storage.Save(blocker);
+            await storage.Save(blockedParent);
+            await storage.Save(freeParent);
+            await storage.Save(sharedChild);
+
+            await manager.CalculateAndUpdateAvailability(blockedParent);
+
+            var updatedSharedChild = await storage.Load("shared-child");
+
+            await Assert.That(updatedSharedChild).IsNotNull();
+            await Assert.That(updatedSharedChild.IsCanBeCompleted).IsFalse();
+            await Assert.That(updatedSharedChild.UnlockedDateTime).IsNull();
+        }
+
+        [Test]
+        public async Task DeleteTask_ShouldUnblockChild_WhenStorageLoadsDetachedInstances()
+        {
+            var storage = new DetachedLoadStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var blocker = new TaskItem
+            {
+                Id = "blocker",
+                IsCompleted = false,
+                BlocksTasks = new List<string> { "parent" }
+            };
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                IsCompleted = false,
+                ContainsTasks = new List<string> { "child" },
+                BlockedByTasks = new List<string> { "blocker" }
+            };
+            var child = new TaskItem
+            {
+                Id = "child",
+                IsCompleted = false,
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow,
+                ParentTasks = new List<string> { "parent" }
+            };
+
+            await storage.Save(blocker);
+            await storage.Save(parent);
+            await storage.Save(child);
+
+            await manager.CalculateAndUpdateAvailability(parent);
+            var blockedChild = await storage.Load("child");
+
+            await Assert.That(blockedChild).IsNotNull();
+            await Assert.That(blockedChild.IsCanBeCompleted).IsFalse();
+
+            await manager.DeleteTask(parent);
+
+            var deletedParent = await storage.Load("parent");
+            var updatedChild = await storage.Load("child");
+
+            await Assert.That(deletedParent).IsNull();
+            await Assert.That(updatedChild).IsNotNull();
+            await Assert.That(updatedChild.ParentTasks).IsEmpty();
+            await Assert.That(updatedChild.IsCanBeCompleted).IsTrue();
+            await Assert.That(updatedChild.UnlockedDateTime).IsNotNull();
+        }
+
+        [Test]
         public async Task AddNewParentToTask_WithSameTask_ShouldNotCreateSelfParentRelation()
         {
             // Arrange
@@ -662,6 +952,94 @@ namespace Unlimotion.Test
             await Assert.That(stored.BlockedByTasks).IsEmpty();
             await Assert.That(stored.BlocksTasks).DoesNotContain(stored.Id);
             await Assert.That(stored.BlockedByTasks).DoesNotContain(stored.Id);
+        }
+
+        private sealed class DetachedLoadStorage : IStorage
+        {
+            private readonly Dictionary<string, TaskItem> _tasks = new(StringComparer.Ordinal);
+
+            public event EventHandler<TaskStorageUpdateEventArgs> Updating
+            {
+                add { }
+                remove { }
+            }
+
+            public event Action<Exception?>? OnConnectionError;
+
+            public Task<TaskItem> Save(TaskItem item)
+            {
+                var clone = CloneTask(item);
+                clone.Id ??= Guid.NewGuid().ToString();
+                item.Id = clone.Id;
+                _tasks[clone.Id] = clone;
+                return Task.FromResult(CloneTask(clone));
+            }
+
+            public Task<bool> Remove(string itemId)
+            {
+                _tasks.Remove(itemId);
+                return Task.FromResult(true);
+            }
+
+            public Task<TaskItem?> Load(string itemId)
+            {
+                return Task.FromResult(_tasks.TryGetValue(itemId, out var task) ? CloneTask(task) : null);
+            }
+
+            public async IAsyncEnumerable<TaskItem> GetAll()
+            {
+                foreach (var task in _tasks.Values)
+                {
+                    yield return CloneTask(task);
+                }
+            }
+
+            public async Task BulkInsert(IEnumerable<TaskItem> taskItems)
+            {
+                foreach (var taskItem in taskItems)
+                {
+                    await Save(taskItem);
+                }
+            }
+
+            public Task<bool> Connect()
+            {
+                return Task.FromResult(true);
+            }
+
+            public Task Disconnect()
+            {
+                return Task.CompletedTask;
+            }
+
+            private static TaskItem CloneTask(TaskItem task)
+            {
+                return new TaskItem
+                {
+                    Id = task.Id,
+                    UserId = task.UserId,
+                    Title = task.Title,
+                    Description = task.Description,
+                    IsCompleted = task.IsCompleted,
+                    IsCanBeCompleted = task.IsCanBeCompleted,
+                    CreatedDateTime = task.CreatedDateTime,
+                    UpdatedDateTime = task.UpdatedDateTime,
+                    UnlockedDateTime = task.UnlockedDateTime,
+                    CompletedDateTime = task.CompletedDateTime,
+                    ArchiveDateTime = task.ArchiveDateTime,
+                    PlannedBeginDateTime = task.PlannedBeginDateTime,
+                    PlannedEndDateTime = task.PlannedEndDateTime,
+                    PlannedDuration = task.PlannedDuration,
+                    ContainsTasks = task.ContainsTasks?.ToList() ?? new List<string>(),
+                    ParentTasks = task.ParentTasks?.ToList() ?? new List<string>(),
+                    BlocksTasks = task.BlocksTasks?.ToList() ?? new List<string>(),
+                    BlockedByTasks = task.BlockedByTasks?.ToList() ?? new List<string>(),
+                    Repeater = task.Repeater,
+                    Importance = task.Importance,
+                    Wanted = task.Wanted,
+                    Version = task.Version
+                };
+            }
         }
     }
 }

--- a/src/Unlimotion.Test/UnifiedTaskStorageMigrationRegressionTests.cs
+++ b/src/Unlimotion.Test/UnifiedTaskStorageMigrationRegressionTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Unlimotion.Domain;
 using Unlimotion.TaskTree;
@@ -107,6 +108,73 @@ public class UnifiedTaskStorageMigrationRegressionTests
         }
     }
 
+    [Test]
+    public async Task UnifiedTaskStorage_Init_ShouldRecalculateDescendantAvailability_WhenAvailabilityReportVersionIsStale()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var fileStorage = new FileStorage(tempDir, watcher: false);
+            var manager = new TaskTreeManager(fileStorage);
+            var unified = new UnifiedTaskStorage(manager);
+
+            var blocker = new TaskItem
+            {
+                Id = "blocker",
+                Version = 1,
+                IsCompleted = false,
+                BlocksTasks = new List<string> { "parent" },
+                BlockedByTasks = new List<string>(),
+                IsCanBeCompleted = true
+            };
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                Version = 1,
+                IsCompleted = false,
+                ContainsTasks = new List<string> { "child" },
+                ParentTasks = new List<string>(),
+                BlocksTasks = new List<string>(),
+                BlockedByTasks = new List<string> { "blocker" },
+                IsCanBeCompleted = false,
+                UnlockedDateTime = null
+            };
+            var child = new TaskItem
+            {
+                Id = "child",
+                Version = 1,
+                IsCompleted = false,
+                ContainsTasks = new List<string>(),
+                ParentTasks = new List<string> { "parent" },
+                BlocksTasks = new List<string>(),
+                BlockedByTasks = new List<string>(),
+                IsCanBeCompleted = true,
+                UnlockedDateTime = DateTimeOffset.UtcNow
+            };
+
+            await fileStorage.Save(blocker);
+            await fileStorage.Save(parent);
+            await fileStorage.Save(child);
+            await SeedMigrationReports(tempDir, availabilityVersion: 1);
+
+            await unified.Init();
+
+            var storedChild = await fileStorage.Load("child");
+            var reportJson = JsonDocument.Parse(await File.ReadAllTextAsync(
+                Path.Combine(tempDir, "availability.migration.report")));
+
+            await Assert.That(storedChild).IsNotNull();
+            await Assert.That(storedChild.IsCanBeCompleted).IsFalse();
+            await Assert.That(storedChild.UnlockedDateTime).IsNull();
+            await Assert.That(storedChild.BlockedByTasks).IsEmpty();
+            await Assert.That(reportJson.RootElement.GetProperty("Version").GetInt32()).IsEqualTo(2);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "unified-migration-regression-" + Guid.NewGuid().ToString("N"));
@@ -114,14 +182,17 @@ public class UnifiedTaskStorageMigrationRegressionTests
         return tempDir;
     }
 
-    private static async Task SeedMigrationReports(string tempDir)
+    private static async Task SeedMigrationReports(
+        string tempDir,
+        int migrationVersion = 1,
+        int availabilityVersion = 1)
     {
         await File.WriteAllTextAsync(
             Path.Combine(tempDir, "migration.report"),
-            "{\"Version\":1,\"Timestamp\":\"2026-01-01T00:00:00Z\"}");
+            $"{{\"Version\":{migrationVersion},\"Timestamp\":\"2026-01-01T00:00:00Z\"}}");
         await File.WriteAllTextAsync(
             Path.Combine(tempDir, "availability.migration.report"),
-            "{\"Version\":1,\"Timestamp\":\"2026-01-01T00:00:00Z\"}");
+            $"{{\"Version\":{availabilityVersion},\"Timestamp\":\"2026-01-01T00:00:00Z\"}}");
     }
 
     private static void TryDeleteDirectory(string dir)

--- a/src/Unlimotion.Test/Unlimotion.Test.csproj
+++ b/src/Unlimotion.Test/Unlimotion.Test.csproj
@@ -128,6 +128,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\Unlimotion.Desktop\Unlimotion.Desktop.csproj" />
 		<ProjectReference Include="..\Unlimotion.Server.ServiceInterface\Unlimotion.Server.ServiceInterface.csproj" />
 		<ProjectReference Include="..\Unlimotion.ViewModel\Unlimotion.ViewModel.csproj" />
 		<ProjectReference Include="..\Unlimotion\Unlimotion.csproj" />

--- a/src/Unlimotion/UnifiedTaskStorage.cs
+++ b/src/Unlimotion/UnifiedTaskStorage.cs
@@ -14,6 +14,7 @@ namespace Unlimotion;
 
 public class UnifiedTaskStorage : ITaskStorage
 {
+    private const int AvailabilityMigrationVersion = 2;
     private readonly bool isFileStorage;
 
     public UnifiedTaskStorage(TaskTreeManager taskTreeManager)
@@ -280,7 +281,7 @@ public class UnifiedTaskStorage : ITaskStorage
         // Create migration report
         var report = new
         {
-            Version = 1,
+            Version = AvailabilityMigrationVersion,
             Timestamp = DateTimeOffset.UtcNow,
             ForceRecheck = forceRecheck,
             TasksProcessed = tasksToMigrate.Count,
@@ -294,25 +295,8 @@ public class UnifiedTaskStorage : ITaskStorage
 
     private static bool IsCanBeCompletedForTask(TaskItem task, IReadOnlyDictionary<string, TaskItem> taskById)
     {
-        if (task.ContainsTasks?.Any() == true)
-        {
-            foreach (var childId in task.ContainsTasks)
-            {
-                if (taskById.TryGetValue(childId, out var childTask) && childTask?.IsCompleted == false)
-                    return false;
-            }
-        }
-
-        if (task.BlockedByTasks?.Any() == true)
-        {
-            foreach (var blockerId in task.BlockedByTasks)
-            {
-                if (taskById.TryGetValue(blockerId, out var blockerTask) && blockerTask?.IsCompleted == false)
-                    return false;
-            }
-        }
-
-        return true;
+        return AreContainedTasksCompleted(task, taskById) &&
+               !HasIncompleteBlockerInTaskOrAncestors(task, taskById, new HashSet<string>(StringComparer.Ordinal));
     }
 
     private static bool ShouldSkipCanBeCompletedRecheck(FileStorage fileStorage, string migrationReportPath)
@@ -328,7 +312,7 @@ public class UnifiedTaskStorage : ITaskStorage
         {
             var reportJson = JObject.Parse(File.ReadAllText(migrationReportPath));
             var reportVersion = reportJson["Version"]?.Value<int>() ?? 0;
-            if (reportVersion < 1)
+            if (reportVersion < AvailabilityMigrationVersion)
                 return false;
 
             var reportTaskCount = reportJson["TasksProcessed"]?.Value<int>() ?? -1;
@@ -374,6 +358,65 @@ public class UnifiedTaskStorage : ITaskStorage
         }
 
         return (count, latestWriteUtc);
+    }
+
+    private static bool AreContainedTasksCompleted(
+        TaskItem task,
+        IReadOnlyDictionary<string, TaskItem> taskById)
+    {
+        if (task.ContainsTasks?.Any() != true)
+            return true;
+
+        foreach (var childId in task.ContainsTasks)
+        {
+            if (taskById.TryGetValue(childId, out var childTask) && childTask?.IsCompleted == false)
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasIncompleteBlockerInTaskOrAncestors(
+        TaskItem task,
+        IReadOnlyDictionary<string, TaskItem> taskById,
+        ISet<string> visitedTaskIds)
+    {
+        if (task?.Id is null || !visitedTaskIds.Add(task.Id))
+            return false;
+
+        if (HasIncompleteDirectBlocker(task, taskById))
+            return true;
+
+        if (task.ParentTasks?.Any() != true)
+            return false;
+
+        foreach (var parentId in task.ParentTasks)
+        {
+            if (taskById.TryGetValue(parentId, out var parentTask) &&
+                parentTask != null &&
+                HasIncompleteBlockerInTaskOrAncestors(parentTask, taskById, visitedTaskIds))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasIncompleteDirectBlocker(
+        TaskItem task,
+        IReadOnlyDictionary<string, TaskItem> taskById)
+    {
+        if (task.BlockedByTasks?.Any() != true)
+            return false;
+
+        foreach (var blockerId in task.BlockedByTasks)
+        {
+            if (taskById.TryGetValue(blockerId, out var blockerTask) && blockerTask?.IsCompleted == false)
+                return true;
+        }
+
+        return false;
     }
 
     private async void TaskStorageOnUpdating(object sender, TaskStorageUpdateEventArgs e)


### PR DESCRIPTION
## Summary
- inherit `Blocking` availability down the task tree without persisting synthetic `BlockedByTasks` links
- recalculate descendant availability on startup and invalidate old cached availability state
- cover descendant blocking, migration, delete-path detached-load behavior, and UI disabled state

## Details
- split local availability from inherited ancestor blocker checks in `TaskTreeManager`
- propagate recalculation through `ContainsTasks` so blocker changes reach descendants
- reload affected tasks by id during delete-path availability updates so detached/server-like storage unblocks children correctly
- switch the new headless UI regression test to the real desktop bootstrap path

## Validation
- `dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj /nr:false /p:UseSharedCompilation=false`
- `src/Unlimotion.Test/bin/Debug/net10.0/Unlimotion.Test.exe --disable-logo --no-progress --output Detailed --treenode-filter "/*/*/TaskAvailabilityCalculationTests/*"`
- `src/Unlimotion.Test/bin/Debug/net10.0/Unlimotion.Test.exe --disable-logo --no-progress --output Detailed --treenode-filter "/*/*/TaskAvailabilityCalculationTests/*DeleteTask_ShouldUnblockChild_WhenStorageLoadsDetachedInstances"`
- `src/Unlimotion.Test/bin/Debug/net10.0/Unlimotion.Test.exe --disable-logo --no-progress --output Detailed --treenode-filter "/*/*/UnifiedTaskStorageMigrationRegressionTests/*"`
- `src/Unlimotion.Test/bin/Debug/net10.0/Unlimotion.Test.exe --disable-logo --no-progress --output Detailed --treenode-filter "/*/*/MainControlAvailabilityUiTests/*"`