### PR TITLE
Stabilize test startup state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ StyleCopReport.xml
 *.tmp
 *.tmp_proj
 *_wpftmp.csproj
+.tmp-tunit-diag/
 *.log
 *.vspscc
 *.vssscc

--- a/src/Unlimotion.Test/BackupViaGitServiceTests.cs
+++ b/src/Unlimotion.Test/BackupViaGitServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using LibGit2Sharp;
@@ -13,6 +14,7 @@ public sealed class BackupViaGitServiceTests : IDisposable
 {
     private readonly string _rootPath;
     private readonly string _configPath;
+    private readonly List<IDisposable> _configurationDisposables = [];
 
     public BackupViaGitServiceTests()
     {
@@ -24,6 +26,11 @@ public sealed class BackupViaGitServiceTests : IDisposable
 
     public void Dispose()
     {
+        foreach (var disposable in _configurationDisposables)
+        {
+            disposable.Dispose();
+        }
+
         TryDeleteDirectory(_rootPath);
     }
 
@@ -281,6 +288,12 @@ public sealed class BackupViaGitServiceTests : IDisposable
         string remoteName = "origin")
     {
         configuration = WritableJsonConfigurationFabric.Create(_configPath);
+
+        if (configuration is IDisposable disposable)
+        {
+            _configurationDisposables.Add(disposable);
+        }
+
         configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.Path)).Set(localPath);
         configuration.GetSection("Git").GetSection(nameof(GitSettings.RemoteUrl)).Set(remotePath);
         configuration.GetSection("Git").GetSection(nameof(GitSettings.RemoteName)).Set(remoteName);

--- a/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
+++ b/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
@@ -12,7 +12,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class BreadcrumbEmojiUiTests
 {
     [Test]

--- a/src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs
+++ b/src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs
@@ -7,7 +7,7 @@ using Unlimotion.ViewModel.Localization;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class LocalizationDisplayDefinitionTests
 {
     [Test]

--- a/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
+++ b/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
@@ -11,7 +11,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class MainControlAvailabilityUiTests
 {
     [Test]

--- a/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
+++ b/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
@@ -12,7 +12,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class MainControlDateQuickSelectionUiTests
 {
     [Test]

--- a/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
+++ b/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
@@ -17,7 +17,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class MainControlRelationPickerUiTests
 {
     [Test]

--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -19,7 +19,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class MainControlTreeCommandsUiTests
 {
     [Test]

--- a/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
+++ b/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
@@ -22,7 +22,7 @@ using WritableJsonConfiguration;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class MainScreenLoadingUiTests
 {
     [Test]
@@ -169,11 +169,16 @@ public class MainScreenLoadingUiTests
     private sealed class TestMainWindowContext : IDisposable
     {
         private readonly string _configPath;
+        private readonly IDisposable? _configurationDisposable;
 
-        private TestMainWindowContext(string configPath, MainWindowViewModel mainWindowViewModel)
+        private TestMainWindowContext(
+            string configPath,
+            MainWindowViewModel mainWindowViewModel,
+            IDisposable? configurationDisposable)
         {
             _configPath = configPath;
             MainWindowViewModel = mainWindowViewModel;
+            _configurationDisposable = configurationDisposable;
         }
 
         public MainWindowViewModel MainWindowViewModel { get; }
@@ -199,11 +204,16 @@ public class MainScreenLoadingUiTests
             TaskItemViewModel.NotificationManagerInstance = notificationManager;
             TaskItemViewModel.MainWindowInstance = mainWindowViewModel;
 
-            return new TestMainWindowContext(configPath, mainWindowViewModel);
+            return new TestMainWindowContext(
+                configPath,
+                mainWindowViewModel,
+                configuration as IDisposable);
         }
 
         public void Dispose()
         {
+            _configurationDisposable?.Dispose();
+
             if (File.Exists(_configPath))
             {
                 File.Delete(_configPath);

--- a/src/Unlimotion.Test/MainWindowViewModelFixture.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
@@ -14,8 +14,10 @@ namespace Unlimotion.Test
         private const string DefaultConfigName = "TestSettings.json";
         private string UniquiId => guid.ToString()!;
         private readonly ThreadLocal<Guid> guid;
+        private readonly IDisposable? configurationDisposable;
 
         private readonly string uniqueConfigName;
+        private bool isCleaned;
         public MainWindowViewModel MainWindowViewModelTest { get; private set; }
         public readonly string DefaultTasksFolderPath;
         private readonly string defaultSnapshotsFolderPath;
@@ -71,6 +73,7 @@ namespace Unlimotion.Test
 
             // Create configuration
             IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(uniqueConfigName);
+            configurationDisposable = configuration as IDisposable;
 
             // Create mapper
             var mapper = AppModelMapping.ConfigureMapping();
@@ -80,13 +83,8 @@ namespace Unlimotion.Test
 
             // Create storage factory
             var storageFactory = new TaskStorageFactory(configuration, mapper, notificationManagerMock);
-            TaskStorageFactory.DefaultStoragePath = DefaultTasksFolderPath;
-
             // Create file storage
             storageFactory.CreateFileStorage(DefaultTasksFolderPath);
-
-            // Set up static instances
-            TaskItemViewModel.NotificationManagerInstance = notificationManagerMock;
 
             // Create SettingsViewModel
             var settingsViewModel = new SettingsViewModel(configuration);
@@ -99,9 +97,6 @@ namespace Unlimotion.Test
                 () => storageFactory.CurrentStorage,
                 settingsViewModel
             );
-
-            // Set static MainWindow reference for TaskItemViewModel
-            TaskItemViewModel.MainWindowInstance = MainWindowViewModelTest;
         }
 
         private void CopyTaskFromSnapshotsFolder()
@@ -134,6 +129,14 @@ namespace Unlimotion.Test
 
         public void CleanTasks()
         {
+            if (isCleaned)
+            {
+                return;
+            }
+
+            isCleaned = true;
+            configurationDisposable?.Dispose();
+
             if (File.Exists(uniqueConfigName))
             {
                 Try(() => File.Delete(uniqueConfigName));

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Avalonia.Headless;
+using Avalonia.Threading;
 using KellermanSoftware.CompareNetObjects;
 using Unlimotion.Domain;
 using Unlimotion.ViewModel;
@@ -14,28 +16,76 @@ namespace Unlimotion.Test
 {
     public class BaseModelTests : IDisposable
     {
-        protected readonly MainWindowViewModelFixture fixture;
-        protected readonly MainWindowViewModel mainWindowVM;
+        private MainWindowViewModelFixture? _fixture;
+        private MainWindowViewModel? _mainWindowVM;
+        private ITaskStorage? _taskRepository;
+
+        protected MainWindowViewModelFixture fixture => EnsureInitialized().Fixture;
+        protected MainWindowViewModel mainWindowVM => EnsureInitialized().MainWindowViewModel;
         protected readonly CompareLogic compareLogic;
-        protected readonly ITaskStorage taskRepository;
+        protected ITaskStorage taskRepository => EnsureInitialized().TaskRepository;
 
         public BaseModelTests()
         {
             compareLogic = new CompareLogic();
             compareLogic.Config.MaxDifferences = 10;
-            TaskItemViewModel.DefaultThrottleTime = TimeSpan.FromMilliseconds(10);
-            fixture = new MainWindowViewModelFixture();
-            mainWindowVM = fixture.MainWindowViewModelTest;
-            mainWindowVM.Connect().GetAwaiter().GetResult();
-            mainWindowVM.AllTasksMode = true;
-            while (mainWindowVM.CurrentAllTasksItems.Count == 0){ }
-            taskRepository = mainWindowVM.taskRepository!;
         }
 
         /// <summary>
         /// Очистка после тестов
         /// </summary>
-        public void Dispose() => fixture.CleanTasks();
+        public void Dispose() => _fixture?.CleanTasks();
+
+        private (MainWindowViewModelFixture Fixture, MainWindowViewModel MainWindowViewModel, ITaskStorage TaskRepository) EnsureInitialized()
+        {
+            if (_fixture != null && _mainWindowVM != null && _taskRepository != null)
+            {
+                return (_fixture, _mainWindowVM, _taskRepository);
+            }
+
+            TaskItemViewModel.DefaultThrottleTime = TimeSpan.FromMilliseconds(10);
+            _fixture = new MainWindowViewModelFixture();
+            _mainWindowVM = _fixture.MainWindowViewModelTest;
+            _mainWindowVM.Connect().GetAwaiter().GetResult();
+            _mainWindowVM.AllTasksMode = true;
+
+            _taskRepository = _mainWindowVM.taskRepository
+                ?? throw new InvalidOperationException("Task repository was not initialized.");
+
+            return (_fixture, _mainWindowVM, _taskRepository);
+        }
+
+        protected async Task RunWithTreeProjectionAsync(
+            Func<MainWindowViewModelFixture, MainWindowViewModel, ITaskStorage, Task> action)
+        {
+            using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await session.Dispatch(async () =>
+            {
+                var projectionFixture = new MainWindowViewModelFixture();
+
+                try
+                {
+                    var viewModel = projectionFixture.MainWindowViewModelTest;
+                    await viewModel.Connect();
+                    viewModel.AllTasksMode = true;
+                    Dispatcher.UIThread.RunJobs();
+
+                    var repository = viewModel.taskRepository
+                        ?? throw new InvalidOperationException("Task repository was not initialized.");
+
+                    if (viewModel.CurrentAllTasksItems.Count == 0)
+                    {
+                        throw new TimeoutException("Main window task tree was not loaded in time for the test.");
+                    }
+
+                    await action(projectionFixture, viewModel, repository);
+                }
+                finally
+                {
+                    projectionFixture.CleanTasks();
+                }
+            }, CancellationToken.None);
+        }
 
         protected TaskItemViewModel? GetTask(string taskId, bool dontAssertNull = false)
         {
@@ -75,7 +125,7 @@ namespace Unlimotion.Test
         }
     }
 
-    [NotInParallel]
+    [ParallelLimiter<SharedUiStateParallelLimit>]
     public class MainWindowViewModelTests : BaseModelTests
     {
         private NotificationManagerWrapperMock NotificationManager => (NotificationManagerWrapperMock)mainWindowVM.ManagerWrapper;
@@ -85,24 +135,34 @@ namespace Unlimotion.Test
             return editor.Suggestions.Select(candidate => candidate.Task.Id).ToHashSet();
         }
 
-        private async Task<(TaskWrapperViewModel RootWrapper, TaskWrapperViewModel ChildWrapper, TaskWrapperViewModel GrandchildWrapper)>
-            CreateThreeLevelTreeCommandBranchAsync()
+        private static async Task<(TaskWrapperViewModel RootWrapper, TaskWrapperViewModel ChildWrapper, TaskWrapperViewModel GrandchildWrapper)>
+            CreateThreeLevelTreeCommandBranchAsync(MainWindowViewModel viewModel, ITaskStorage repository)
         {
-            mainWindowVM.AllTasksMode = true;
-            var childTask = GetTask(MainWindowViewModelFixture.SubTask22Id);
-            var grandchildTask = await taskRepository.AddChild(childTask);
+            viewModel.AllTasksMode = true;
+            var childTask = TestHelpers.GetTask(viewModel, MainWindowViewModelFixture.SubTask22Id);
+            var grandchildTask = await repository.AddChild(childTask);
             grandchildTask.Title = "Tree command grandchild";
+
             await TestHelpers.WaitThrottleTime();
+            Dispatcher.UIThread.RunJobs();
 
-            var childWrapper = mainWindowVM.FindTaskWrapperViewModel(childTask, mainWindowVM.CurrentAllTasksItems);
-            var grandchildWrapper = mainWindowVM.FindTaskWrapperViewModel(grandchildTask, mainWindowVM.CurrentAllTasksItems);
+            var wrappersLoaded = await TestHelpers.WaitUntilAsync(() =>
+            {
+                Dispatcher.UIThread.RunJobs();
+                var childWrapper = viewModel.FindTaskWrapperViewModel(childTask!, viewModel.CurrentAllTasksItems);
+                var grandchildWrapper = viewModel.FindTaskWrapperViewModel(grandchildTask!, viewModel.CurrentAllTasksItems);
+                return childWrapper?.Parent != null && grandchildWrapper?.Parent == childWrapper;
+            }, TimeSpan.FromSeconds(2));
 
-            await Assert.That(childWrapper).IsNotNull();
-            await Assert.That(grandchildWrapper).IsNotNull();
-            await Assert.That(childWrapper!.Parent).IsNotNull();
-            await Assert.That(grandchildWrapper!.Parent).IsEqualTo(childWrapper);
+            await Assert.That(wrappersLoaded).IsTrue();
+            var finalChildWrapper = viewModel.FindTaskWrapperViewModel(childTask!, viewModel.CurrentAllTasksItems);
+            var finalGrandchildWrapper = viewModel.FindTaskWrapperViewModel(grandchildTask!, viewModel.CurrentAllTasksItems);
+            await Assert.That(finalChildWrapper).IsNotNull();
+            await Assert.That(finalGrandchildWrapper).IsNotNull();
 
-            return (childWrapper.Parent, childWrapper, grandchildWrapper);
+            var childWrapper = finalChildWrapper!;
+            var grandchildWrapper = finalGrandchildWrapper!;
+            return (childWrapper!.Parent, childWrapper, grandchildWrapper!);
         }
 
         private static IReadOnlyList<TaskWrapperViewModel> FindWrappersByTaskId(
@@ -166,16 +226,27 @@ namespace Unlimotion.Test
             // Act: Set title immediately after creation
             var expectedTitle = "Test Title That Should Not Reset";
             task.Title = expectedTitle;
-            
-            // Wait for file watcher to potentially trigger update (1 second throttle + buffer)
-            await Task.Delay(TimeSpan.FromSeconds(2));
-            
-            // Assert: Title should still be what we set
-            await Assert.That(task.Title).IsEqualTo(expectedTitle);
+            var verificationWindow = TimeSpan.FromSeconds(2);
+            var verificationStartedAt = DateTime.UtcNow;
 
-            // Also verify it eventually saves correctly
-            await TestHelpers.WaitThrottleTime();
+            var savedWithoutReset = await TestHelpers.WaitUntilAsync(
+                () =>
+                {
+                    var storedTask = TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, task.Id);
+                    return task.Title == expectedTitle && storedTask?.Title == expectedTitle;
+                },
+                verificationWindow);
+
+            await Assert.That(savedWithoutReset).IsTrue();
+
+            var remainingWindow = verificationWindow - (DateTime.UtcNow - verificationStartedAt);
+            if (remainingWindow > TimeSpan.Zero)
+            {
+                await Task.Delay(remainingWindow);
+            }
+
             var storedTask = TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, task.Id);
+            await Assert.That(task.Title).IsEqualTo(expectedTitle);
             await Assert.That(storedTask?.Title).IsEqualTo(expectedTitle);
         }
 
@@ -750,18 +821,20 @@ namespace Unlimotion.Test
         [Test]
         public async Task SubItemLinkRemoveCommand_Success()
         {
-            var rootWrapper = mainWindowVM.CurrentAllTasksItems
-                .First(i => i.TaskItem.Id == MainWindowViewModelFixture.RootTask4Id);
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, repository) =>
+            {
+                var rootWrapper = viewModel.CurrentAllTasksItems
+                    .First(i => i.TaskItem.Id == MainWindowViewModelFixture.RootTask4Id);
+                var subWrapper = rootWrapper.SubTasks
+                    .First(st => st.TaskItem.Id == MainWindowViewModelFixture.SubTask41Id);
 
-            var subWrapper = rootWrapper.SubTasks
-                .First(st => st.TaskItem.Id == MainWindowViewModelFixture.SubTask41Id);
+                ((NotificationManagerWrapperMock)viewModel.ManagerWrapper).AskResult = true;
 
-            ((NotificationManagerWrapperMock)mainWindowVM.ManagerWrapper).AskResult = true;
+                await TestHelpers.ActionNotCreateItems(() => subWrapper.RemoveCommand.Execute(null), repository, -1);
 
-            await TestHelpers.ActionNotCreateItems(() => subWrapper.RemoveCommand.Execute(null), taskRepository, -1);
-
-            var subStored = TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask41Id);
-            await Assert.That(subStored).IsNull();
+                var subStored = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask41Id);
+                await Assert.That(subStored).IsNull();
+            });
         }
 
         /// <summary>
@@ -771,22 +844,24 @@ namespace Unlimotion.Test
         [Test]
         public async Task SubItemRemoveCommand_Success()
         {
-            var rootWrapper = mainWindowVM.CurrentAllTasksItems
-                .First(i => i.TaskItem.Id == MainWindowViewModelFixture.RootTask4Id);
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, repository) =>
+            {
+                var rootWrapper = viewModel.CurrentAllTasksItems
+                    .First(i => i.TaskItem.Id == MainWindowViewModelFixture.RootTask4Id);
+                var subWrapper = rootWrapper.SubTasks
+                    .First(st => st.TaskItem.Id == MainWindowViewModelFixture.SubTask41Id);
 
-            var subWrapper = rootWrapper.SubTasks
-                .First(st => st.TaskItem.Id == MainWindowViewModelFixture.SubTask41Id);
+                ((NotificationManagerWrapperMock)viewModel.ManagerWrapper).AskResult = false;
 
-            ((NotificationManagerWrapperMock)mainWindowVM.ManagerWrapper).AskResult = false;
-            
-            await TestHelpers.ActionNotCreateItems(() => subWrapper.RemoveCommand.Execute(null), taskRepository);
-            
-            var rootStored = TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask4Id);
-            var subStored = TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask41Id);
+                await TestHelpers.ActionNotCreateItems(() => subWrapper.RemoveCommand.Execute(null), repository);
 
-            await Assert.That(rootStored).IsNotNull();
-            await Assert.That(subStored).IsNotNull();
-            await Assert.That(rootStored.ContainsTasks).Contains(subWrapper.TaskItem.Id);
+                var rootStored = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask4Id);
+                var subStored = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask41Id);
+
+                await Assert.That(rootStored).IsNotNull();
+                await Assert.That(subStored).IsNotNull();
+                await Assert.That(rootStored.ContainsTasks).Contains(subWrapper.TaskItem.Id);
+            });
         }
 
         /// <summary>
@@ -796,85 +871,100 @@ namespace Unlimotion.Test
         [Test]
         public async Task ItemRemoveCommand_Success()
         {
-            var parent = mainWindowVM.CurrentAllTasksItems
-                .First(i => i.Id == MainWindowViewModelFixture.RootTask4Id);
-            var subTask = TestHelpers.GetTask(mainWindowVM, MainWindowViewModelFixture.SubTask22Id);
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, repository) =>
+            {
+                var parent = viewModel.CurrentAllTasksItems
+                    .First(i => i.Id == MainWindowViewModelFixture.RootTask4Id);
+                var subTask = TestHelpers.GetTask(viewModel, MainWindowViewModelFixture.SubTask22Id);
 
-            ((NotificationManagerWrapperMock)mainWindowVM.ManagerWrapper).AskResult = true;
-            await TestHelpers.ActionNotCreateItems(() => parent.RemoveCommand.Execute(null), taskRepository, -1);
-            
-            await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, parent.Id)).IsNull();
-            await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, subTask.Id)).IsNotNull();
+                ((NotificationManagerWrapperMock)viewModel.ManagerWrapper).AskResult = true;
+                await TestHelpers.ActionNotCreateItems(() => parent.RemoveCommand.Execute(null), repository, -1);
+
+                await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, parent.Id)).IsNull();
+                await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, subTask.Id)).IsNotNull();
+            });
         }
 
         [Test]
         public async Task RemoveSelectedWrappers_MultiParentSameTask_RemovesEachWrapperContext()
         {
-            var wrappers = FindWrappersByTaskId(mainWindowVM.CurrentAllTasksItems, MainWindowViewModelFixture.SubTask22Id);
-            await Assert.That(wrappers.Count).IsEqualTo(2);
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, _) =>
+            {
+                var wrappers = FindWrappersByTaskId(viewModel.CurrentAllTasksItems, MainWindowViewModelFixture.SubTask22Id);
+                await Assert.That(wrappers.Count).IsEqualTo(2);
 
-            var root2Wrapper = wrappers.FirstOrDefault(wrapper => wrapper.Parent?.TaskItem.Id == MainWindowViewModelFixture.RootTask2Id);
-            var root3Wrapper = wrappers.FirstOrDefault(wrapper => wrapper.Parent?.TaskItem.Id == MainWindowViewModelFixture.RootTask3Id);
-            await Assert.That(root2Wrapper).IsNotNull();
-            await Assert.That(root3Wrapper).IsNotNull();
+                var root2Wrapper = wrappers.FirstOrDefault(wrapper => wrapper.Parent?.TaskItem.Id == MainWindowViewModelFixture.RootTask2Id);
+                var root3Wrapper = wrappers.FirstOrDefault(wrapper => wrapper.Parent?.TaskItem.Id == MainWindowViewModelFixture.RootTask3Id);
+                await Assert.That(root2Wrapper).IsNotNull();
+                await Assert.That(root3Wrapper).IsNotNull();
 
-            NotificationManager.AskResult = true;
-            mainWindowVM.RemoveSelectedWrappers([root2Wrapper!, root3Wrapper!]);
-            await TestHelpers.WaitThrottleTime();
+                ((NotificationManagerWrapperMock)viewModel.ManagerWrapper).AskResult = true;
+                viewModel.RemoveSelectedWrappers([root2Wrapper!, root3Wrapper!]);
+                await TestHelpers.WaitThrottleTime();
 
-            var taskFile = GetStorageTaskItem(MainWindowViewModelFixture.SubTask22Id);
-            var root2Stored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask2Id);
-            var root3Stored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask3Id);
+                var taskFile = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask22Id);
+                var root2Stored = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask2Id);
+                var root3Stored = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask3Id);
 
-            await Assert.That(taskFile).IsNull();
-            await Assert.That(root2Stored!.ContainsTasks).DoesNotContain(MainWindowViewModelFixture.SubTask22Id);
-            await Assert.That(root3Stored!.ContainsTasks).DoesNotContain(MainWindowViewModelFixture.SubTask22Id);
+                await Assert.That(taskFile).IsNull();
+                await Assert.That(root2Stored!.ContainsTasks).DoesNotContain(MainWindowViewModelFixture.SubTask22Id);
+                await Assert.That(root3Stored!.ContainsTasks).DoesNotContain(MainWindowViewModelFixture.SubTask22Id);
+            });
         }
 
         [Test]
         public async Task RemoveSelectedWrappers_CancelledBatch_KeepsAllSelectedEntries()
         {
-            var wrappers = new[]
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, _) =>
             {
-                mainWindowVM.CurrentAllTasksItems.First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.RootTask1Id),
-                mainWindowVM.CurrentAllTasksItems.First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.RootTask4Id)
-            };
+                var wrappers = new[]
+                {
+                    viewModel.CurrentAllTasksItems.First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.RootTask1Id),
+                    viewModel.CurrentAllTasksItems.First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.RootTask4Id)
+                };
 
-            NotificationManager.AskResult = false;
-            mainWindowVM.RemoveSelectedWrappers(wrappers);
-            await TestHelpers.WaitThrottleTime();
+                ((NotificationManagerWrapperMock)viewModel.ManagerWrapper).AskResult = false;
+                viewModel.RemoveSelectedWrappers(wrappers);
+                await TestHelpers.WaitThrottleTime();
 
-            var root1Stored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask1Id);
-            var root4Stored = GetStorageTaskItem(MainWindowViewModelFixture.RootTask4Id);
+                var root1Stored = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask1Id);
+                var root4Stored = TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask4Id);
 
-            await Assert.That(root1Stored).IsNotNull();
-            await Assert.That(root4Stored).IsNotNull();
+                await Assert.That(root1Stored).IsNotNull();
+                await Assert.That(root4Stored).IsNotNull();
+            });
         }
 
         [Test]
         public async Task NormalizeForMoveBatch_RemovesDescendantsWhenAncestorSelected()
         {
-            var rootWrapper = mainWindowVM.CurrentAllTasksItems
-                .First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.RootTask2Id);
-            var childWrapper = rootWrapper.SubTasks
-                .First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.SubTask22Id);
+            await RunWithTreeProjectionAsync(async (_, viewModel, _) =>
+            {
+                var rootWrapper = viewModel.CurrentAllTasksItems
+                    .First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.RootTask2Id);
+                var childWrapper = rootWrapper.SubTasks
+                    .First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.SubTask22Id);
 
-            var normalized = new[] { rootWrapper, childWrapper }.NormalizeForMoveBatch();
+                var normalized = new[] { rootWrapper, childWrapper }.NormalizeForMoveBatch();
 
-            await Assert.That(normalized.Count).IsEqualTo(1);
-            await Assert.That(normalized[0]).IsSameReferenceAs(rootWrapper);
+                await Assert.That(normalized.Count).IsEqualTo(1);
+                await Assert.That(normalized[0]).IsSameReferenceAs(rootWrapper);
+            });
         }
 
         [Test]
         public async Task NormalizeForNonMoveBatch_DeduplicatesSameTaskAcrossParents()
         {
-            var wrappers = FindWrappersByTaskId(mainWindowVM.CurrentAllTasksItems, MainWindowViewModelFixture.SubTask22Id);
-            await Assert.That(wrappers.Count).IsEqualTo(2);
+            await RunWithTreeProjectionAsync(async (_, viewModel, _) =>
+            {
+                var wrappers = FindWrappersByTaskId(viewModel.CurrentAllTasksItems, MainWindowViewModelFixture.SubTask22Id);
+                await Assert.That(wrappers.Count).IsEqualTo(2);
 
-            var normalized = wrappers.NormalizeForNonMoveBatch();
+                var normalized = wrappers.NormalizeForNonMoveBatch();
 
-            await Assert.That(normalized.Count).IsEqualTo(1);
-            await Assert.That(normalized[0].TaskItem.Id).IsEqualTo(MainWindowViewModelFixture.SubTask22Id);
+                await Assert.That(normalized.Count).IsEqualTo(1);
+                await Assert.That(normalized[0].TaskItem.Id).IsEqualTo(MainWindowViewModelFixture.SubTask22Id);
+            });
         }
 
         /// <summary>
@@ -988,15 +1078,18 @@ namespace Unlimotion.Test
         [Test]
         public async Task CancelItemRemoveCommand_Success()
         {
-            var parent = mainWindowVM.CurrentAllTasksItems
-                .First(i => i.Id == MainWindowViewModelFixture.RootTask4Id);
-            var subTask = TestHelpers.GetTask(mainWindowVM, MainWindowViewModelFixture.SubTask22Id);
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, repository) =>
+            {
+                var parent = viewModel.CurrentAllTasksItems
+                    .First(i => i.Id == MainWindowViewModelFixture.RootTask4Id);
+                var subTask = TestHelpers.GetTask(viewModel, MainWindowViewModelFixture.SubTask22Id);
 
-            ((NotificationManagerWrapperMock)mainWindowVM.ManagerWrapper).AskResult = false;
-            await TestHelpers.ActionNotCreateItems(() => parent.RemoveCommand.Execute(null), taskRepository);
+                ((NotificationManagerWrapperMock)viewModel.ManagerWrapper).AskResult = false;
+                await TestHelpers.ActionNotCreateItems(() => parent.RemoveCommand.Execute(null), repository);
 
-            await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, parent.Id)).IsNotNull();
-            await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, subTask.Id)).IsNotNull();
+                await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, parent.Id)).IsNotNull();
+                await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, subTask.Id)).IsNotNull();
+            });
         }
 
         /// <summary>
@@ -1225,7 +1318,6 @@ namespace Unlimotion.Test
             if (isdestinationNotBlockedByDraggable)
             {
                 await Assert.That(result.Differences).HasSingleItem();
-                // Проверяем, что количество блокируемых задач изменилось
                 var blocksTasksDifference = result.Differences.FirstOrDefault(d => d.PropertyName == nameof(TaskItem.BlocksTasks));
                 await Assert.That(blocksTasksDifference).IsNotNull();
 
@@ -1525,32 +1617,42 @@ namespace Unlimotion.Test
         [Test]
         public async Task SelectCurrentTaskMode_SyncsCorrectly()
         {
-            var task = mainWindowVM.CurrentAllTasksItems.First().TaskItem;
+            await RunWithTreeProjectionAsync(async (_, viewModel, _) =>
+            {
+                var task = viewModel.CurrentAllTasksItems.First().TaskItem;
+                viewModel.AllTasksMode = true;
+                viewModel.CurrentTaskItem = task;
+                Dispatcher.UIThread.RunJobs();
 
-            mainWindowVM.AllTasksMode = true;
-            mainWindowVM.CurrentTaskItem = task;
+                var allTasksSelected = await TestHelpers.WaitUntilAsync(() =>
+                {
+                    Dispatcher.UIThread.RunJobs();
+                    return viewModel.CurrentAllTasksItem?.TaskItem?.Id == task.Id;
+                }, TimeSpan.FromSeconds(2));
+                await Assert.That(allTasksSelected).IsTrue();
 
-            var allTasksSelected = SpinWait.SpinUntil(
-                () => mainWindowVM.CurrentAllTasksItem?.TaskItem?.Id == task.Id,
-                TimeSpan.FromSeconds(2));
-            await Assert.That(allTasksSelected).IsTrue();
+                viewModel.AllTasksMode = false;
+                viewModel.UnlockedMode = true;
+                Dispatcher.UIThread.RunJobs();
 
-            mainWindowVM.AllTasksMode = false;
-            mainWindowVM.UnlockedMode = true;
+                var hasUnlockedItems = await TestHelpers.WaitUntilAsync(() =>
+                {
+                    Dispatcher.UIThread.RunJobs();
+                    return viewModel.UnlockedItems.Count > 0;
+                }, TimeSpan.FromSeconds(2));
+                await Assert.That(hasUnlockedItems).IsTrue();
 
-            var hasUnlockedItems = SpinWait.SpinUntil(
-                () => mainWindowVM.UnlockedItems.Count > 0,
-                TimeSpan.FromSeconds(2));
-            await Assert.That(hasUnlockedItems).IsTrue();
+                var unlockedTask = viewModel.UnlockedItems.First().TaskItem;
+                viewModel.CurrentTaskItem = unlockedTask;
+                Dispatcher.UIThread.RunJobs();
 
-            var unlockedTask = mainWindowVM.UnlockedItems.First().TaskItem;
-            mainWindowVM.CurrentTaskItem = unlockedTask;
-
-            var unlockedSelected = SpinWait.SpinUntil(
-                () => mainWindowVM.CurrentUnlockedItem?.TaskItem?.Id == unlockedTask.Id,
-                TimeSpan.FromSeconds(2));
-            await Assert.That(unlockedSelected).IsTrue();
-
+                var unlockedSelected = await TestHelpers.WaitUntilAsync(() =>
+                {
+                    Dispatcher.UIThread.RunJobs();
+                    return viewModel.CurrentUnlockedItem?.TaskItem?.Id == unlockedTask.Id;
+                }, TimeSpan.FromSeconds(2));
+                await Assert.That(unlockedSelected).IsTrue();
+            });
         }
 
         [Test]
@@ -1610,85 +1712,99 @@ namespace Unlimotion.Test
         [Test]
         public async Task TreeCommand_ExpandNodeAndDescendants_ExpandsWholeSubtree()
         {
-            var (rootWrapper, childWrapper, grandchildWrapper) = await CreateThreeLevelTreeCommandBranchAsync();
+            await RunWithTreeProjectionAsync(async (_, viewModel, repository) =>
+            {
+                var (rootWrapper, childWrapper, grandchildWrapper) =
+                    await CreateThreeLevelTreeCommandBranchAsync(viewModel, repository);
 
-            rootWrapper.IsExpanded = false;
-            childWrapper.IsExpanded = false;
-            grandchildWrapper.IsExpanded = false;
+                rootWrapper.IsExpanded = false;
+                childWrapper.IsExpanded = false;
+                grandchildWrapper.IsExpanded = false;
+                viewModel.ExpandNodeAndDescendants(rootWrapper);
 
-            mainWindowVM.ExpandNodeAndDescendants(rootWrapper);
-
-            await Assert.That(rootWrapper.IsExpanded).IsTrue();
-            await Assert.That(childWrapper.IsExpanded).IsTrue();
-            await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+                await Assert.That(rootWrapper.IsExpanded).IsTrue();
+                await Assert.That(childWrapper.IsExpanded).IsTrue();
+                await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+            });
         }
 
         [Test]
         public async Task TreeCommand_CollapseNodeDescendants_KeepsCurrentAndCollapsesChildren()
         {
-            var (rootWrapper, childWrapper, grandchildWrapper) = await CreateThreeLevelTreeCommandBranchAsync();
+            await RunWithTreeProjectionAsync(async (_, viewModel, repository) =>
+            {
+                var (rootWrapper, childWrapper, grandchildWrapper) =
+                    await CreateThreeLevelTreeCommandBranchAsync(viewModel, repository);
 
-            rootWrapper.IsExpanded = true;
-            childWrapper.IsExpanded = true;
-            grandchildWrapper.IsExpanded = true;
+                rootWrapper.IsExpanded = true;
+                childWrapper.IsExpanded = true;
+                grandchildWrapper.IsExpanded = true;
+                viewModel.CollapseNodeDescendants(rootWrapper);
 
-            mainWindowVM.CollapseNodeDescendants(rootWrapper);
-
-            await Assert.That(rootWrapper.IsExpanded).IsFalse();
-            await Assert.That(childWrapper.IsExpanded).IsFalse();
-            await Assert.That(grandchildWrapper.IsExpanded).IsFalse();
+                await Assert.That(rootWrapper.IsExpanded).IsFalse();
+                await Assert.That(childWrapper.IsExpanded).IsFalse();
+                await Assert.That(grandchildWrapper.IsExpanded).IsFalse();
+            });
         }
 
         [Test]
         public async Task TreeCommand_ExpandAllNodes_ExpandsAllRootsAndDescendants()
         {
-            var (rootWrapper, childWrapper, grandchildWrapper) = await CreateThreeLevelTreeCommandBranchAsync();
-            var siblingRoot = mainWindowVM.CurrentAllTasksItems.First(wrapper => wrapper != rootWrapper);
+            await RunWithTreeProjectionAsync(async (_, viewModel, repository) =>
+            {
+                var (rootWrapper, childWrapper, grandchildWrapper) =
+                    await CreateThreeLevelTreeCommandBranchAsync(viewModel, repository);
+                var siblingRoot = viewModel.CurrentAllTasksItems.First(wrapper => wrapper != rootWrapper);
 
-            rootWrapper.IsExpanded = false;
-            childWrapper.IsExpanded = false;
-            grandchildWrapper.IsExpanded = false;
-            siblingRoot.IsExpanded = false;
+                rootWrapper.IsExpanded = false;
+                childWrapper.IsExpanded = false;
+                grandchildWrapper.IsExpanded = false;
+                siblingRoot.IsExpanded = false;
+                viewModel.ExpandAllNodes(viewModel.CurrentAllTasksItems);
 
-            mainWindowVM.ExpandAllNodes(mainWindowVM.CurrentAllTasksItems);
-
-            await Assert.That(rootWrapper.IsExpanded).IsTrue();
-            await Assert.That(childWrapper.IsExpanded).IsTrue();
-            await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
-            await Assert.That(siblingRoot.IsExpanded).IsTrue();
+                await Assert.That(rootWrapper.IsExpanded).IsTrue();
+                await Assert.That(childWrapper.IsExpanded).IsTrue();
+                await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+                await Assert.That(siblingRoot.IsExpanded).IsTrue();
+            });
         }
 
         [Test]
         public async Task TreeCommand_CollapseAllNodes_CollapsesAllRootsAndDescendants()
         {
-            var (rootWrapper, childWrapper, grandchildWrapper) = await CreateThreeLevelTreeCommandBranchAsync();
-            var siblingRoot = mainWindowVM.CurrentAllTasksItems.First(wrapper => wrapper != rootWrapper);
+            await RunWithTreeProjectionAsync(async (_, viewModel, repository) =>
+            {
+                var (rootWrapper, childWrapper, grandchildWrapper) =
+                    await CreateThreeLevelTreeCommandBranchAsync(viewModel, repository);
+                var siblingRoot = viewModel.CurrentAllTasksItems.First(wrapper => wrapper != rootWrapper);
 
-            rootWrapper.IsExpanded = true;
-            childWrapper.IsExpanded = true;
-            grandchildWrapper.IsExpanded = true;
-            siblingRoot.IsExpanded = true;
+                rootWrapper.IsExpanded = true;
+                childWrapper.IsExpanded = true;
+                grandchildWrapper.IsExpanded = true;
+                siblingRoot.IsExpanded = true;
+                viewModel.CollapseAllNodes(viewModel.CurrentAllTasksItems);
 
-            mainWindowVM.CollapseAllNodes(mainWindowVM.CurrentAllTasksItems);
-
-            await Assert.That(rootWrapper.IsExpanded).IsFalse();
-            await Assert.That(childWrapper.IsExpanded).IsFalse();
-            await Assert.That(grandchildWrapper.IsExpanded).IsFalse();
-            await Assert.That(siblingRoot.IsExpanded).IsFalse();
+                await Assert.That(rootWrapper.IsExpanded).IsFalse();
+                await Assert.That(childWrapper.IsExpanded).IsFalse();
+                await Assert.That(grandchildWrapper.IsExpanded).IsFalse();
+                await Assert.That(siblingRoot.IsExpanded).IsFalse();
+            });
         }
 
         [Test]
         public async Task TreeCommand_NullContext_IsNoOp()
         {
-            var rootWrapper = mainWindowVM.CurrentAllTasksItems.First();
-            rootWrapper.IsExpanded = false;
+            await RunWithTreeProjectionAsync(async (_, viewModel, _) =>
+            {
+                var rootWrapper = viewModel.CurrentAllTasksItems.First();
+                rootWrapper.IsExpanded = false;
+                viewModel.ExpandNodeAndDescendants(null);
+                viewModel.CollapseNodeDescendants(null);
+                viewModel.ExpandAllNodes(null);
+                viewModel.CollapseAllNodes(null);
 
-            mainWindowVM.ExpandNodeAndDescendants(null);
-            mainWindowVM.CollapseNodeDescendants(null);
-            mainWindowVM.ExpandAllNodes(null);
-            mainWindowVM.CollapseAllNodes(null);
-
-            await Assert.That(rootWrapper.IsExpanded).IsFalse();
+                await Assert.That(rootWrapper.IsExpanded).IsFalse();
+            });
         }
     }
 }

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -13,7 +13,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class SettingsControlResponsiveUiTests
 {
     [Test]

--- a/src/Unlimotion.Test/SettingsViewModelTests.cs
+++ b/src/Unlimotion.Test/SettingsViewModelTests.cs
@@ -10,9 +10,11 @@ using WritableJsonConfiguration;
 
 namespace Unlimotion.Test;
 
+ [ParallelLimiter<SharedUiStateParallelLimit>]
 public class SettingsViewModelTests : IDisposable
 {
     private readonly string _configPath;
+    private readonly List<IDisposable> _configurationDisposables = [];
 
     public SettingsViewModelTests()
     {
@@ -24,16 +26,33 @@ public class SettingsViewModelTests : IDisposable
 
     public void Dispose()
     {
+        foreach (var disposable in _configurationDisposables)
+        {
+            disposable.Dispose();
+        }
+
         if (File.Exists(_configPath))
         {
             File.Delete(_configPath);
         }
     }
 
+    private IConfigurationRoot CreateConfiguration()
+    {
+        var configuration = WritableJsonConfigurationFabric.Create(_configPath);
+
+        if (configuration is IDisposable disposable)
+        {
+            _configurationDisposables.Add(disposable);
+        }
+
+        return configuration;
+    }
+
     [Test]
     public async System.Threading.Tasks.Task ThemeMode_PersistsChoiceAndCompatibilityShimReflectsSelection()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration, defaultIsDarkTheme: true);
 
         await Assert.That(settings.ThemeMode).IsEqualTo(ThemeMode.System);
@@ -61,7 +80,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task Updates_AreDisabled_WhenUpdateServiceIsUnsupported()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var updateService = new FakeApplicationUpdateService { IsSupported = false };
         var settings = CreateSettingsViewModel(configuration);
 
@@ -77,7 +96,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task CheckForUpdatesAsync_SetsNoUpdatesState_WhenNoUpdateExists()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var updateService = new FakeApplicationUpdateService();
         var settings = CreateSettingsViewModel(configuration);
         settings.ConfigureUpdateService(updateService);
@@ -94,7 +113,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task CheckForUpdatesAsync_UsesPendingUpdateBeforeNetworkCheck()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var updateService = new FakeApplicationUpdateService();
         var settings = CreateSettingsViewModel(configuration);
         settings.ConfigureUpdateService(updateService);
@@ -113,7 +132,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task DownloadUpdateAsync_SetsReadyToApply_WhenUpdateWasFound()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var updateService = new FakeApplicationUpdateService
         {
             NextUpdate = new ApplicationUpdateInfo("2.0.0")
@@ -133,7 +152,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task ApplyUpdateAsync_CallsUpdateServiceRestart_WhenUpdateIsReady()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var updateService = new FakeApplicationUpdateService
         {
             NextUpdate = new ApplicationUpdateInfo("2.0.0")
@@ -153,7 +172,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task CheckForUpdatesAsync_IgnoresRepeatedCalls_WhileBusy()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var updateService = new FakeApplicationUpdateService
         {
             CheckCompletion = new System.Threading.Tasks.TaskCompletionSource<ApplicationUpdateInfo?>()
@@ -176,7 +195,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task BackupAuthMode_DerivesFromRemoteUrl_WhenRepositoryRemotesAreUnavailable()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration);
 
         settings.GitRemoteUrl = "git@github.com:org/unlimotion-backup.git";
@@ -189,7 +208,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task BackupConnection_BecomesReadyForClone_WhenSshKeyIsSelected()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var localization = new LocalizationService(new FakeSystemCultureProvider("ru-RU"));
         localization.SetLanguage(LocalizationService.RussianLanguage);
         var settings = new SettingsViewModel(configuration, localizationService: localization)
@@ -221,7 +240,7 @@ public class SettingsViewModelTests : IDisposable
             }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration, backupService);
 
         settings.GitRemoteNameDisplay = "backup (SSH)";
@@ -233,7 +252,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task FontSize_PersistsAndNormalizesConfiguredValue()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration);
 
         await Assert.That(settings.FontSize).IsEqualTo(AppearanceSettings.DefaultFontSize);
@@ -260,7 +279,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task LanguageMode_DoesNotCultureFormatPersistedNumericSettings()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var localization = new LocalizationService(new FakeSystemCultureProvider("ru-RU"));
         var settings = new SettingsViewModel(configuration, localizationService: localization);
 
@@ -294,7 +313,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task LanguageMode_PersistsChoiceAndUpdatesLocalizedStatusText()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var localization = new LocalizationService(new FakeSystemCultureProvider("en-US"));
         var settings = new SettingsViewModel(configuration, localizationService: localization)
         {
@@ -317,7 +336,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task LanguageModeIndex_ReturnsToCapturedSystemLanguage()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var localization = new LocalizationService(new FakeSystemCultureProvider("ru-RU"));
         var settings = new SettingsViewModel(configuration, localizationService: localization);
 
@@ -334,7 +353,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task LanguageModeIndex_IgnoresTransientInvalidSelectionIndex()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var localization = new LocalizationService(new FakeSystemCultureProvider("en-US"));
         var settings = new SettingsViewModel(configuration, localizationService: localization);
 
@@ -348,7 +367,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task LanguageOptions_KeepCollectionInstanceWhenLanguageChanges()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var localization = new LocalizationService(new FakeSystemCultureProvider("en-US"));
         var settings = new SettingsViewModel(configuration, localizationService: localization);
         var options = settings.LanguageOptions;
@@ -367,7 +386,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task CanConnectStorage_FollowsSelectedModeRequirements()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration);
 
         await Assert.That(settings.CanConnectStorage).IsFalse();
@@ -388,7 +407,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task EnsureDefaultTaskStoragePath_PersistsDefaultPathWhenLocalPathIsEmpty()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var defaultPath = Path.Combine(Environment.CurrentDirectory, "DefaultTasks");
 
         App.EnsureDefaultTaskStoragePath(configuration, defaultPath);
@@ -403,7 +422,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task EnsureDefaultTaskStoragePath_PreservesExistingPath()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var existingPath = Path.Combine(Environment.CurrentDirectory, "ExistingTasks");
         configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.Path)).Set(existingPath);
 
@@ -419,7 +438,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task TaskStoragePathTooltip_ResolvesRelativePathToFullPath()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration);
 
         settings.TaskStoragePath = Path.Combine("Data", "Tasks");
@@ -431,7 +450,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task TaskStoragePathTooltip_UsesActualFallbackPathWhenPathIsEmpty()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration);
 
         settings.TaskStoragePath = string.Empty;
@@ -443,7 +462,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task TaskStoragePathTooltip_DoesNotThrowForInvalidIntermediateInput()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration);
 
         settings.TaskStoragePath = new string((char)0, 1);
@@ -465,7 +484,7 @@ public class SettingsViewModelTests : IDisposable
             }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         configuration.GetSection("Git").GetSection(nameof(GitSettings.RemoteName)).Set("backup");
         var settings = new SettingsViewModel(configuration, backupService);
 
@@ -484,7 +503,7 @@ public class SettingsViewModelTests : IDisposable
             }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         configuration.GetSection("Git").GetSection(nameof(GitSettings.RemoteName)).Set("origin");
         configuration.GetSection("Git").GetSection(nameof(GitSettings.RemoteUrl)).Set("https://example.com/custom.git");
         var settings = new SettingsViewModel(configuration, backupService);
@@ -504,7 +523,7 @@ public class SettingsViewModelTests : IDisposable
             }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         configuration.GetSection("Git").GetSection(nameof(GitSettings.RemoteName)).Set("origin");
         var settings = new SettingsViewModel(configuration, backupService);
 
@@ -525,7 +544,7 @@ public class SettingsViewModelTests : IDisposable
             }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         configuration.GetSection("Git").GetSection(nameof(GitSettings.RemoteName)).Set("missing");
         var settings = new SettingsViewModel(configuration, backupService);
 
@@ -536,7 +555,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task GitPushRefSpec_FallsBackToCanonicalBranchWhenPushRefSpecIsEmpty()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         configuration.GetSection("Git").GetSection(nameof(GitSettings.Branch)).Set("master");
         configuration.GetSection("Git").GetSection(nameof(GitSettings.PushRefSpec)).Set(string.Empty);
 
@@ -553,7 +572,7 @@ public class SettingsViewModelTests : IDisposable
             ReferenceNames = new List<string> { "refs/heads/main" }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         configuration.GetSection("Git").GetSection(nameof(GitSettings.PushRefSpec)).Set("refs/heads/master");
         var settings = new SettingsViewModel(configuration, backupService);
 
@@ -573,7 +592,7 @@ public class SettingsViewModelTests : IDisposable
             ReferenceNames = new List<string> { "refs/heads/main", "refs/heads/release" }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         configuration.GetSection("Git").GetSection(nameof(GitSettings.PushRefSpec)).Set("refs/heads/release");
         var settings = new SettingsViewModel(configuration, backupService);
 
@@ -583,7 +602,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task CanSyncRepository_RequiresBackupRemoteAndPushRefSpecWithoutConnectedState()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration)
         {
             GitBackupEnabled = true,
@@ -610,7 +629,7 @@ public class SettingsViewModelTests : IDisposable
             }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration, backupService);
         settings.SelectedSshPublicKeyPath = @"C:\Users\Test\.ssh\id_first.pub";
 
@@ -638,7 +657,7 @@ public class SettingsViewModelTests : IDisposable
             }
         };
 
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration, backupService);
 
         settings.ReloadSshPublicKeys(@"C:\Users\Test\.ssh\id_second.pub");
@@ -650,7 +669,7 @@ public class SettingsViewModelTests : IDisposable
     [Test]
     public async System.Threading.Tasks.Task SelectedSshPublicKeyPath_UpdatesPrivateKeyPath()
     {
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        IConfigurationRoot configuration = CreateConfiguration();
         var settings = new SettingsViewModel(configuration);
 
         settings.SelectedSshPublicKeyPath = @"C:\Users\Test\.ssh\id_ed25519.pub";

--- a/src/Unlimotion.Test/StartupProjectionAndRelationsTests.cs
+++ b/src/Unlimotion.Test/StartupProjectionAndRelationsTests.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class StartupProjectionAndRelationsTests : BaseModelTests
 {
     [Test]

--- a/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
+++ b/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
@@ -17,7 +17,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[NotInParallel]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public class TaskListRepeaterMarkerUiTests
 {
     [Test]

--- a/src/Unlimotion.Test/TestHelpers.cs
+++ b/src/Unlimotion.Test/TestHelpers.cs
@@ -73,6 +73,27 @@ namespace Unlimotion.Test
             await Task.Delay(sleepTime);
         }
 
+        public static async Task<bool> WaitUntilAsync(
+            Func<bool> predicate,
+            TimeSpan timeout,
+            TimeSpan? pollInterval = null)
+        {
+            var delay = pollInterval ?? TimeSpan.FromMilliseconds(20);
+            var deadline = DateTime.UtcNow + timeout;
+
+            while (DateTime.UtcNow < deadline)
+            {
+                if (predicate())
+                {
+                    return true;
+                }
+
+                await Task.Delay(delay);
+            }
+
+            return predicate();
+        }
+
         public static TaskItemViewModel? GetTask(MainWindowViewModel viewModel, string taskId, bool assertIfMissing = true)
         {
             if (viewModel.taskRepository != null)

--- a/src/Unlimotion.Test/TestParallelLimits.cs
+++ b/src/Unlimotion.Test/TestParallelLimits.cs
@@ -1,0 +1,8 @@
+using TUnit.Core.Interfaces;
+
+namespace Unlimotion.Test;
+
+public sealed class SharedUiStateParallelLimit : IParallelLimit
+{
+    public int Limit => 1;
+}

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -30,7 +30,7 @@ namespace Unlimotion.ViewModel
     [AddINotifyPropertyChangedInterface]
     public class MainWindowViewModel : DisposableList
     {
-        public static bool _isInited; 
+        public bool IsInitialized { get; private set; }
         private DisposableList connectionDisposableList = new DisposableListRealization();
         private bool _isCompletedTabInitialized;
         private bool _isArchivedTabInitialized;
@@ -356,6 +356,13 @@ namespace Unlimotion.ViewModel
             TitleFocusRequestVersion++;
         }
 
+        private void AttachTaskContext(TaskItemViewModel taskItem)
+        {
+            taskItem.NotificationManager = ManagerWrapper;
+            taskItem.MainWindow = this;
+            taskItem.IsInitializedProvider = () => IsInitialized;
+        }
+
         public async Task Connect()
         {
             IsTasksLoading = true;
@@ -363,7 +370,7 @@ namespace Unlimotion.ViewModel
 
             try
             {
-                _isInited = false;
+                IsInitialized = false;
                 connectionDisposableList.Dispose();
                 connectionDisposableList.Disposables.Clear();
                 _isCompletedTabInitialized = false;
@@ -416,12 +423,14 @@ namespace Unlimotion.ViewModel
 
                 //Если из коллекции пропадает итем, то очищаем выделенный итем.
                 taskRepository.Tasks.Connect()
+                    .OnItemAdded(AttachTaskContext)
                     .OnItemRemoved(x =>
                     {
                         if (CurrentTaskItem?.Id == x.Id) CurrentTaskItem = null;
                     })
                     .OnItemUpdated((newItem, oldItem) =>
                     {
+                        AttachTaskContext(newItem);
                         if (newItem.Id == CurrentTaskItem?.Id && newItem.Id == oldItem.Id) CurrentTaskItem = newItem;
                     })
                     .Subscribe()
@@ -1309,9 +1318,13 @@ namespace Unlimotion.ViewModel
                 .AddToDispose(connectionDisposableList);
 
                 await taskStorage.Init();
+                foreach (var taskItem in taskRepository.Tasks.Items)
+                {
+                    AttachTaskContext(taskItem);
+                }
                 RegisterCommands();
 
-                _isInited = true;
+                IsInitialized = true;
             }
             finally
             {

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -26,9 +26,16 @@ namespace Unlimotion.ViewModel
         // Static dependencies - set once during app initialization
         public static INotificationManagerWrapper? NotificationManagerInstance { get; set; }
         public static MainWindowViewModel? MainWindowInstance { get; set; }
+        public INotificationManagerWrapper? NotificationManager { get; set; }
+        public MainWindowViewModel? MainWindow { get; set; }
+        public Func<bool>? IsInitializedProvider { get; set; }
 
-        public TaskItemViewModel(TaskItem model, ITaskStorage taskStorage)
+        public TaskItemViewModel(
+            TaskItem model,
+            ITaskStorage taskStorage,
+            Func<bool>? isInitializedProvider = null)
         {
+            IsInitializedProvider = isInitializedProvider ?? (() => true);
             Model = model;
             _taskStorage = taskStorage;
             _containsTasks = new ReadOnlyObservableCollection<TaskItemViewModel>(_containsTasksSource);
@@ -57,6 +64,7 @@ namespace Unlimotion.ViewModel
         public SetDurationCommands SetDurationCommands { get; set; } = null!;
         public static TimeSpan DefaultThrottleTime = TimeSpan.FromSeconds(10);
         public TimeSpan PropertyChangedThrottleTimeSpanDefault { get; set; } = DefaultThrottleTime;
+        private bool IsInitialized => IsInitializedProvider?.Invoke() ?? true;
 
         private void Init(ITaskStorage taskStorage)
         {
@@ -76,7 +84,7 @@ namespace Unlimotion.ViewModel
             this.WhenAnyValue(m => m.IsCompleted).Subscribe(async b =>
             {
                 // Use TaskTreeManager to handle IsCompleted changes
-                if (MainWindowViewModel._isInited)
+                if (IsInitialized)
                 {
                     SaveItemCommand.Execute();
                 }
@@ -84,7 +92,7 @@ namespace Unlimotion.ViewModel
 
             ArchiveCommand = ReactiveCommand.Create(() =>
             {
-                var notificationManager = NotificationManagerInstance;
+                var notificationManager = NotificationManager ?? NotificationManagerInstance;
 
                 switch (IsCompleted)
                 {
@@ -165,9 +173,9 @@ namespace Unlimotion.ViewModel
                         }
                     })
                     .Publish(shared =>
-                        shared.Where(_ => !MainWindowViewModel._isInited)
+                        shared.Where(_ => !IsInitialized)
                               .Merge(
-                                  shared.Where(_ => MainWindowViewModel._isInited)
+                                  shared.Where(_ => IsInitialized)
                                         .Throttle(PropertyChangedThrottleTimeSpanDefault)
                               )
                     );
@@ -175,7 +183,7 @@ namespace Unlimotion.ViewModel
                 propertyChanged
                     .Subscribe(_ =>
                     {
-                        if (MainWindowViewModel._isInited)
+                        if (IsInitialized)
                             SaveItemCommand.Execute();
                     })
                     .AddToDispose(this);
@@ -265,7 +273,7 @@ namespace Unlimotion.ViewModel
                 .Throttle(TimeSpan.FromSeconds(2))
                 .Subscribe(_ =>
                 {
-                    if (MainWindowViewModel._isInited) SaveItemCommand.Execute();
+                    if (IsInitialized) SaveItemCommand.Execute();
                 });
 
             _repeaterPropertyChangedSubscription.Disposable = new CompositeDisposable(markerSubscription, saveSubscription);
@@ -521,8 +529,6 @@ namespace Unlimotion.ViewModel
 
         public ReadOnlyObservableCollection<TaskItemViewModel> BlockedByTasks => _blockedByTasks;
 
-        public MainWindowViewModel? MainWindow => MainWindowInstance;
-
         public ObservableCollection<string> Contains { get; set; } = new();
         public ObservableCollection<string> Parents { get; set; } = new();
         public ObservableCollection<string> Blocks { get; set; } = new();
@@ -631,10 +637,10 @@ namespace Unlimotion.ViewModel
         /// </summary>
         public DateCommands Commands => commands ??= new DateCommands(this);
         
-        private void ShowModalAndChangeChildrenStatuses(INotificationManagerWrapper notificationManager, string taskName,
+        private void ShowModalAndChangeChildrenStatuses(INotificationManagerWrapper? notificationManager, string taskName,
             List<TaskItemViewModel> childrenTasks, ArchiveMethodType methodType)
         {
-            if (childrenTasks.Count == 0) return;
+            if (childrenTasks.Count == 0 || notificationManager == null) return;
 
             Action yesAction = methodType switch
             {

--- a/src/Unlimotion/UnifiedTaskStorage.cs
+++ b/src/Unlimotion/UnifiedTaskStorage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using DynamicData;
 using Newtonsoft.Json;
@@ -39,7 +40,8 @@ public class UnifiedTaskStorage : ITaskStorage
         TaskTreeManager.Storage.Updating -= TaskStorageOnUpdating;
 
         var initialTaskViews = await BuildInitialTaskViewsAsync();
-        await AddInitialTasksToCacheAsync(initialTaskViews);
+        var shouldYieldBetweenBatches = SynchronizationContext.Current != null;
+        await AddInitialTasksToCacheAsync(initialTaskViews, shouldYieldBetweenBatches);
 
         if (TaskTreeManager.Storage is FileStorage initFileStorage)
         {
@@ -68,8 +70,9 @@ public class UnifiedTaskStorage : ITaskStorage
                 initialTasks.Add(task);
             }
 
+            // Initial view models subscribe immediately; keep startup hydration from saving tasks.
             var initialTaskViews = initialTasks
-                .Select(task => new TaskItemViewModel(task, this))
+                .Select(task => new TaskItemViewModel(task, this, () => false))
                 .ToList();
 
             new TaskRelationsIndex().Rebuild(initialTaskViews);
@@ -77,7 +80,9 @@ public class UnifiedTaskStorage : ITaskStorage
         });
     }
 
-    private async Task AddInitialTasksToCacheAsync(IEnumerable<TaskItemViewModel> initialTaskViews)
+    private async Task AddInitialTasksToCacheAsync(
+        IEnumerable<TaskItemViewModel> initialTaskViews,
+        bool shouldYieldBetweenBatches)
     {
         var batch = new List<TaskItemViewModel>(InitialLoadBatchSize);
 
@@ -92,7 +97,13 @@ public class UnifiedTaskStorage : ITaskStorage
 
             Tasks.Edit(operations => operations.AddOrUpdate(batch));
             batch = new List<TaskItemViewModel>(InitialLoadBatchSize);
-            await Task.Yield();
+
+            // Yield only when a UI synchronization context is present, so the app stays responsive
+            // without making plain test runs depend on thread-pool rescheduling between batches.
+            if (shouldYieldBetweenBatches)
+            {
+                await Task.Yield();
+            }
         }
 
         if (batch.Count > 0)


### PR DESCRIPTION
## Summary

- Replace process-wide task initialization state with per-`MainWindowViewModel` initialization context.
- Prevent initial storage hydration from saving tasks and mutating `UpdatedDateTime` during startup.
- Narrow UI-test serialization with a shared parallel limiter while keeping strict regression assertions.
- Dispose writable test configuration instances and ignore temporary TUnit diagnostic logs.

## Why

The previous startup/test path could leak shared state across tests and could save hydrated tasks before the main window finished initializing. That made tests slower/flakier and could hide unintended model mutations.

## Validation

- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-restore --verbosity minimal` — passed, 226/226.
- `dotnet test tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj --no-restore --verbosity minimal` — passed, 5/5.
- `dotnet test tests/Unlimotion.UiTests.FlaUI/Unlimotion.UiTests.FlaUI.csproj --no-restore --verbosity minimal` — passed, 5/5.