### PR TITLE
Redesign task relation editor

### DIFF
--- a/src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs
+++ b/src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs
@@ -138,13 +138,12 @@ public class LocalizationDisplayDefinitionTests
     }
 
     [Test]
-    public async System.Threading.Tasks.Task TaskRelationPicker_DisposeUnsubscribesFromCultureChanges()
+    public async System.Threading.Tasks.Task TaskRelationEditor_DisposeUnsubscribesFromCultureChanges()
     {
         var localization = new LocalizationService(new FakeSystemCultureProvider("en-US"));
-        var picker = new TaskRelationPickerViewModel(
-            TaskRelationKind.Parents,
-            () => null,
+        var editor = new TaskRelationEditorViewModel(
             () => [],
+            _ => null,
             () => false,
             (_, _, _) => true,
             (_, _, _) => System.Threading.Tasks.Task.FromResult(true),
@@ -152,17 +151,17 @@ public class LocalizationDisplayDefinitionTests
             new NotificationManagerWrapperMock(),
             localization);
         var watermarkChangeCount = 0;
-        picker.PropertyChanged += OnPropertyChanged;
+        editor.PropertyChanged += OnPropertyChanged;
 
         localization.SetLanguage(LocalizationService.RussianLanguage);
-        picker.Dispose();
+        editor.Dispose();
         localization.SetLanguage(LocalizationService.EnglishLanguage);
 
         await Assert.That(watermarkChangeCount).IsEqualTo(1);
 
         void OnPropertyChanged(object? sender, PropertyChangedEventArgs args)
         {
-            if (args.PropertyName == nameof(TaskRelationPickerViewModel.Watermark))
+            if (args.PropertyName == nameof(TaskRelationEditorViewModel.Watermark))
             {
                 watermarkChangeCount++;
             }

--- a/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
+++ b/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
@@ -21,7 +21,58 @@ namespace Unlimotion.Test;
 public class MainControlRelationPickerUiTests
 {
     [Test]
-    public async Task TaskCardRelationPicker_AddParentFromCard_UpdatesStorage()
+    [Arguments(MainWindowViewModelFixture.BlockedTask7Id, "CurrentTaskParentsRelationAddButton", "CurrentTaskParentsRelationAddInput")]
+    [Arguments(MainWindowViewModelFixture.BlockedTask7Id, "CurrentTaskBlockingRelationAddButton", "CurrentTaskBlockingRelationAddInput")]
+    [Arguments(MainWindowViewModelFixture.RootTask1Id, "CurrentTaskContainingRelationAddButton", "CurrentTaskContainingRelationAddInput")]
+    [Arguments(MainWindowViewModelFixture.RootTask7Id, "CurrentTaskBlockedRelationAddButton", "CurrentTaskBlockedRelationAddInput")]
+    public async Task TaskCardRelationEditor_OpenFocusesExpectedInput(
+        string currentTaskId,
+        string addButtonAutomationId,
+        string inputAutomationId)
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+                vm.DetailsAreOpen = true;
+                var currentTask = TestHelpers.SetCurrentTask(vm, currentTaskId);
+                await Assert.That(currentTask).IsNotNull();
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var addButton = WaitForControl<Button>(view, addButtonAutomationId);
+                await ClickControlAsync(window, addButton);
+
+                var input = WaitForControl<TextBox>(view, inputAutomationId);
+                var focused = WaitFor(() =>
+                    ReferenceEquals(window.FocusManager?.GetFocusedElement(), input) || input.IsFocused);
+
+                using (Assert.Multiple())
+                {
+                    await Assert.That(input.IsVisible).IsTrue();
+                    await Assert.That(focused).IsTrue();
+                }
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TaskCardRelationEditor_AddParentFromCard_UpdatesStorage()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
@@ -46,14 +97,14 @@ public class MainControlRelationPickerUiTests
                 var addButton = WaitForControl<Button>(view, "CurrentTaskParentsRelationAddButton");
                 await ClickControlAsync(window, addButton);
 
-                var input = WaitForControl<AutoCompleteBox>(view, "CurrentTaskParentsRelationAddInput");
+                var input = WaitForControl<TextBox>(view, "CurrentTaskParentsRelationAddInput");
                 await ClickControlAsync(window, input);
-                input.Text = "Task 1";
+                input.Text = "Root Task 1";
                 Dispatcher.UIThread.RunJobs();
 
                 var pickerReady = WaitFor(() =>
-                    vm.CurrentItemParentsPicker?.CanConfirm == true &&
-                    vm.CurrentItemParentsPicker.Suggestions.Any(candidate =>
+                    vm.CurrentRelationEditor.CanConfirm &&
+                    vm.CurrentRelationEditor.Suggestions.Any(candidate =>
                         candidate.Task.Id == MainWindowViewModelFixture.RootTask1Id));
                 await Assert.That(pickerReady).IsTrue();
 
@@ -125,7 +176,10 @@ public class MainControlRelationPickerUiTests
                     string.Equals(
                         AutomationProperties.GetAutomationId(candidate),
                         automationId,
-                        StringComparison.Ordinal));
+                        StringComparison.Ordinal) &&
+                    candidate.IsAttachedToVisualTree() &&
+                    candidate.IsVisible &&
+                    candidate.IsEnabled);
             return control != null;
         }, timeoutMilliseconds);
 

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -80,9 +80,9 @@ namespace Unlimotion.Test
     {
         private NotificationManagerWrapperMock NotificationManager => (NotificationManagerWrapperMock)mainWindowVM.ManagerWrapper;
 
-        private static HashSet<string> CandidateIds(TaskRelationPickerViewModel picker)
+        private static HashSet<string> CandidateIds(TaskRelationEditorViewModel editor)
         {
-            return picker.Suggestions.Select(candidate => candidate.Task.Id).ToHashSet();
+            return editor.Suggestions.Select(candidate => candidate.Task.Id).ToHashSet();
         }
 
         private async Task<(TaskWrapperViewModel RootWrapper, TaskWrapperViewModel ChildWrapper, TaskWrapperViewModel GrandchildWrapper)>
@@ -557,12 +557,12 @@ namespace Unlimotion.Test
         public async Task CurrentItemParentsAdd_Success()
         {
             var currentTask = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.BlockedTask7Id);
-            var picker = mainWindowVM.CurrentItemParentsPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Parents);
+            var editor = mainWindowVM.CurrentRelationEditor;
 
-            picker.OpenCommand.Execute(null);
-            picker.SelectedCandidate = picker.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.RootTask1Id);
+            editor.SelectedCandidate = editor.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.RootTask1Id);
 
-            await TestHelpers.ActionNotCreateItems(() => picker.ConfirmCommand.Execute(null), taskRepository);
+            await TestHelpers.ActionNotCreateItems(() => editor.ConfirmCommand.Execute(null), taskRepository);
 
             var currentStored = GetStorageTaskItem(MainWindowViewModelFixture.BlockedTask7Id);
             var parentStored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask1Id);
@@ -577,12 +577,12 @@ namespace Unlimotion.Test
         public async Task CurrentItemContainsAdd_Success()
         {
             var currentTask = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
-            var picker = mainWindowVM.CurrentItemContainsPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Containing);
+            var editor = mainWindowVM.CurrentRelationEditor;
 
-            picker.OpenCommand.Execute(null);
-            picker.SelectedCandidate = picker.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.BlockedTask7Id);
+            editor.SelectedCandidate = editor.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.BlockedTask7Id);
 
-            await TestHelpers.ActionNotCreateItems(() => picker.ConfirmCommand.Execute(null), taskRepository);
+            await TestHelpers.ActionNotCreateItems(() => editor.ConfirmCommand.Execute(null), taskRepository);
 
             var currentStored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask1Id);
             var childStored = GetStorageTaskItem(MainWindowViewModelFixture.BlockedTask7Id);
@@ -597,12 +597,12 @@ namespace Unlimotion.Test
         public async Task CurrentItemBlockedByAdd_Success()
         {
             TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.BlockedTask7Id);
-            var picker = mainWindowVM.CurrentItemBlockedByPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Blocking);
+            var editor = mainWindowVM.CurrentRelationEditor;
 
-            picker.OpenCommand.Execute(null);
-            picker.SelectedCandidate = picker.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.RootTask7Id);
+            editor.SelectedCandidate = editor.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.RootTask7Id);
 
-            await TestHelpers.ActionNotCreateItems(() => picker.ConfirmCommand.Execute(null), taskRepository);
+            await TestHelpers.ActionNotCreateItems(() => editor.ConfirmCommand.Execute(null), taskRepository);
 
             var blockerStored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask7Id);
             var blockedStored = GetStorageTaskItem(MainWindowViewModelFixture.BlockedTask7Id);
@@ -619,12 +619,12 @@ namespace Unlimotion.Test
         public async Task CurrentItemBlocksAdd_Success()
         {
             TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask7Id);
-            var picker = mainWindowVM.CurrentItemBlocksPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Blocked);
+            var editor = mainWindowVM.CurrentRelationEditor;
 
-            picker.OpenCommand.Execute(null);
-            picker.SelectedCandidate = picker.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.BlockedTask7Id);
+            editor.SelectedCandidate = editor.Suggestions.First(candidate => candidate.Task.Id == MainWindowViewModelFixture.BlockedTask7Id);
 
-            await TestHelpers.ActionNotCreateItems(() => picker.ConfirmCommand.Execute(null), taskRepository);
+            await TestHelpers.ActionNotCreateItems(() => editor.ConfirmCommand.Execute(null), taskRepository);
 
             var blockerStored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask7Id);
             var blockedStored = GetStorageTaskItem(MainWindowViewModelFixture.BlockedTask7Id);
@@ -638,36 +638,33 @@ namespace Unlimotion.Test
         }
 
         [Test]
-        public async Task CurrentItemParentsPicker_ShouldNotContainSelfCandidate()
+        public async Task CurrentRelationEditor_ShouldNotContainSelfCandidateForParents()
         {
             TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
-            var picker = mainWindowVM.CurrentItemParentsPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Parents);
+            var editor = mainWindowVM.CurrentRelationEditor;
 
-            picker.OpenCommand.Execute(null);
-
-            await Assert.That(CandidateIds(picker)).DoesNotContain(MainWindowViewModelFixture.RootTask1Id);
+            await Assert.That(CandidateIds(editor)).DoesNotContain(MainWindowViewModelFixture.RootTask1Id);
         }
 
         [Test]
-        public async Task CurrentItemBlockedByPicker_ShouldNotContainExistingRelationCandidate()
+        public async Task CurrentRelationEditor_ShouldNotContainExistingBlockingCandidate()
         {
             TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.BlockedTask2Id);
-            var picker = mainWindowVM.CurrentItemBlockedByPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Blocking);
+            var editor = mainWindowVM.CurrentRelationEditor;
 
-            picker.OpenCommand.Execute(null);
-
-            await Assert.That(CandidateIds(picker)).DoesNotContain(MainWindowViewModelFixture.RootTask2Id);
+            await Assert.That(CandidateIds(editor)).DoesNotContain(MainWindowViewModelFixture.RootTask2Id);
         }
 
         [Test]
-        public async Task CurrentItemParentsPicker_ShouldNotContainCandidateThatCreatesCycle()
+        public async Task CurrentRelationEditor_ShouldNotContainCandidateThatCreatesCycle()
         {
             TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask4Id);
-            var picker = mainWindowVM.CurrentItemParentsPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Parents);
+            var editor = mainWindowVM.CurrentRelationEditor;
 
-            picker.OpenCommand.Execute(null);
-
-            await Assert.That(CandidateIds(picker)).DoesNotContain(MainWindowViewModelFixture.SubTask41Id);
+            await Assert.That(CandidateIds(editor)).DoesNotContain(MainWindowViewModelFixture.SubTask41Id);
         }
 
         [Test]
@@ -693,23 +690,22 @@ namespace Unlimotion.Test
         }
 
         [Test]
-        public async Task CurrentItemBlockedByPicker_InvalidForcedConfirm_ShouldShowToastAndKeepRelationsUnchanged()
+        public async Task CurrentRelationEditor_InvalidForcedConfirm_ShouldShowToastAndKeepRelationsUnchanged()
         {
             TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.DeadlockTask6Id);
-            var picker = mainWindowVM.CurrentItemBlockedByPicker!;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Blocking);
+            var editor = mainWindowVM.CurrentRelationEditor;
             var candidateTask = GetTask(MainWindowViewModelFixture.DeadlockBlockedTask6Id);
             NotificationManager.ClearMessages();
 
-            picker.OpenCommand.Execute(null);
+            await Assert.That(CandidateIds(editor)).DoesNotContain(MainWindowViewModelFixture.DeadlockBlockedTask6Id);
 
-            await Assert.That(CandidateIds(picker)).DoesNotContain(MainWindowViewModelFixture.DeadlockBlockedTask6Id);
-
-            picker.SelectedCandidate = new TaskRelationCandidateViewModel(
+            editor.SelectedCandidate = new TaskRelationCandidateViewModel(
                 candidateTask,
                 candidateTask.Title,
                 candidateTask.Id);
 
-            await TestHelpers.ActionNotCreateItems(() => picker.ConfirmCommand.Execute(null), taskRepository);
+            await TestHelpers.ActionNotCreateItems(() => editor.ConfirmCommand.Execute(null), taskRepository);
 
             var currentStored = GetStorageTaskItem(MainWindowViewModelFixture.DeadlockTask6Id);
             var candidateStored = GetStorageTaskItem(MainWindowViewModelFixture.DeadlockBlockedTask6Id);
@@ -717,6 +713,34 @@ namespace Unlimotion.Test
             await Assert.That(currentStored.BlockedByTasks).DoesNotContain(candidateTask.Id);
             await Assert.That(candidateStored.BlocksTasks).DoesNotContain(MainWindowViewModelFixture.DeadlockTask6Id);
             await Assert.That(NotificationManager.LastErrorMessage).IsNotNull();
+        }
+
+        [Test]
+        public async Task CurrentRelationEditor_ShouldCloseWhenCurrentTaskChanges()
+        {
+            TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Parents);
+
+            await Assert.That(mainWindowVM.CurrentRelationEditor.IsOpen).IsTrue();
+
+            TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask2Id);
+
+            await Assert.That(mainWindowVM.CurrentRelationEditor.IsOpen).IsFalse();
+            await Assert.That(mainWindowVM.CurrentRelationEditor.Query).IsEmpty();
+        }
+
+        [Test]
+        public async Task CurrentRelationEditor_ShouldCloseWhenDetailsPaneCloses()
+        {
+            TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            mainWindowVM.DetailsAreOpen = true;
+            mainWindowVM.OpenRelationEditor(TaskRelationKind.Parents);
+
+            await Assert.That(mainWindowVM.CurrentRelationEditor.IsOpen).IsTrue();
+
+            mainWindowVM.DetailsAreOpen = false;
+
+            await Assert.That(mainWindowVM.CurrentRelationEditor.IsOpen).IsFalse();
         }
 
         /// <summary>

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -108,11 +108,20 @@ namespace Unlimotion.ViewModel
             this.WhenAnyValue(m => m.Settings.IsFuzzySearch)
                 .Subscribe(b => Search.IsFuzzySearch = b)
                 .AddToDispose(this);
+            CurrentRelationEditor = new TaskRelationEditorViewModel(
+                () => taskRepository?.Tasks.Items ?? Enumerable.Empty<TaskItemViewModel>(),
+                FindTaskById,
+                () => Settings.IsFuzzySearch,
+                IsRelationCandidateValid,
+                TryAddRelationAsync,
+                GetRelationCandidateContext,
+                ManagerWrapper,
+                LocalizationService.Current);
             var localization = LocalizationService.Current;
             EventHandler localizationChanged = (_, __) => RefreshLocalizedCollections();
             localization.CultureChanged += localizationChanged;
             Disposable.Create(() => localization.CultureChanged -= localizationChanged).AddToDispose(this);
-            Disposable.Create(DisposeCurrentRelationPickers).AddToDispose(this);
+            Disposable.Create(() => CurrentRelationEditor.Dispose()).AddToDispose(this);
         }
 
         private void RefreshLocalizedCollections()
@@ -1288,23 +1297,12 @@ namespace Unlimotion.ViewModel
             this.WhenAnyValue(m => m.CurrentTaskItem)
                 .Subscribe(item =>
                 {
-                    DisposeCurrentRelationPickers();
-
-                    if (item != null)
-                    {
-                        CurrentItemContainsPicker = CreateRelationPicker(TaskRelationKind.Containing);
-                        CurrentItemParentsPicker = CreateRelationPicker(TaskRelationKind.Parents);
-                        CurrentItemBlocksPicker = CreateRelationPicker(TaskRelationKind.Blocked);
-                        CurrentItemBlockedByPicker = CreateRelationPicker(TaskRelationKind.Blocking);
-                    }
-                    else
-                    {
-                        CurrentItemContainsPicker = null;
-                        CurrentItemParentsPicker = null;
-                        CurrentItemBlocksPicker = null;
-                        CurrentItemBlockedByPicker = null;
-                    }
+                    CurrentRelationEditor.SyncCurrentTask(item);
                 })
+                .AddToDispose(connectionDisposableList);
+            this.WhenAnyValue(m => m.DetailsAreOpen)
+                .Where(isOpen => !isOpen)
+                .Subscribe(_ => CurrentRelationEditor.Close())
                 .AddToDispose(connectionDisposableList);
             RegisterCommands();
 
@@ -1459,27 +1457,20 @@ namespace Unlimotion.ViewModel
             }
         }
 
-        private TaskRelationPickerViewModel CreateRelationPicker(TaskRelationKind kind)
+        public void OpenRelationEditor(TaskRelationKind kind)
         {
-            var picker = new TaskRelationPickerViewModel(
-                kind,
-                () => CurrentTaskItem,
-                () => taskRepository?.Tasks.Items ?? Enumerable.Empty<TaskItemViewModel>(),
-                () => Settings.IsFuzzySearch,
-                IsRelationCandidateValid,
-                TryAddRelationAsync,
-                GetRelationCandidateContext,
-                ManagerWrapper,
-                LocalizationService.Current);
-            return picker;
+            CurrentRelationEditor.Open(kind, CurrentTaskItem);
         }
 
-        private void DisposeCurrentRelationPickers()
+        private TaskItemViewModel? FindTaskById(string taskId)
         {
-            CurrentItemContainsPicker?.Dispose();
-            CurrentItemParentsPicker?.Dispose();
-            CurrentItemBlocksPicker?.Dispose();
-            CurrentItemBlockedByPicker?.Dispose();
+            if (taskRepository == null || string.IsNullOrWhiteSpace(taskId))
+            {
+                return null;
+            }
+
+            var lookup = taskRepository.Tasks.Lookup(taskId);
+            return lookup.HasValue ? lookup.Value : null;
         }
 
         private async Task<bool> TryAddRelationAsync(
@@ -1703,10 +1694,7 @@ namespace Unlimotion.ViewModel
         public TaskWrapperViewModel CurrentItemParents { get; private set; } = null!;
         public TaskWrapperViewModel CurrentItemBlocks { get; private set; } = null!;
         public TaskWrapperViewModel CurrentItemBlockedBy { get; private set; } = null!;
-        public TaskRelationPickerViewModel? CurrentItemContainsPicker { get; private set; }
-        public TaskRelationPickerViewModel? CurrentItemParentsPicker { get; private set; }
-        public TaskRelationPickerViewModel? CurrentItemBlocksPicker { get; private set; }
-        public TaskRelationPickerViewModel? CurrentItemBlockedByPicker { get; private set; }
+        public TaskRelationEditorViewModel CurrentRelationEditor { get; }
         public SearchDefinition Search { get; set; } = new();
 
         public ICommand Create { get; set; }

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -11,6 +11,10 @@
   <data name="AddBlockingTasksMessage" xml:space="preserve"><value>Are you sure you want to mark {0} selected tasks as blockers for "{1}"?</value></data>
   <data name="AddRelationFailed" xml:space="preserve"><value>Could not add the relation.</value></data>
   <data name="AddRelationFailedWithError" xml:space="preserve"><value>Could not add the relation: {0}</value></data>
+  <data name="AddParentRelation" xml:space="preserve"><value>Add parent task</value></data>
+  <data name="AddContainingRelation" xml:space="preserve"><value>Add containing task</value></data>
+  <data name="AddBlockingRelation" xml:space="preserve"><value>Add blocking task</value></data>
+  <data name="AddBlockedRelation" xml:space="preserve"><value>Add blocked task</value></data>
   <data name="AdvancedHint" xml:space="preserve"><value>Parameters for advanced sync setup and diagnostics.</value></data>
   <data name="AdvancedSettings" xml:space="preserve"><value>Advanced settings</value></data>
   <data name="AfterComplete" xml:space="preserve"><value>After complete</value></data>
@@ -101,6 +105,7 @@
   <data name="ExpandCurrentNested" xml:space="preserve"><value>Expand nested for current</value></data>
   <data name="FileStorageNoAccess" xml:space="preserve"><value>No access to directory: {0}</value></data>
   <data name="FindTask" xml:space="preserve"><value>Find task</value></data>
+  <data name="NoRelationCandidates" xml:space="preserve"><value>No available tasks for this relation.</value></data>
   <data name="FirstDayNextMonth" xml:space="preserve"><value>First day of next month</value></data>
   <data name="FiveDays" xml:space="preserve"><value>5 days</value></data>
   <data name="FiveMinutes" xml:space="preserve"><value>5 minutes</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -11,6 +11,10 @@
   <data name="AddBlockingTasksMessage" xml:space="preserve"><value>Сделать {0} выбранных задач блокирующими для "{1}"?</value></data>
   <data name="AddRelationFailed" xml:space="preserve"><value>Не удалось добавить связь.</value></data>
   <data name="AddRelationFailedWithError" xml:space="preserve"><value>Не удалось добавить связь: {0}</value></data>
+  <data name="AddParentRelation" xml:space="preserve"><value>Добавить родительскую задачу</value></data>
+  <data name="AddContainingRelation" xml:space="preserve"><value>Добавить содержащую задачу</value></data>
+  <data name="AddBlockingRelation" xml:space="preserve"><value>Добавить блокирующую задачу</value></data>
+  <data name="AddBlockedRelation" xml:space="preserve"><value>Добавить заблокированную задачу</value></data>
   <data name="AdvancedHint" xml:space="preserve"><value>Параметры для продвинутой настройки синхронизации и диагностики.</value></data>
   <data name="AdvancedSettings" xml:space="preserve"><value>Расширенные настройки</value></data>
   <data name="AfterComplete" xml:space="preserve"><value>После выполнения</value></data>
@@ -101,6 +105,7 @@
   <data name="ExpandCurrentNested" xml:space="preserve"><value>Развернуть вложенные текущего</value></data>
   <data name="FileStorageNoAccess" xml:space="preserve"><value>Нет доступа к каталогу: {0}</value></data>
   <data name="FindTask" xml:space="preserve"><value>Найти задачу</value></data>
+  <data name="NoRelationCandidates" xml:space="preserve"><value>Для этого типа связи нет доступных задач.</value></data>
   <data name="FirstDayNextMonth" xml:space="preserve"><value>Первый день следующего месяца</value></data>
   <data name="FiveDays" xml:space="preserve"><value>5 дней</value></data>
   <data name="FiveMinutes" xml:space="preserve"><value>5 минут</value></data>

--- a/src/Unlimotion.ViewModel/TaskRelationEditorViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskRelationEditorViewModel.cs
@@ -9,14 +9,13 @@ using Unlimotion.ViewModel.Search;
 
 namespace Unlimotion.ViewModel;
 
-public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
+public sealed class TaskRelationEditorViewModel : ReactiveObject, IDisposable
 {
     private const int EmptyQuerySuggestionLimit = 30;
     private const int SearchSuggestionLimit = 100;
 
-    private readonly TaskRelationKind _kind;
-    private readonly Func<TaskItemViewModel?> _getCurrentTask;
     private readonly Func<IEnumerable<TaskItemViewModel>> _getAllTasks;
+    private readonly Func<string, TaskItemViewModel?> _findTaskById;
     private readonly Func<bool> _getIsFuzzySearch;
     private readonly Func<TaskRelationKind, TaskItemViewModel, TaskItemViewModel, bool> _isCandidateValid;
     private readonly Func<TaskRelationKind, TaskItemViewModel, TaskItemViewModel, Task<bool>> _addRelationAsync;
@@ -26,15 +25,16 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
     private readonly EventHandler _cultureChangedHandler;
     private bool _isDisposed;
 
-    private bool _isExpanded;
+    private string? _currentTaskId;
+    private TaskRelationKind? _kind;
     private string _query = string.Empty;
     private TaskRelationCandidateViewModel? _selectedCandidate;
     private IReadOnlyList<TaskRelationCandidateViewModel> _suggestions = Array.Empty<TaskRelationCandidateViewModel>();
+    private long _focusRequestVersion;
 
-    public TaskRelationPickerViewModel(
-        TaskRelationKind kind,
-        Func<TaskItemViewModel?> getCurrentTask,
+    public TaskRelationEditorViewModel(
         Func<IEnumerable<TaskItemViewModel>> getAllTasks,
+        Func<string, TaskItemViewModel?> findTaskById,
         Func<bool> getIsFuzzySearch,
         Func<TaskRelationKind, TaskItemViewModel, TaskItemViewModel, bool> isCandidateValid,
         Func<TaskRelationKind, TaskItemViewModel, TaskItemViewModel, Task<bool>> addRelationAsync,
@@ -42,9 +42,8 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
         INotificationManagerWrapper notificationManager,
         ILocalizationService? localizationService = null)
     {
-        _kind = kind;
-        _getCurrentTask = getCurrentTask;
         _getAllTasks = getAllTasks;
+        _findTaskById = findTaskById;
         _getIsFuzzySearch = getIsFuzzySearch;
         _isCandidateValid = isCandidateValid;
         _addRelationAsync = addRelationAsync;
@@ -52,32 +51,23 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
         _notificationManager = notificationManager;
         _localization = localizationService ?? LocalizationService.Current;
 
-        OpenCommand = ReactiveCommand.Create(Open);
         CancelCommand = ReactiveCommand.Create(Cancel);
         ConfirmCommand = ReactiveCommand.CreateFromTask(ConfirmAsync, this.WhenAnyValue(vm => vm.CanConfirm));
-        _cultureChangedHandler = (_, _) => this.RaisePropertyChanged(nameof(Watermark));
+        _cultureChangedHandler = (_, _) => RaiseLocalizationPropertiesChanged();
         _localization.CultureChanged += _cultureChangedHandler;
     }
 
-    public bool IsExpanded
-    {
-        get => _isExpanded;
-        set
-        {
-            if (_isExpanded != value)
-            {
-                this.RaiseAndSetIfChanged(ref _isExpanded, value);
-                if (value)
-                {
-                    RefreshSuggestions();
-                }
-                else
-                {
-                    ResetTransientState(clearExpansion: false);
-                }
-            }
-        }
-    }
+    public bool IsOpen => !string.IsNullOrWhiteSpace(_currentTaskId) && _kind.HasValue;
+
+    public TaskRelationKind? Kind => _kind;
+
+    public bool IsOpenForParents => IsOpen && _kind == TaskRelationKind.Parents;
+
+    public bool IsOpenForContaining => IsOpen && _kind == TaskRelationKind.Containing;
+
+    public bool IsOpenForBlocking => IsOpen && _kind == TaskRelationKind.Blocking;
+
+    public bool IsOpenForBlocked => IsOpen && _kind == TaskRelationKind.Blocked;
 
     public string Query
     {
@@ -114,55 +104,155 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
             if (!ReferenceEquals(_suggestions, value))
             {
                 this.RaiseAndSetIfChanged(ref _suggestions, value);
+                this.RaisePropertyChanged(nameof(HasSuggestions));
                 this.RaisePropertyChanged(nameof(CanConfirm));
             }
         }
     }
 
+    public bool HasSuggestions => Suggestions.Count > 0;
+
     public bool CanConfirm => ResolveCandidateForConfirm() != null;
 
     public string Watermark => _localization.Get("FindTask");
 
-    public string KindName => _kind.ToString();
+    public string EmptyStateText => _localization.Get("NoRelationCandidates");
 
-    public string AddButtonAutomationId => $"CurrentTask{KindName}RelationAddButton";
+    public string Header => _kind switch
+    {
+        TaskRelationKind.Parents => _localization.Get("AddParentRelation"),
+        TaskRelationKind.Containing => _localization.Get("AddContainingRelation"),
+        TaskRelationKind.Blocking => _localization.Get("AddBlockingRelation"),
+        TaskRelationKind.Blocked => _localization.Get("AddBlockedRelation"),
+        _ => string.Empty
+    };
 
-    public string InputAutomationId => $"CurrentTask{KindName}RelationAddInput";
+    public string InputAutomationId => _kind switch
+    {
+        TaskRelationKind.Parents => "CurrentTaskParentsRelationAddInput",
+        TaskRelationKind.Containing => "CurrentTaskContainingRelationAddInput",
+        TaskRelationKind.Blocking => "CurrentTaskBlockingRelationAddInput",
+        TaskRelationKind.Blocked => "CurrentTaskBlockedRelationAddInput",
+        _ => "CurrentTaskRelationAddInput"
+    };
 
-    public string ConfirmButtonAutomationId => $"CurrentTask{KindName}RelationAddConfirmButton";
+    public string ConfirmButtonAutomationId => _kind switch
+    {
+        TaskRelationKind.Parents => "CurrentTaskParentsRelationAddConfirmButton",
+        TaskRelationKind.Containing => "CurrentTaskContainingRelationAddConfirmButton",
+        TaskRelationKind.Blocking => "CurrentTaskBlockingRelationAddConfirmButton",
+        TaskRelationKind.Blocked => "CurrentTaskBlockedRelationAddConfirmButton",
+        _ => "CurrentTaskRelationAddConfirmButton"
+    };
 
-    public string CancelButtonAutomationId => $"CurrentTask{KindName}RelationAddCancelButton";
+    public string CancelButtonAutomationId => _kind switch
+    {
+        TaskRelationKind.Parents => "CurrentTaskParentsRelationAddCancelButton",
+        TaskRelationKind.Containing => "CurrentTaskContainingRelationAddCancelButton",
+        TaskRelationKind.Blocking => "CurrentTaskBlockingRelationAddCancelButton",
+        TaskRelationKind.Blocked => "CurrentTaskBlockedRelationAddCancelButton",
+        _ => "CurrentTaskRelationAddCancelButton"
+    };
 
-    public ICommand OpenCommand { get; }
+    public string SuggestionsAutomationId => _kind switch
+    {
+        TaskRelationKind.Parents => "CurrentTaskParentsRelationSuggestions",
+        TaskRelationKind.Containing => "CurrentTaskContainingRelationSuggestions",
+        TaskRelationKind.Blocking => "CurrentTaskBlockingRelationSuggestions",
+        TaskRelationKind.Blocked => "CurrentTaskBlockedRelationSuggestions",
+        _ => "CurrentTaskRelationSuggestions"
+    };
+
+    public long FocusRequestVersion => _focusRequestVersion;
 
     public ICommand CancelCommand { get; }
 
     public ICommand ConfirmCommand { get; }
 
-    private void Open()
+    public void Open(TaskRelationKind kind, TaskItemViewModel? currentTask)
     {
-        IsExpanded = true;
-        Query = string.Empty;
-        SelectedCandidate = null;
+        if (currentTask == null || string.IsNullOrWhiteSpace(currentTask.Id))
+        {
+            Cancel();
+            return;
+        }
+
+        _kind = kind;
+        _currentTaskId = currentTask.Id;
+        ResetTransientState();
+
+        this.RaisePropertyChanged(nameof(IsOpen));
+        this.RaisePropertyChanged(nameof(Kind));
+        this.RaisePropertyChanged(nameof(IsOpenForParents));
+        this.RaisePropertyChanged(nameof(IsOpenForContaining));
+        this.RaisePropertyChanged(nameof(IsOpenForBlocking));
+        this.RaisePropertyChanged(nameof(IsOpenForBlocked));
+        this.RaisePropertyChanged(nameof(Header));
+        this.RaisePropertyChanged(nameof(InputAutomationId));
+        this.RaisePropertyChanged(nameof(ConfirmButtonAutomationId));
+        this.RaisePropertyChanged(nameof(CancelButtonAutomationId));
+        this.RaisePropertyChanged(nameof(SuggestionsAutomationId));
+
         RefreshSuggestions();
+        RequestFocus();
     }
 
-    private void Cancel()
+    public void SyncCurrentTask(TaskItemViewModel? currentTask)
     {
-        IsExpanded = false;
-    }
-
-    private async Task ConfirmAsync()
-    {
-        var currentTask = _getCurrentTask();
-        var candidate = ResolveCandidateForConfirm();
-
-        if (currentTask == null || candidate == null)
+        if (!IsOpen)
         {
             return;
         }
 
-        if (!_isCandidateValid(_kind, currentTask, candidate.Task))
+        if (currentTask == null ||
+            string.IsNullOrWhiteSpace(currentTask.Id) ||
+            !string.Equals(_currentTaskId, currentTask.Id, StringComparison.Ordinal))
+        {
+            Cancel();
+        }
+    }
+
+    public void Close()
+    {
+        Cancel();
+    }
+
+    private void Cancel()
+    {
+        if (_kind == null && string.IsNullOrWhiteSpace(_currentTaskId) && !IsOpen)
+        {
+            return;
+        }
+
+        _currentTaskId = null;
+        _kind = null;
+        ResetTransientState();
+
+        this.RaisePropertyChanged(nameof(IsOpen));
+        this.RaisePropertyChanged(nameof(Kind));
+        this.RaisePropertyChanged(nameof(IsOpenForParents));
+        this.RaisePropertyChanged(nameof(IsOpenForContaining));
+        this.RaisePropertyChanged(nameof(IsOpenForBlocking));
+        this.RaisePropertyChanged(nameof(IsOpenForBlocked));
+        this.RaisePropertyChanged(nameof(Header));
+        this.RaisePropertyChanged(nameof(InputAutomationId));
+        this.RaisePropertyChanged(nameof(ConfirmButtonAutomationId));
+        this.RaisePropertyChanged(nameof(CancelButtonAutomationId));
+        this.RaisePropertyChanged(nameof(SuggestionsAutomationId));
+    }
+
+    private async Task ConfirmAsync()
+    {
+        var currentTask = ResolveCurrentTask();
+        var candidate = ResolveCandidateForConfirm();
+        var candidateTask = candidate != null ? _findTaskById(candidate.Task.Id) : null;
+
+        if (currentTask == null || candidateTask == null)
+        {
+            return;
+        }
+
+        if (!_kind.HasValue || !_isCandidateValid(_kind.Value, currentTask, candidateTask))
         {
             _notificationManager.ErrorToast(_localization.Get("InvalidRelation"));
             RefreshSuggestions();
@@ -171,7 +261,7 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
 
         try
         {
-            var added = await _addRelationAsync(_kind, currentTask, candidate.Task);
+            var added = await _addRelationAsync(_kind.Value, currentTask, candidateTask);
             if (!added)
             {
                 _notificationManager.ErrorToast(_localization.Get("AddRelationFailed"));
@@ -186,13 +276,13 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
             return;
         }
 
-        IsExpanded = false;
+        Cancel();
     }
 
     private void RefreshSuggestions()
     {
-        var currentTask = _getCurrentTask();
-        if (!IsExpanded || currentTask == null)
+        var currentTask = ResolveCurrentTask();
+        if (!IsOpen || currentTask == null || !_kind.HasValue)
         {
             Suggestions = Array.Empty<TaskRelationCandidateViewModel>();
             SelectedCandidate = null;
@@ -204,9 +294,9 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
 
         IEnumerable<TaskItemViewModel> tasks = _getAllTasks() ?? Enumerable.Empty<TaskItemViewModel>();
         tasks = tasks
-            .Where(task => task != null && !string.IsNullOrWhiteSpace(task.Id))
-            .Where(task => _isCandidateValid(_kind, currentTask, task))
-            .OrderBy(task => GetSortTitle(task))
+            .Where(static task => task != null && !string.IsNullOrWhiteSpace(task.Id))
+            .Where(task => _isCandidateValid(_kind.Value, currentTask, task))
+            .OrderBy(GetSortTitle)
             .ThenBy(task => task.Id, StringComparer.Ordinal);
 
         if (!string.IsNullOrWhiteSpace(query))
@@ -240,6 +330,11 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
         }
     }
 
+    private TaskItemViewModel? ResolveCurrentTask()
+    {
+        return string.IsNullOrWhiteSpace(_currentTaskId) ? null : _findTaskById(_currentTaskId);
+    }
+
     private TaskRelationCandidateViewModel? ResolveCandidateForConfirm()
     {
         if (SelectedCandidate != null)
@@ -261,7 +356,7 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
         return Suggestions.FirstOrDefault(candidate => IsExactMatch(query, candidate));
     }
 
-    private void ResetTransientState(bool clearExpansion)
+    private void ResetTransientState()
     {
         _query = string.Empty;
         _selectedCandidate = null;
@@ -270,13 +365,8 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
         this.RaisePropertyChanged(nameof(Query));
         this.RaisePropertyChanged(nameof(SelectedCandidate));
         this.RaisePropertyChanged(nameof(Suggestions));
+        this.RaisePropertyChanged(nameof(HasSuggestions));
         this.RaisePropertyChanged(nameof(CanConfirm));
-
-        if (clearExpansion && _isExpanded)
-        {
-            _isExpanded = false;
-            this.RaisePropertyChanged(nameof(IsExpanded));
-        }
     }
 
     private TaskRelationCandidateViewModel CreateCandidate(TaskItemViewModel task)
@@ -284,6 +374,19 @@ public sealed class TaskRelationPickerViewModel : ReactiveObject, IDisposable
         var title = GetDisplayTitle(task);
         var context = _getContextText(task);
         return new TaskRelationCandidateViewModel(task, title, context);
+    }
+
+    private void RequestFocus()
+    {
+        _focusRequestVersion++;
+        this.RaisePropertyChanged(nameof(FocusRequestVersion));
+    }
+
+    private void RaiseLocalizationPropertiesChanged()
+    {
+        this.RaisePropertyChanged(nameof(Watermark));
+        this.RaisePropertyChanged(nameof(EmptyStateText));
+        this.RaisePropertyChanged(nameof(Header));
     }
 
     private static bool Matches(TaskItemViewModel task, string userText, bool fuzzySearch)

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -7,7 +7,6 @@ xmlns:unlimotion="clr-namespace:Unlimotion"
 xmlns:views="clr-namespace:Unlimotion.Views"
 xmlns:converters="clr-namespace:Unlimotion.Converters"
 xmlns:behavior="clr-namespace:Unlimotion.Behavior"
-xmlns:behaviours="clr-namespace:TestAutoCompleteBehaviour.Behaviours"
 xmlns:Interaction="using:Avalonia.Xaml.Interactivity"
 xmlns:domain="clr-namespace:Unlimotion.Domain;assembly=Unlimotion.Domain"
 xmlns:searchControl="clr-namespace:Unlimotion.Views.SearchControl"
@@ -39,18 +38,22 @@ x:Class="Unlimotion.Views.MainControl">
             <Setter Property="ColumnSpacing" Value="8"/>
             <Setter Property="Margin" Value="0,12,0,4"/>
         </Style>
-        <Style Selector="Grid.RelationPickerRow">
-            <Setter Property="ColumnSpacing" Value="8"/>
-            <Setter Property="Margin" Value="0,0,0,6"/>
+        <Style Selector="StackPanel.RelationPickerRow">
+            <Setter Property="Spacing" Value="8"/>
+            <Setter Property="Margin" Value="0,0,0,10"/>
         </Style>
-        <Style Selector="AutoCompleteBox.RelationPickerInput">
-            <Setter Property="MinimumPrefixLength" Value="0"/>
-            <Setter Property="MinimumPopulateDelay" Value="0"/>
-            <Setter Property="FilterMode" Value="None"/>
-            <Setter Property="IsTextCompletionEnabled" Value="False"/>
-            <Setter Property="ClearSelectionOnLostFocus" Value="False"/>
-            <Setter Property="MaxDropDownHeight" Value="280"/>
+        <Style Selector="Border.RelationEditorCard">
+            <Setter Property="Margin" Value="0,0,0,8"/>
+            <Setter Property="Padding" Value="10"/>
+            <Setter Property="BorderBrush" Value="#33000000"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="CornerRadius" Value="8"/>
+        </Style>
+        <Style Selector="TextBox.RelationEditorSearch">
             <Setter Property="HorizontalAlignment" Value="Stretch"/>
+        </Style>
+        <Style Selector="ListBox.RelationEditorSuggestions">
+            <Setter Property="MaxHeight" Value="240"/>
         </Style>
         <Style Selector="TreeView.TaskTree">
             <Setter Property="ContextMenu">
@@ -712,42 +715,45 @@ Content="❌"
 
                                     </StackPanel>
 
-                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto,Auto">
+                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto">
                                         <Label Content="{DynamicResource ParentsTasks}"/>
                                         <Button Grid.Column="1"
-                                                DataContext="{Binding MainWindow.CurrentItemParentsPicker}"
-                                                Content="+"
-                                                Command="{Binding OpenCommand}"
-                                                IsVisible="{Binding !IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding AddButtonAutomationId}"/>
-                                        <Button Grid.Column="2"
-                                                DataContext="{Binding MainWindow.CurrentItemParentsPicker}"
-                                                Content="{DynamicResource Cancel}"
-                                                Command="{Binding CancelCommand}"
-                                                IsVisible="{Binding IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding CancelButtonAutomationId}"/>
-                                    </Grid>
-                                    <Grid Classes="RelationPickerRow"
-                                          DataContext="{Binding MainWindow.CurrentItemParentsPicker}"
-                                          ColumnDefinitions="*,Auto"
-                                          IsVisible="{Binding IsExpanded}">
-                                        <AutoCompleteBox Classes="RelationPickerInput"
-                                                         Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                         SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
-                                                         ItemsSource="{Binding Suggestions}"
-                                                         ValueMemberBinding="{Binding Title}"
-                                                         Watermark="{Binding Watermark}"
-                                                         KeyDown="RelationPickerEditor_OnKeyDown"
-                                                         AutomationProperties.AutomationId="{Binding InputAutomationId}">
-                                            <Interaction.Behaviors>
-                                                <behaviours:AutoCompleteZeroMinimumPrefixLengthDropdownBehaviour />
-                                            </Interaction.Behaviors>
-                                        </AutoCompleteBox>
-                                        <Button Grid.Column="1"
                                                 Content="{DynamicResource Add}"
-                                                Command="{Binding ConfirmCommand}"
-                                                AutomationProperties.AutomationId="{Binding ConfirmButtonAutomationId}"/>
+                                                Click="RelationAddButton_OnClick"
+                                                Tag="Parents"
+                                                AutomationProperties.AutomationId="CurrentTaskParentsRelationAddButton"/>
                                     </Grid>
+                                    <Border Classes="RelationEditorCard"
+                                            DataContext="{Binding MainWindow.CurrentRelationEditor}"
+                                            IsVisible="{Binding IsOpenForParents}">
+                                        <StackPanel Classes="RelationPickerRow">
+                                            <TextBlock Text="{Binding Header}" FontWeight="Bold"/>
+                                            <TextBox Classes="RelationEditorSearch"
+                                                     Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     Watermark="{Binding Watermark}"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskParentsRelationAddInput"/>
+                                            <ListBox Classes="RelationEditorSuggestions"
+                                                     ItemsSource="{Binding Suggestions}"
+                                                     SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
+                                                     DoubleTapped="RelationEditorSuggestions_OnDoubleTapped"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskParentsRelationSuggestions"/>
+                                            <TextBlock Text="{Binding EmptyStateText}"
+                                                       IsVisible="{Binding !HasSuggestions}"
+                                                       Opacity="0.7"
+                                                       TextWrapping="Wrap"/>
+                                            <Grid ColumnDefinitions="Auto,Auto" ColumnSpacing="8" HorizontalAlignment="Right">
+                                                <Button Content="{DynamicResource Cancel}"
+                                                        Command="{Binding CancelCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskParentsRelationAddCancelButton"/>
+                                                <Button Grid.Column="1"
+                                                        Content="{DynamicResource Add}"
+                                                        Command="{Binding ConfirmCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskParentsRelationAddConfirmButton"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
                                     <TreeView DataContext="{Binding MainWindow}"
                                               ItemsSource="{Binding CurrentItemParents.SubTasks}"
                                               SelectionMode="Multiple"
@@ -762,42 +768,45 @@ Content="❌"
                                         </TreeView.ItemTemplate>
                                     </TreeView>
 
-                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto,Auto">
+                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto">
                                         <Label Content="{DynamicResource BlockingTasks}"/>
                                         <Button Grid.Column="1"
-                                                DataContext="{Binding MainWindow.CurrentItemBlockedByPicker}"
-                                                Content="+"
-                                                Command="{Binding OpenCommand}"
-                                                IsVisible="{Binding !IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding AddButtonAutomationId}"/>
-                                        <Button Grid.Column="2"
-                                                DataContext="{Binding MainWindow.CurrentItemBlockedByPicker}"
-                                                Content="{DynamicResource Cancel}"
-                                                Command="{Binding CancelCommand}"
-                                                IsVisible="{Binding IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding CancelButtonAutomationId}"/>
-                                    </Grid>
-                                    <Grid Classes="RelationPickerRow"
-                                          DataContext="{Binding MainWindow.CurrentItemBlockedByPicker}"
-                                          ColumnDefinitions="*,Auto"
-                                          IsVisible="{Binding IsExpanded}">
-                                        <AutoCompleteBox Classes="RelationPickerInput"
-                                                         Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                         SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
-                                                         ItemsSource="{Binding Suggestions}"
-                                                         ValueMemberBinding="{Binding Title}"
-                                                         Watermark="{Binding Watermark}"
-                                                         KeyDown="RelationPickerEditor_OnKeyDown"
-                                                         AutomationProperties.AutomationId="{Binding InputAutomationId}">
-                                            <Interaction.Behaviors>
-                                                <behaviours:AutoCompleteZeroMinimumPrefixLengthDropdownBehaviour />
-                                            </Interaction.Behaviors>
-                                        </AutoCompleteBox>
-                                        <Button Grid.Column="1"
                                                 Content="{DynamicResource Add}"
-                                                Command="{Binding ConfirmCommand}"
-                                                AutomationProperties.AutomationId="{Binding ConfirmButtonAutomationId}"/>
+                                                Click="RelationAddButton_OnClick"
+                                                Tag="Blocking"
+                                                AutomationProperties.AutomationId="CurrentTaskBlockingRelationAddButton"/>
                                     </Grid>
+                                    <Border Classes="RelationEditorCard"
+                                            DataContext="{Binding MainWindow.CurrentRelationEditor}"
+                                            IsVisible="{Binding IsOpenForBlocking}">
+                                        <StackPanel Classes="RelationPickerRow">
+                                            <TextBlock Text="{Binding Header}" FontWeight="Bold"/>
+                                            <TextBox Classes="RelationEditorSearch"
+                                                     Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     Watermark="{Binding Watermark}"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskBlockingRelationAddInput"/>
+                                            <ListBox Classes="RelationEditorSuggestions"
+                                                     ItemsSource="{Binding Suggestions}"
+                                                     SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
+                                                     DoubleTapped="RelationEditorSuggestions_OnDoubleTapped"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskBlockingRelationSuggestions"/>
+                                            <TextBlock Text="{Binding EmptyStateText}"
+                                                       IsVisible="{Binding !HasSuggestions}"
+                                                       Opacity="0.7"
+                                                       TextWrapping="Wrap"/>
+                                            <Grid ColumnDefinitions="Auto,Auto" ColumnSpacing="8" HorizontalAlignment="Right">
+                                                <Button Content="{DynamicResource Cancel}"
+                                                        Command="{Binding CancelCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskBlockingRelationAddCancelButton"/>
+                                                <Button Grid.Column="1"
+                                                        Content="{DynamicResource Add}"
+                                                        Command="{Binding ConfirmCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskBlockingRelationAddConfirmButton"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
                                     <TreeView DataContext="{Binding MainWindow}"
                                               ItemsSource="{Binding CurrentItemBlockedBy.SubTasks}"
                                               SelectionMode="Multiple"
@@ -812,42 +821,45 @@ Content="❌"
                                         </TreeView.ItemTemplate>
                                     </TreeView>
 
-                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto,Auto">
+                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto">
                                         <Label Content="{DynamicResource ContainingTasks}"/>
                                         <Button Grid.Column="1"
-                                                DataContext="{Binding MainWindow.CurrentItemContainsPicker}"
-                                                Content="+"
-                                                Command="{Binding OpenCommand}"
-                                                IsVisible="{Binding !IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding AddButtonAutomationId}"/>
-                                        <Button Grid.Column="2"
-                                                DataContext="{Binding MainWindow.CurrentItemContainsPicker}"
-                                                Content="{DynamicResource Cancel}"
-                                                Command="{Binding CancelCommand}"
-                                                IsVisible="{Binding IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding CancelButtonAutomationId}"/>
-                                    </Grid>
-                                    <Grid Classes="RelationPickerRow"
-                                          DataContext="{Binding MainWindow.CurrentItemContainsPicker}"
-                                          ColumnDefinitions="*,Auto"
-                                          IsVisible="{Binding IsExpanded}">
-                                        <AutoCompleteBox Classes="RelationPickerInput"
-                                                         Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                         SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
-                                                         ItemsSource="{Binding Suggestions}"
-                                                         ValueMemberBinding="{Binding Title}"
-                                                         Watermark="{Binding Watermark}"
-                                                         KeyDown="RelationPickerEditor_OnKeyDown"
-                                                         AutomationProperties.AutomationId="{Binding InputAutomationId}">
-                                            <Interaction.Behaviors>
-                                                <behaviours:AutoCompleteZeroMinimumPrefixLengthDropdownBehaviour />
-                                            </Interaction.Behaviors>
-                                        </AutoCompleteBox>
-                                        <Button Grid.Column="1"
                                                 Content="{DynamicResource Add}"
-                                                Command="{Binding ConfirmCommand}"
-                                                AutomationProperties.AutomationId="{Binding ConfirmButtonAutomationId}"/>
+                                                Click="RelationAddButton_OnClick"
+                                                Tag="Containing"
+                                                AutomationProperties.AutomationId="CurrentTaskContainingRelationAddButton"/>
                                     </Grid>
+                                    <Border Classes="RelationEditorCard"
+                                            DataContext="{Binding MainWindow.CurrentRelationEditor}"
+                                            IsVisible="{Binding IsOpenForContaining}">
+                                        <StackPanel Classes="RelationPickerRow">
+                                            <TextBlock Text="{Binding Header}" FontWeight="Bold"/>
+                                            <TextBox Classes="RelationEditorSearch"
+                                                     Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     Watermark="{Binding Watermark}"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskContainingRelationAddInput"/>
+                                            <ListBox Classes="RelationEditorSuggestions"
+                                                     ItemsSource="{Binding Suggestions}"
+                                                     SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
+                                                     DoubleTapped="RelationEditorSuggestions_OnDoubleTapped"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskContainingRelationSuggestions"/>
+                                            <TextBlock Text="{Binding EmptyStateText}"
+                                                       IsVisible="{Binding !HasSuggestions}"
+                                                       Opacity="0.7"
+                                                       TextWrapping="Wrap"/>
+                                            <Grid ColumnDefinitions="Auto,Auto" ColumnSpacing="8" HorizontalAlignment="Right">
+                                                <Button Content="{DynamicResource Cancel}"
+                                                        Command="{Binding CancelCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskContainingRelationAddCancelButton"/>
+                                                <Button Grid.Column="1"
+                                                        Content="{DynamicResource Add}"
+                                                        Command="{Binding ConfirmCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskContainingRelationAddConfirmButton"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
                                     <TreeView DataContext="{Binding MainWindow}"
                                               ItemsSource="{Binding CurrentItemContains.SubTasks}"
                                               SelectionMode="Multiple"
@@ -862,42 +874,45 @@ Content="❌"
                                         </TreeView.ItemTemplate>
                                     </TreeView>
 
-                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto,Auto">
+                                    <Grid Classes="RelationSectionHeader" ColumnDefinitions="*,Auto">
                                         <Label Content="{DynamicResource BlockedTasks}"/>
                                         <Button Grid.Column="1"
-                                                DataContext="{Binding MainWindow.CurrentItemBlocksPicker}"
-                                                Content="+"
-                                                Command="{Binding OpenCommand}"
-                                                IsVisible="{Binding !IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding AddButtonAutomationId}"/>
-                                        <Button Grid.Column="2"
-                                                DataContext="{Binding MainWindow.CurrentItemBlocksPicker}"
-                                                Content="{DynamicResource Cancel}"
-                                                Command="{Binding CancelCommand}"
-                                                IsVisible="{Binding IsExpanded}"
-                                                AutomationProperties.AutomationId="{Binding CancelButtonAutomationId}"/>
-                                    </Grid>
-                                    <Grid Classes="RelationPickerRow"
-                                          DataContext="{Binding MainWindow.CurrentItemBlocksPicker}"
-                                          ColumnDefinitions="*,Auto"
-                                          IsVisible="{Binding IsExpanded}">
-                                        <AutoCompleteBox Classes="RelationPickerInput"
-                                                         Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                                                         SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
-                                                         ItemsSource="{Binding Suggestions}"
-                                                         ValueMemberBinding="{Binding Title}"
-                                                         Watermark="{Binding Watermark}"
-                                                         KeyDown="RelationPickerEditor_OnKeyDown"
-                                                         AutomationProperties.AutomationId="{Binding InputAutomationId}">
-                                            <Interaction.Behaviors>
-                                                <behaviours:AutoCompleteZeroMinimumPrefixLengthDropdownBehaviour />
-                                            </Interaction.Behaviors>
-                                        </AutoCompleteBox>
-                                        <Button Grid.Column="1"
                                                 Content="{DynamicResource Add}"
-                                                Command="{Binding ConfirmCommand}"
-                                                AutomationProperties.AutomationId="{Binding ConfirmButtonAutomationId}"/>
+                                                Click="RelationAddButton_OnClick"
+                                                Tag="Blocked"
+                                                AutomationProperties.AutomationId="CurrentTaskBlockedRelationAddButton"/>
                                     </Grid>
+                                    <Border Classes="RelationEditorCard"
+                                            DataContext="{Binding MainWindow.CurrentRelationEditor}"
+                                            IsVisible="{Binding IsOpenForBlocked}">
+                                        <StackPanel Classes="RelationPickerRow">
+                                            <TextBlock Text="{Binding Header}" FontWeight="Bold"/>
+                                            <TextBox Classes="RelationEditorSearch"
+                                                     Text="{Binding Query, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                                     Watermark="{Binding Watermark}"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskBlockedRelationAddInput"/>
+                                            <ListBox Classes="RelationEditorSuggestions"
+                                                     ItemsSource="{Binding Suggestions}"
+                                                     SelectedItem="{Binding SelectedCandidate, Mode=TwoWay}"
+                                                     DoubleTapped="RelationEditorSuggestions_OnDoubleTapped"
+                                                     KeyDown="RelationEditorControl_OnKeyDown"
+                                                     AutomationProperties.AutomationId="CurrentTaskBlockedRelationSuggestions"/>
+                                            <TextBlock Text="{Binding EmptyStateText}"
+                                                       IsVisible="{Binding !HasSuggestions}"
+                                                       Opacity="0.7"
+                                                       TextWrapping="Wrap"/>
+                                            <Grid ColumnDefinitions="Auto,Auto" ColumnSpacing="8" HorizontalAlignment="Right">
+                                                <Button Content="{DynamicResource Cancel}"
+                                                        Command="{Binding CancelCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskBlockedRelationAddCancelButton"/>
+                                                <Button Grid.Column="1"
+                                                        Content="{DynamicResource Add}"
+                                                        Command="{Binding ConfirmCommand}"
+                                                        AutomationProperties.AutomationId="CurrentTaskBlockedRelationAddConfirmButton"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
                                     <TreeView DataContext="{Binding MainWindow}"
                                               ItemsSource="{Binding CurrentItemBlocks.SubTasks}"
                                               SelectionMode="Multiple"

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -39,7 +40,9 @@ namespace Unlimotion.Views
         // Static dependencies - set once during app initialization
         public static IDialogs? DialogsInstance { get; set; }
         private const int MaxTitleFocusRetries = 5;
+        private const int MaxRelationEditorFocusRetries = 5;
         private IDisposable? _titleFocusSubscription;
+        private IDisposable? _relationEditorFocusSubscription;
         private MainWindowViewModel? _treeCommandViewModel;
         private TreeView? _activeTaskTree;
         private TreeView? _contextMenuTree;
@@ -100,6 +103,8 @@ namespace Unlimotion.Views
         {
             _titleFocusSubscription?.Dispose();
             _titleFocusSubscription = null;
+            _relationEditorFocusSubscription?.Dispose();
+            _relationEditorFocusSubscription = null;
             if (_treeCommandViewModel != null)
             {
                 _treeCommandViewModel.ExecuteTreeCommandAction = null;
@@ -116,6 +121,13 @@ namespace Unlimotion.Views
                 vm.ExecuteTreeCommandAction = ExecuteTreeCommand;
                 _titleFocusSubscription = vm.WhenAnyValue(m => m.TitleFocusRequestVersion)
                     .Subscribe(requestVersion => QueueTitleFocus(requestVersion, vm.CurrentTaskItem?.Id, MaxTitleFocusRetries));
+                _relationEditorFocusSubscription = vm.CurrentRelationEditor
+                    .WhenAnyValue(m => m.FocusRequestVersion)
+                    .Subscribe(requestVersion =>
+                        QueueRelationEditorFocus(
+                            requestVersion,
+                            vm.CurrentRelationEditor.InputAutomationId,
+                            MaxRelationEditorFocusRetries));
                 vm.MoveToPath = ReactiveCommand.CreateFromTask(async () =>
                 {
                     if (vm.CurrentTaskItem == null)
@@ -213,6 +225,69 @@ namespace Unlimotion.Views
             }
 
             QueueTitleFocus(requestVersion, targetTaskId, retriesRemaining - 1);
+        }
+
+        private void QueueRelationEditorFocus(long requestVersion, string? automationId, int retriesRemaining)
+        {
+            if (requestVersion <= 0 || string.IsNullOrWhiteSpace(automationId))
+            {
+                return;
+            }
+
+            Dispatcher.UIThread.Post(
+                () => TryFocusRelationEditor(requestVersion, automationId, retriesRemaining),
+                DispatcherPriority.Background);
+        }
+
+        private void TryFocusRelationEditor(long requestVersion, string automationId, int retriesRemaining)
+        {
+            if (DataContext is not MainWindowViewModel vm)
+            {
+                return;
+            }
+
+            var editor = vm.CurrentRelationEditor;
+            if (!editor.IsOpen ||
+                editor.FocusRequestVersion != requestVersion ||
+                !string.Equals(editor.InputAutomationId, automationId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var input = this.GetVisualDescendants()
+                .OfType<TextBox>()
+                .FirstOrDefault(candidate =>
+                    string.Equals(
+                        AutomationProperties.GetAutomationId(candidate),
+                        automationId,
+                        StringComparison.Ordinal) &&
+                    candidate.IsAttachedToVisualTree() &&
+                    candidate.IsVisible &&
+                    candidate.IsEnabled);
+
+            if (input == null)
+            {
+                RetryRelationEditorFocus(requestVersion, automationId, retriesRemaining);
+                return;
+            }
+
+            if (!input.Focus())
+            {
+                RetryRelationEditorFocus(requestVersion, automationId, retriesRemaining);
+                return;
+            }
+
+            input.CaretIndex = input.Text?.Length ?? 0;
+        }
+
+        private void RetryRelationEditorFocus(long requestVersion, string automationId, int retriesRemaining)
+        {
+            if (retriesRemaining <= 0)
+            {
+                return;
+            }
+
+            QueueRelationEditorFocus(requestVersion, automationId, retriesRemaining - 1);
         }
 
         private const string CustomFormat = "application/xxx-unlimotion-task";
@@ -777,28 +852,54 @@ namespace Unlimotion.Views
             }
         }
 
-        private void RelationPickerEditor_OnKeyDown(object? sender, KeyEventArgs e)
+        private void RelationAddButton_OnClick(object? sender, RoutedEventArgs e)
         {
-            if (sender is not Control { DataContext: TaskRelationPickerViewModel picker })
+            if (DataContext is not MainWindowViewModel vm ||
+                sender is not Control control ||
+                !Enum.TryParse<TaskRelationKind>(control.Tag?.ToString(), out var kind))
+            {
+                return;
+            }
+
+            vm.OpenRelationEditor(kind);
+        }
+
+        private void RelationEditorControl_OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (sender is not Control { DataContext: TaskRelationEditorViewModel editor })
             {
                 return;
             }
 
             if (e.Key == Key.Enter)
             {
-                if (picker.ConfirmCommand.CanExecute(null))
+                if (editor.ConfirmCommand.CanExecute(null))
                 {
-                    picker.ConfirmCommand.Execute(null);
+                    editor.ConfirmCommand.Execute(null);
                     e.Handled = true;
                 }
             }
             else if (e.Key == Key.Escape)
             {
-                if (picker.CancelCommand.CanExecute(null))
+                if (editor.CancelCommand.CanExecute(null))
                 {
-                    picker.CancelCommand.Execute(null);
+                    editor.CancelCommand.Execute(null);
                     e.Handled = true;
                 }
+            }
+        }
+
+        private void RelationEditorSuggestions_OnDoubleTapped(object? sender, TappedEventArgs e)
+        {
+            if (sender is not Control { DataContext: TaskRelationEditorViewModel editor })
+            {
+                return;
+            }
+
+            if (editor.ConfirmCommand.CanExecute(null))
+            {
+                editor.ConfirmCommand.Execute(null);
+                e.Handled = true;
             }
         }
 
@@ -1332,7 +1433,24 @@ namespace Unlimotion.Views
         {
             return IsControlOrAncestor<TextBox>(control) ||
                    IsControlOrAncestor<AutoCompleteBox>(control) ||
-                   IsControlOrAncestor<NumericUpDown>(control);
+                   IsControlOrAncestor<NumericUpDown>(control) ||
+                   IsRelationEditorSuggestionsOrAncestor(control);
+        }
+
+        private static bool IsRelationEditorSuggestionsOrAncestor(Control control)
+        {
+            Control? current = control;
+            while (current != null)
+            {
+                if (current is ListBox listBox && listBox.DataContext is TaskRelationEditorViewModel)
+                {
+                    return true;
+                }
+
+                current = current.FindParent<Control>();
+            }
+
+            return false;
         }
 
         private static bool IsControlOrAncestor<TControl>(Control control)

--- a/tests/Unlimotion.UiTests.Authoring/Pages/MainWindowPage.cs
+++ b/tests/Unlimotion.UiTests.Authoring/Pages/MainWindowPage.cs
@@ -10,7 +10,19 @@ namespace Unlimotion.UiTests.Authoring.Pages;
 [UiControl("CurrentTaskParentsRelationAddButton", UiControlType.Button, "CurrentTaskParentsRelationAddButton")]
 [UiControl("CurrentTaskParentsRelationAddInput", UiControlType.AutomationElement, "CurrentTaskParentsRelationAddInput")]
 [UiControl("CurrentTaskParentsRelationAddCancelButton", UiControlType.Button, "CurrentTaskParentsRelationAddCancelButton")]
+[UiControl("CurrentTaskBlockingRelationAddButton", UiControlType.Button, "CurrentTaskBlockingRelationAddButton")]
+[UiControl("CurrentTaskBlockingRelationAddInput", UiControlType.AutomationElement, "CurrentTaskBlockingRelationAddInput")]
+[UiControl("CurrentTaskBlockingRelationAddCancelButton", UiControlType.Button, "CurrentTaskBlockingRelationAddCancelButton")]
+[UiControl("CurrentTaskContainingRelationAddButton", UiControlType.Button, "CurrentTaskContainingRelationAddButton")]
+[UiControl("CurrentTaskContainingRelationAddInput", UiControlType.AutomationElement, "CurrentTaskContainingRelationAddInput")]
+[UiControl("CurrentTaskContainingRelationAddCancelButton", UiControlType.Button, "CurrentTaskContainingRelationAddCancelButton")]
+[UiControl("CurrentTaskBlockedRelationAddButton", UiControlType.Button, "CurrentTaskBlockedRelationAddButton")]
+[UiControl("CurrentTaskBlockedRelationAddInput", UiControlType.AutomationElement, "CurrentTaskBlockedRelationAddInput")]
+[UiControl("CurrentTaskBlockedRelationAddCancelButton", UiControlType.Button, "CurrentTaskBlockedRelationAddCancelButton")]
 [UiControl("CurrentItemParentsTree", UiControlType.Tree, "CurrentItemParentsTree")]
+[UiControl("CurrentItemBlockedByTree", UiControlType.Tree, "CurrentItemBlockedByTree")]
+[UiControl("CurrentItemContainsTree", UiControlType.Tree, "CurrentItemContainsTree")]
+[UiControl("CurrentItemBlocksTree", UiControlType.Tree, "CurrentItemBlocksTree")]
 public sealed partial class MainWindowPage : UiPage
 {
     public MainWindowPage(IUiControlResolver resolver) : base(resolver)

--- a/tests/Unlimotion.UiTests.Authoring/Tests/MainWindowScenariosBase.cs
+++ b/tests/Unlimotion.UiTests.Authoring/Tests/MainWindowScenariosBase.cs
@@ -31,6 +31,11 @@ public abstract partial class MainWindowScenariosBase<TSession> : UiTestBase<TSe
 
         Page.ClickButton(static page => page.CurrentTaskParentsRelationAddButton);
 
+        var input = WaitUntil(
+            () => TryResolveDuringWait(() => Page.CurrentTaskParentsRelationAddInput),
+            static control => control is not null,
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Parents relation editor input did not open.")!;
         var cancelButton = WaitUntil(
             () => TryResolveDuringWait(() => Page.CurrentTaskParentsRelationAddCancelButton),
             static control => control is not null,
@@ -42,10 +47,108 @@ public abstract partial class MainWindowScenariosBase<TSession> : UiTestBase<TSe
             await UiAssert.TextEqualsAsync(
                 () => Page.CurrentTaskTitleTextBox.Text,
                 UnlimotionAppLaunchHost.CurrentTaskTitle);
+            await Assert.That(input.AutomationId)
+                .IsEqualTo("CurrentTaskParentsRelationAddInput");
             await Assert.That(cancelButton.AutomationId)
                 .IsEqualTo("CurrentTaskParentsRelationAddCancelButton");
             await Assert.That(Page.CurrentItemParentsTree.AutomationId)
                 .IsEqualTo("CurrentItemParentsTree");
+        }
+
+        cancelButton.Invoke();
+    }
+
+    [Test]
+    [NotInParallel(DesktopUiConstraint)]
+    public async Task Card_blocking_relation_editor_can_be_opened_from_task_card()
+    {
+        await Assert.That(Page.MainTabs.AutomationId).IsEqualTo("MainTabs");
+
+        Page.ClickButton(static page => page.CurrentTaskBlockingRelationAddButton);
+
+        var input = WaitUntil(
+            () => TryResolveDuringWait(() => Page.CurrentTaskBlockingRelationAddInput),
+            static control => control is not null,
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Blocking relation editor input did not open.")!;
+        var cancelButton = WaitUntil(
+            () => TryResolveDuringWait(() => Page.CurrentTaskBlockingRelationAddCancelButton),
+            static control => control is not null,
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Blocking relation editor did not open.")!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(input.AutomationId)
+                .IsEqualTo("CurrentTaskBlockingRelationAddInput");
+            await Assert.That(cancelButton.AutomationId)
+                .IsEqualTo("CurrentTaskBlockingRelationAddCancelButton");
+            await Assert.That(Page.CurrentItemBlockedByTree.AutomationId)
+                .IsEqualTo("CurrentItemBlockedByTree");
+        }
+
+        cancelButton.Invoke();
+    }
+
+    [Test]
+    [NotInParallel(DesktopUiConstraint)]
+    public async Task Card_containing_relation_editor_can_be_opened_from_task_card()
+    {
+        await Assert.That(Page.MainTabs.AutomationId).IsEqualTo("MainTabs");
+
+        Page.ClickButton(static page => page.CurrentTaskContainingRelationAddButton);
+
+        var input = WaitUntil(
+            () => TryResolveDuringWait(() => Page.CurrentTaskContainingRelationAddInput),
+            static control => control is not null,
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Containing relation editor input did not open.")!;
+        var cancelButton = WaitUntil(
+            () => TryResolveDuringWait(() => Page.CurrentTaskContainingRelationAddCancelButton),
+            static control => control is not null,
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Containing relation editor did not open.")!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(input.AutomationId)
+                .IsEqualTo("CurrentTaskContainingRelationAddInput");
+            await Assert.That(cancelButton.AutomationId)
+                .IsEqualTo("CurrentTaskContainingRelationAddCancelButton");
+            await Assert.That(Page.CurrentItemContainsTree.AutomationId)
+                .IsEqualTo("CurrentItemContainsTree");
+        }
+
+        cancelButton.Invoke();
+    }
+
+    [Test]
+    [NotInParallel(DesktopUiConstraint)]
+    public async Task Card_blocked_relation_editor_can_be_opened_from_task_card()
+    {
+        await Assert.That(Page.MainTabs.AutomationId).IsEqualTo("MainTabs");
+
+        Page.ClickButton(static page => page.CurrentTaskBlockedRelationAddButton);
+
+        var input = WaitUntil(
+            () => TryResolveDuringWait(() => Page.CurrentTaskBlockedRelationAddInput),
+            static control => control is not null,
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Blocked relation editor input did not open.")!;
+        var cancelButton = WaitUntil(
+            () => TryResolveDuringWait(() => Page.CurrentTaskBlockedRelationAddCancelButton),
+            static control => control is not null,
+            timeout: TimeSpan.FromSeconds(10),
+            timeoutMessage: "Blocked relation editor did not open.")!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(input.AutomationId)
+                .IsEqualTo("CurrentTaskBlockedRelationAddInput");
+            await Assert.That(cancelButton.AutomationId)
+                .IsEqualTo("CurrentTaskBlockedRelationAddCancelButton");
+            await Assert.That(Page.CurrentItemBlocksTree.AutomationId)
+                .IsEqualTo("CurrentItemBlocksTree");
         }
 
         cancelButton.Invoke();


### PR DESCRIPTION
## What changed
- replaced the old task-card relation picker flow with a shared relation editor model and updated task-card UI
- restored stable automation ids for all relation sections and removed duplicate ids across hidden editors
- updated native headless and AppAutomation headless coverage for opening, focusing, and using the relation editor from the task card

## Why
The previous relation-picker implementation had fragile UI behavior and side effects in the task card. It could expose duplicate automation ids, misdirect autofocus into hidden controls, and regress AppAutomation selectors for non-parent relation sections.

## Impact
- relation editing from the task card is more predictable and easier to automate
- focus now lands on the visible input for the section the user actually opened
- existing selector contracts for task-card relation sections stay stable

## Root cause
The redesign initially rendered the same editor state in multiple sections at once while reusing shared automation ids. That made control discovery ambiguous and caused focus/automation issues outside the parents section.

## Validation
- `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj`
- `dotnet build tests\Unlimotion.UiTests.Headless\Unlimotion.UiTests.Headless.csproj`
- `src\Unlimotion.Test\bin\Debug\net10.0\Unlimotion.Test.exe --treenode-filter "/*/*/MainControlRelationPickerUiTests/*" --no-progress --output Detailed`
- `tests\Unlimotion.UiTests.Headless\bin\Debug\net10.0\Unlimotion.UiTests.Headless.exe --treenode-filter "/*/*/MainWindowHeadlessTests/*" --no-progress --output Detailed`

## Notes
- AppAutomation headless tests still print pre-existing `FileSystemWatcher` cleanup exceptions for deleted temp directories after the suite finishes, but the test run itself passes.