### PR TITLE
Fix wanted task title bold styling

### DIFF
--- a/src/Unlimotion.Test/TaskImportanceUiTests.cs
+++ b/src/Unlimotion.Test/TaskImportanceUiTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Unlimotion;
+using Unlimotion.ViewModel;
+using Unlimotion.Views;
+
+namespace Unlimotion.Test;
+
+[NotInParallel]
+public class TaskImportanceUiTests
+{
+    [Test]
+    public async Task WantedTaskTitle_ShouldBeBold_InAllTasksTreeAndParentRelationTree()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+                vm.DetailsAreOpen = true;
+
+                var importantRoot = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
+                var currentTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.SubTask22Id);
+
+                await Assert.That(importantRoot).IsNotNull();
+                await Assert.That(currentTask).IsNotNull();
+
+                importantRoot!.Wanted = true;
+                vm.CurrentTaskItem = currentTask;
+                vm.SelectCurrentTask();
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var allTasksText = WaitForTaskTitleTextBlock(
+                    view,
+                    MainWindowViewModelFixture.RootTask2Id,
+                    "AllTasksTree",
+                    importantRoot.Title);
+                var relationText = WaitForTaskTitleTextBlock(
+                    view,
+                    MainWindowViewModelFixture.RootTask2Id,
+                    "CurrentItemParentsTree",
+                    importantRoot.Title);
+
+                await Assert.That(allTasksText.FontWeight).IsEqualTo(FontWeight.Bold);
+                await Assert.That(relationText.FontWeight).IsEqualTo(FontWeight.Bold);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task WantedTaskTitle_ShouldBeBold_InRoadmapGraph()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var importantRoot = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
+                await Assert.That(importantRoot).IsNotNull();
+
+                importantRoot!.Wanted = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = view.GetVisualDescendants().OfType<GraphControl>().FirstOrDefault();
+                await Assert.That(graphControl).IsNotNull();
+
+                var graphText = WaitForTaskTitleTextBlock(
+                    graphControl!,
+                    MainWindowViewModelFixture.RootTask2Id,
+                    title: importantRoot.Title);
+
+                await Assert.That(graphText.FontWeight).IsEqualTo(FontWeight.Bold);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    private static Window CreateWindow(Control content)
+    {
+        return new Window
+        {
+            Width = 1400,
+            Height = 900,
+            Content = content
+        };
+    }
+
+    private static TextBlock WaitForTaskTitleTextBlock(
+        Control root,
+        string taskId,
+        string? ancestorAutomationId = null,
+        string? title = null,
+        int timeoutMilliseconds = 3000)
+    {
+        TextBlock? textBlock = null;
+        var ready = SpinWait.SpinUntil(() =>
+        {
+            Dispatcher.UIThread.RunJobs();
+            textBlock = FindTaskTitleTextBlock(root, taskId, ancestorAutomationId, title);
+            return textBlock != null;
+        }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
+
+        if (!ready || textBlock == null)
+        {
+            throw new InvalidOperationException($"Title TextBlock for task '{taskId}' was not found.");
+        }
+
+        return textBlock;
+    }
+
+    private static TextBlock? FindTaskTitleTextBlock(
+        Control root,
+        string taskId,
+        string? ancestorAutomationId,
+        string? title)
+    {
+        var descendants = root.GetVisualDescendants().OfType<TextBlock>();
+        if (!string.IsNullOrWhiteSpace(ancestorAutomationId))
+        {
+            descendants = descendants.Where(textBlock =>
+                textBlock.FindAncestorOfType<Control>(includeSelf: true) is { } control &&
+                HasAncestorWithAutomationId(control, ancestorAutomationId));
+        }
+
+        return descendants.FirstOrDefault(textBlock =>
+            textBlock.DataContext is TaskItemViewModel task &&
+            task.Id == taskId &&
+            (title == null || textBlock.Text == title));
+    }
+
+    private static bool HasAncestorWithAutomationId(Control control, string automationId)
+    {
+        for (Control? current = control; current != null; current = current.Parent as Control)
+        {
+            if (Avalonia.Automation.AutomationProperties.GetAutomationId(current) == automationId)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Unlimotion/App.axaml
+++ b/src/Unlimotion/App.axaml
@@ -29,6 +29,9 @@
         <Style Selector="Label.IsWanted">
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
+        <Style Selector="TextBlock.IsWanted">
+            <Setter Property="FontWeight" Value="Bold"/>
+        </Style>
 		<Style Selector="TextBlock.IsCanBeCompleted">
 			<Setter Property="Opacity" Value="0.4"/>
 		</Style>

--- a/src/Unlimotion/Views/GraphControl.axaml
+++ b/src/Unlimotion/Views/GraphControl.axaml
@@ -52,7 +52,7 @@
                                            AutomationProperties.AutomationId="TaskRepeaterGraphMarker"
                                            Margin="4,0,4,0"
                                            VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="3" Text="{Binding TitleWithoutEmoji}" TextWrapping="Wrap" MaxWidth="300"  VerticalAlignment="Center" Classes.highlighted="{Binding IsHighlighted}" Classes.IsCanBeCompleted="{Binding !IsCanBeCompleted}"/>
+                                <TextBlock Grid.Column="3" Text="{Binding TitleWithoutEmoji}" TextWrapping="Wrap" MaxWidth="300"  VerticalAlignment="Center" Classes.highlighted="{Binding IsHighlighted}" Classes.IsWanted="{Binding Wanted}" Classes.IsCanBeCompleted="{Binding !IsCanBeCompleted}"/>
 							</Grid>
 							<!--<Border BorderBrush="Gray" CornerRadius="4" BorderThickness="1" Background="Transparent" DragDrop.AllowDrop="True" PointerPressed="InputElement_OnPointerPressed">
 								<Grid ColumnDefinitions="Auto, *" Margin="5,0">


### PR DESCRIPTION
## Summary

Fixes wanted task titles not rendering bold in UI surfaces that use `TextBlock` templates.

## Root Cause

The application had a global `Label.IsWanted` style, but the AllTasks tree and task-card relation trees render task titles through the shared `TaskItemViewModel` `TextBlock` template. Roadmap graph titles also did not apply the `IsWanted` class at all.

## Changes

- Added a global `TextBlock.IsWanted` style that sets `FontWeight=Bold`.
- Applied `Classes.IsWanted` to Roadmap graph task titles.
- Added headless UI regression tests for AllTasks, the parent relation tree, and Roadmap graph title bolding.

## Validation

- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/TaskImportanceUiTests/*" --no-progress`

Known existing warnings remain for vulnerable package advisories and nullable diagnostics.