### PR TITLE
Add cascading task deletion

### DIFF
--- a/src/Unlimotion.TaskTreeManager/TaskTreeManager.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskTreeManager.cs
@@ -130,6 +130,73 @@ public class TaskTreeManager
 
     public async Task<List<TaskItem>> DeleteTask(TaskItem change, bool deleteInStorage = true)
     {
+        if (!deleteInStorage)
+        {
+            return await DeleteSingleTask(change, false);
+        }
+
+        var tasksToDelete = await GetTaskAndContainedTasksForDelete(change);
+        if (tasksToDelete.Count <= 1)
+        {
+            return await DeleteSingleTask(change);
+        }
+
+        var result = new Dictionary<string, TaskItem>();
+        var deletedTaskIds = tasksToDelete
+            .Select(static task => task.Id)
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var taskToDelete in tasksToDelete.AsEnumerable().Reverse())
+        {
+            result.AddOrUpdateRange(
+                (await DeleteSingleTask(taskToDelete))
+                .Where(task => !deletedTaskIds.Contains(task.Id)));
+            result.Remove(taskToDelete.Id);
+        }
+
+        return result.Values.ToList();
+    }
+
+    private async Task<List<TaskItem>> GetTaskAndContainedTasksForDelete(TaskItem change)
+    {
+        var result = new List<TaskItem>();
+        var visitedTaskIds = new HashSet<string>(StringComparer.Ordinal);
+        var queue = new Queue<TaskItem>();
+        queue.Enqueue(change);
+
+        while (queue.TryDequeue(out var current))
+        {
+            if (current == null || string.IsNullOrWhiteSpace(current.Id) || !visitedTaskIds.Add(current.Id))
+            {
+                continue;
+            }
+
+            var currentFromStorage = await Storage.Load(current.Id) ?? current;
+            result.Add(currentFromStorage);
+
+            if (currentFromStorage.ContainsTasks?.Any() != true)
+            {
+                continue;
+            }
+
+            foreach (var childId in currentFromStorage.ContainsTasks)
+            {
+                if (string.IsNullOrWhiteSpace(childId))
+                {
+                    continue;
+                }
+
+                var child = await Storage.Load(childId);
+                queue.Enqueue(child ?? new TaskItem { Id = childId });
+            }
+        }
+
+        return result;
+    }
+
+    private async Task<List<TaskItem>> DeleteSingleTask(TaskItem change, bool deleteInStorage = true)
+    {
         var result = new Dictionary<string, TaskItem>();
         var taskIdsToRecalculate = new HashSet<string>(StringComparer.Ordinal);
 

--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -1141,6 +1141,7 @@ public class MainControlTreeCommandsUiTests
 
                 await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask1Id)).IsNull();
                 await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask4Id)).IsNull();
+                await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask41Id)).IsNull();
             }
             finally
             {

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -11,6 +11,7 @@ using Avalonia.Threading;
 using KellermanSoftware.CompareNetObjects;
 using Unlimotion.Domain;
 using Unlimotion.ViewModel;
+using L10n = Unlimotion.ViewModel.Localization.Localization;
 
 namespace Unlimotion.Test
 {
@@ -960,13 +961,15 @@ namespace Unlimotion.Test
             {
                 var parent = viewModel.CurrentAllTasksItems
                     .First(i => i.Id == MainWindowViewModelFixture.RootTask4Id);
-                var subTask = TestHelpers.GetTask(viewModel, MainWindowViewModelFixture.SubTask22Id);
+                var childTask = TestHelpers.GetTask(viewModel, MainWindowViewModelFixture.SubTask41Id);
+                var unrelatedSubTask = TestHelpers.GetTask(viewModel, MainWindowViewModelFixture.SubTask22Id);
 
                 ((NotificationManagerWrapperMock)viewModel.ManagerWrapper).AskResult = true;
-                await TestHelpers.ActionNotCreateItems(() => parent.RemoveCommand.Execute(null), repository, -1);
+                await TestHelpers.ActionNotCreateItems(() => parent.RemoveCommand.Execute(null), repository, -2);
 
                 await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, parent.Id)).IsNull();
-                await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, subTask.Id)).IsNotNull();
+                await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, childTask.Id)).IsNull();
+                await Assert.That(TestHelpers.GetStorageTaskItem(projectionFixture.DefaultTasksFolderPath, unrelatedSubTask.Id)).IsNotNull();
             });
         }
 
@@ -994,6 +997,29 @@ namespace Unlimotion.Test
                 await Assert.That(taskFile).IsNull();
                 await Assert.That(root2Stored!.ContainsTasks).DoesNotContain(MainWindowViewModelFixture.SubTask22Id);
                 await Assert.That(root3Stored!.ContainsTasks).DoesNotContain(MainWindowViewModelFixture.SubTask22Id);
+            });
+        }
+
+        [Test]
+        public async Task RemoveSelectedWrappers_RelationOnlyTaskWithContainedTask_DoesNotCountCascadeInConfirmation()
+        {
+            await RunWithTreeProjectionAsync(async (_, viewModel, repository) =>
+            {
+                var multiParentTask = TestHelpers.GetTask(viewModel, MainWindowViewModelFixture.SubTask22Id);
+                var containedTask = await TestHelpers.CreateAndReturnNewTaskItem(viewModel.Create, repository);
+                await containedTask.CopyInto(multiParentTask);
+                await TestHelpers.WaitThrottleTime();
+
+                var root1Wrapper = viewModel.CurrentAllTasksItems
+                    .First(wrapper => wrapper.TaskItem.Id == MainWindowViewModelFixture.RootTask1Id);
+                var relationOnlyWrapper = FindWrappersByTaskId(viewModel.CurrentAllTasksItems, MainWindowViewModelFixture.SubTask22Id)
+                    .First(wrapper => wrapper.Parent?.TaskItem.Id == MainWindowViewModelFixture.RootTask2Id);
+                var notificationManager = (NotificationManagerWrapperMock)viewModel.ManagerWrapper;
+
+                notificationManager.AskResult = false;
+                viewModel.RemoveSelectedWrappers([root1Wrapper, relationOnlyWrapper]);
+
+                await Assert.That(notificationManager.LastAskMessage).IsEqualTo(L10n.Format("RemoveTasksMessage", 2));
             });
         }
 
@@ -1188,10 +1214,10 @@ namespace Unlimotion.Test
 
             ((NotificationManagerWrapperMock)mainWindowVM.ManagerWrapper).AskResult = true;
             
-            await TestHelpers.ActionNotCreateItems(() => mainWindowVM.Remove.Execute(null), taskRepository, -1);
+            await TestHelpers.ActionNotCreateItems(() => mainWindowVM.Remove.Execute(null), taskRepository, -2);
             
             await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.RootTask4Id)).IsNull();
-            await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask41Id)).IsNotNull();
+            await Assert.That(TestHelpers.GetStorageTaskItem(fixture.DefaultTasksFolderPath, MainWindowViewModelFixture.SubTask41Id)).IsNull();
         }
 
         /// <summary>

--- a/src/Unlimotion.Test/TaskAvailabilityCalculationTests.cs
+++ b/src/Unlimotion.Test/TaskAvailabilityCalculationTests.cs
@@ -851,7 +851,7 @@ namespace Unlimotion.Test
         }
 
         [Test]
-        public async Task DeleteTask_ShouldUnblockChild_WhenStorageLoadsDetachedInstances()
+        public async Task DeleteTask_WithoutStorageDelete_ShouldUnblockChild_WhenStorageLoadsDetachedInstances()
         {
             var storage = new DetachedLoadStorage();
             var manager = new TaskTreeManager(storage);
@@ -888,16 +888,94 @@ namespace Unlimotion.Test
             await Assert.That(blockedChild).IsNotNull();
             await Assert.That(blockedChild.IsCanBeCompleted).IsFalse();
 
-            await manager.DeleteTask(parent);
+            await manager.DeleteTask(parent, deleteInStorage: false);
 
-            var deletedParent = await storage.Load("parent");
             var updatedChild = await storage.Load("child");
 
-            await Assert.That(deletedParent).IsNull();
             await Assert.That(updatedChild).IsNotNull();
             await Assert.That(updatedChild.ParentTasks).IsEmpty();
             await Assert.That(updatedChild.IsCanBeCompleted).IsTrue();
             await Assert.That(updatedChild.UnlockedDateTime).IsNotNull();
+        }
+
+        [Test]
+        public async Task DeleteTask_ShouldCascadeDeleteContainedTasks_WhenDeletingFromStorage()
+        {
+            var storage = new DetachedLoadStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                IsCompleted = false,
+                ContainsTasks = new List<string> { "child" }
+            };
+            var externalParent = new TaskItem
+            {
+                Id = "external-parent",
+                IsCompleted = false,
+                ContainsTasks = new List<string> { "child" }
+            };
+            var child = new TaskItem
+            {
+                Id = "child",
+                IsCompleted = false,
+                ParentTasks = new List<string> { "parent", "external-parent" },
+                ContainsTasks = new List<string> { "grandchild" }
+            };
+            var grandchild = new TaskItem
+            {
+                Id = "grandchild",
+                IsCompleted = false,
+                ParentTasks = new List<string> { "child" }
+            };
+
+            await storage.Save(parent);
+            await storage.Save(externalParent);
+            await storage.Save(child);
+            await storage.Save(grandchild);
+
+            await manager.DeleteTask(parent);
+
+            var deletedParent = await storage.Load("parent");
+            var deletedChild = await storage.Load("child");
+            var deletedGrandchild = await storage.Load("grandchild");
+            var updatedExternalParent = await storage.Load("external-parent");
+
+            await Assert.That(deletedParent).IsNull();
+            await Assert.That(deletedChild).IsNull();
+            await Assert.That(deletedGrandchild).IsNull();
+            await Assert.That(updatedExternalParent).IsNotNull();
+            await Assert.That(updatedExternalParent.ContainsTasks).DoesNotContain("child");
+        }
+
+        [Test]
+        public async Task DeleteTask_ShouldRemoveContainedTaskById_WhenContainedTaskLoadFails()
+        {
+            var storage = new DetachedLoadStorage();
+            var manager = new TaskTreeManager(storage);
+
+            var parent = new TaskItem
+            {
+                Id = "parent",
+                IsCompleted = false,
+                ContainsTasks = new List<string> { "child" }
+            };
+            var child = new TaskItem
+            {
+                Id = "child",
+                IsCompleted = false,
+                ParentTasks = new List<string> { "parent" }
+            };
+
+            await storage.Save(parent);
+            await storage.Save(child);
+            storage.FailLoadFor("child");
+
+            await manager.DeleteTask(parent);
+
+            await Assert.That(storage.ContainsStoredTask("parent")).IsFalse();
+            await Assert.That(storage.ContainsStoredTask("child")).IsFalse();
         }
 
         [Test]
@@ -957,6 +1035,7 @@ namespace Unlimotion.Test
         private sealed class DetachedLoadStorage : IStorage
         {
             private readonly Dictionary<string, TaskItem> _tasks = new(StringComparer.Ordinal);
+            private readonly HashSet<string> _failedLoadTaskIds = new(StringComparer.Ordinal);
 
             public event EventHandler<TaskStorageUpdateEventArgs> Updating
             {
@@ -983,7 +1062,22 @@ namespace Unlimotion.Test
 
             public Task<TaskItem?> Load(string itemId)
             {
+                if (_failedLoadTaskIds.Contains(itemId))
+                {
+                    return Task.FromResult<TaskItem?>(null);
+                }
+
                 return Task.FromResult(_tasks.TryGetValue(itemId, out var task) ? CloneTask(task) : null);
+            }
+
+            public void FailLoadFor(string taskId)
+            {
+                _failedLoadTaskIds.Add(taskId);
+            }
+
+            public bool ContainsStoredTask(string taskId)
+            {
+                return _tasks.ContainsKey(taskId);
             }
 
             public async IAsyncEnumerable<TaskItem> GetAll()

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -1403,7 +1403,7 @@ namespace Unlimotion.ViewModel
             if (task.TaskItem.RemoveRequiresConfirmation(task.Parent?.TaskItem.Id))
             {
                 ManagerWrapper.Ask(L10n.Get("RemoveTaskHeader"),
-                    L10n.Format("RemoveTaskMessage", task.TaskItem.Title),
+                    GetRemoveTaskMessage(task.TaskItem),
                     async () =>
                     {
                         if (await task.TaskItem.RemoveFunc.Invoke(task.Parent?.TaskItem))
@@ -1424,7 +1424,7 @@ namespace Unlimotion.ViewModel
         private async Task RemoveTaskItem(TaskItemViewModel task)
         {
             ManagerWrapper.Ask(L10n.Get("RemoveTaskHeader"),
-                L10n.Format("RemoveTaskMessage", task.Title),
+                GetRemoveTaskMessage(task),
                 async () =>
                 {
                     if (task.Parents?.Count > 0)
@@ -1461,8 +1461,99 @@ namespace Unlimotion.ViewModel
 
             ManagerWrapper.Ask(
                 L10n.Get("RemoveTasksHeader"),
-                L10n.Format("RemoveTasksMessage", orderedWrappers.Count),
+                GetRemoveTasksMessage(orderedWrappers),
                 async () => await RemoveWrappersInternalAsync(orderedWrappers));
+        }
+
+        private static string GetRemoveTaskMessage(TaskItemViewModel task)
+        {
+            var containedTaskCount = CountContainedTasks(task);
+            return containedTaskCount > 0
+                ? L10n.Format("RemoveTaskWithContainedTasksMessage", task.Title, containedTaskCount)
+                : L10n.Format("RemoveTaskMessage", task.Title);
+        }
+
+        private static string GetRemoveTasksMessage(IReadOnlyList<TaskWrapperViewModel> wrappers)
+        {
+            var containedTaskCount = CountContainedTasks(wrappers);
+            return containedTaskCount > 0
+                ? L10n.Format("RemoveTasksWithContainedTasksMessage", wrappers.Count, containedTaskCount)
+                : L10n.Format("RemoveTasksMessage", wrappers.Count);
+        }
+
+        private static int CountContainedTasks(TaskItemViewModel task)
+        {
+            var containedTaskIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var child in task.ContainsTasks)
+            {
+                CollectTaskAndContainedTaskIds(child, containedTaskIds);
+            }
+
+            return containedTaskIds.Count;
+        }
+
+        private static int CountContainedTasks(IReadOnlyList<TaskWrapperViewModel> wrappers)
+        {
+            var selectedTaskIds = wrappers
+                .Select(static wrapper => wrapper.TaskItem?.Id)
+                .Where(static id => !string.IsNullOrWhiteSpace(id))
+                .Select(static id => id!)
+                .ToHashSet(StringComparer.Ordinal);
+            var selectedParentCountsByTaskId = wrappers
+                .Where(static wrapper => !string.IsNullOrWhiteSpace(wrapper.TaskItem?.Id) &&
+                                         !string.IsNullOrWhiteSpace(wrapper.Parent?.TaskItem?.Id))
+                .GroupBy(static wrapper => wrapper.TaskItem.Id!)
+                .ToDictionary(
+                    static group => group.Key,
+                    static group => group
+                        .Select(static wrapper => wrapper.Parent!.TaskItem.Id!)
+                        .Distinct(StringComparer.Ordinal)
+                        .Count(),
+                    StringComparer.Ordinal);
+            var cascadeTaskIds = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var wrapper in wrappers)
+            {
+                if (WillDeleteTaskInBatch(wrapper, selectedParentCountsByTaskId))
+                {
+                    CollectTaskAndContainedTaskIds(wrapper.TaskItem, cascadeTaskIds);
+                }
+            }
+
+            cascadeTaskIds.ExceptWith(selectedTaskIds);
+            return cascadeTaskIds.Count;
+        }
+
+        private static bool WillDeleteTaskInBatch(
+            TaskWrapperViewModel wrapper,
+            IReadOnlyDictionary<string, int> selectedParentCountsByTaskId)
+        {
+            if (string.IsNullOrWhiteSpace(wrapper.TaskItem?.Id))
+            {
+                return false;
+            }
+
+            if (wrapper.Parent == null)
+            {
+                return true;
+            }
+
+            var parentCount = wrapper.TaskItem.Parents.Count;
+            return parentCount <= 1 ||
+                   selectedParentCountsByTaskId.GetValueOrDefault(wrapper.TaskItem.Id) >= parentCount;
+        }
+
+        private static void CollectTaskAndContainedTaskIds(TaskItemViewModel? task, ISet<string> taskIds)
+        {
+            if (task == null || string.IsNullOrWhiteSpace(task.Id) || !taskIds.Add(task.Id))
+            {
+                return;
+            }
+
+            foreach (var child in task.ContainsTasks)
+            {
+                CollectTaskAndContainedTaskIds(child, taskIds);
+            }
         }
 
         private async Task RemoveWrappersInternalAsync(IReadOnlyList<TaskWrapperViewModel> wrappers)

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -184,8 +184,10 @@
   <data name="Remove" xml:space="preserve"><value>Remove</value></data>
   <data name="RemoveTaskHeader" xml:space="preserve"><value>Remove task</value></data>
   <data name="RemoveTaskMessage" xml:space="preserve"><value>Are you sure you want to remove the task "{0}" from disk?</value></data>
+  <data name="RemoveTaskWithContainedTasksMessage" xml:space="preserve"><value>Are you sure you want to remove the task "{0}" and {1} contained tasks from disk?</value></data>
   <data name="RemoveTasksHeader" xml:space="preserve"><value>Remove tasks</value></data>
   <data name="RemoveTasksMessage" xml:space="preserve"><value>Are you sure you want to remove {0} selected task entries?</value></data>
+  <data name="RemoveTasksWithContainedTasksMessage" xml:space="preserve"><value>Are you sure you want to remove {0} selected task entries and {1} contained tasks?</value></data>
   <data name="RepeaterTemplates" xml:space="preserve"><value>Repeater templates</value></data>
   <data name="Repository" xml:space="preserve"><value>Repository</value></data>
   <data name="RepositoryConnected" xml:space="preserve"><value>Repository connected.</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -184,8 +184,10 @@
   <data name="Remove" xml:space="preserve"><value>Удалить</value></data>
   <data name="RemoveTaskHeader" xml:space="preserve"><value>Удалить задачу</value></data>
   <data name="RemoveTaskMessage" xml:space="preserve"><value>Удалить задачу "{0}" с диска?</value></data>
+  <data name="RemoveTaskWithContainedTasksMessage" xml:space="preserve"><value>Удалить задачу "{0}" и {1} вложенных задач с диска?</value></data>
   <data name="RemoveTasksHeader" xml:space="preserve"><value>Удалить задачи</value></data>
   <data name="RemoveTasksMessage" xml:space="preserve"><value>Удалить {0} выбранных записей задач?</value></data>
+  <data name="RemoveTasksWithContainedTasksMessage" xml:space="preserve"><value>Удалить {0} выбранных записей задач и {1} вложенных задач?</value></data>
   <data name="RepeaterTemplates" xml:space="preserve"><value>Шаблоны повторения</value></data>
   <data name="Repository" xml:space="preserve"><value>Репозиторий</value></data>
   <data name="RepositoryConnected" xml:space="preserve"><value>Репозиторий подключен.</value></data>

--- a/src/Unlimotion/UnifiedTaskStorage.cs
+++ b/src/Unlimotion/UnifiedTaskStorage.cs
@@ -150,13 +150,53 @@ public class UnifiedTaskStorage : ITaskStorage
 
     public async Task<bool> Delete(TaskItemViewModel change, bool deleteInStorage = true)
     {
+        var deletedTaskIds = deleteInStorage
+            ? GetTaskAndContainedTaskIds(change)
+            : new List<string> { change.Id };
         var connectedItemList = await TaskTreeManager.DeleteTask(change.Model, deleteInStorage);
 
         foreach (var task in connectedItemList) UpdateCache(task);
-        Tasks.Remove(change);
+        RemoveTasksFromCache(deletedTaskIds);
         RefreshRelations();
 
         return true;
+    }
+
+    private static List<string> GetTaskAndContainedTaskIds(TaskItemViewModel change)
+    {
+        var result = new List<string>();
+        var visitedTaskIds = new HashSet<string>(StringComparer.Ordinal);
+        var queue = new Queue<TaskItemViewModel>();
+        queue.Enqueue(change);
+
+        while (queue.TryDequeue(out var current))
+        {
+            if (current == null || string.IsNullOrWhiteSpace(current.Id) || !visitedTaskIds.Add(current.Id))
+            {
+                continue;
+            }
+
+            result.Add(current.Id);
+
+            foreach (var child in current.ContainsTasks)
+            {
+                queue.Enqueue(child);
+            }
+        }
+
+        return result;
+    }
+
+    private void RemoveTasksFromCache(IEnumerable<string> taskIds)
+    {
+        foreach (var taskId in taskIds.Distinct(StringComparer.Ordinal))
+        {
+            var cachedTask = Tasks.Lookup(taskId);
+            if (cachedTask.HasValue)
+            {
+                Tasks.Remove(cachedTask.Value);
+            }
+        }
     }
 
     public async Task<bool> Delete(TaskItemViewModel change, TaskItemViewModel parent)


### PR DESCRIPTION
## Summary
- Add storage-level cascading delete for tasks contained by the deleted task.
- Remove contained child tasks by known id even when loading the full child task fails.
- Keep relation-only delete behavior for multi-parent task wrappers and external storage removal events.
- Update delete confirmation text to include actually deleted contained tasks.
- Add domain, view-model, and UI regression coverage for cascading delete and confirmation counts.

## Validation
- `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore --verbosity minimal -m:1`
- `dotnet src\Unlimotion.Test\bin\Debug\net10.0\Unlimotion.Test.dll --filter-uid Unlimotion.Test.TaskAvailabilityCalculationTests.1.1.DeleteTask_WithoutStorageDelete_ShouldUnblockChild_WhenStorageLoadsDetachedInstances.1.1.0 Unlimotion.Test.TaskAvailabilityCalculationTests.1.1.DeleteTask_ShouldCascadeDeleteContainedTasks_WhenDeletingFromStorage.1.1.0 Unlimotion.Test.TaskAvailabilityCalculationTests.1.1.DeleteTask_ShouldRemoveContainedTaskById_WhenContainedTaskLoadFails.1.1.0 Unlimotion.Test.MainWindowViewModelTests.1.1.ItemRemoveCommand_Success.1.1.0 Unlimotion.Test.MainWindowViewModelTests.1.1.RemoveSelectedWrappers_RelationOnlyTaskWithContainedTask_DoesNotCountCascadeInConfirmation.1.1.0 Unlimotion.Test.MainWindowViewModelTests.1.1.CurrentTaskItemRemove_Success.1.1.0 Unlimotion.Test.MainControlTreeCommandsUiTests.1.1.TreeCommandUi_ShiftDelete_RemovesSelectedMainTreeItems.1.1.0 --minimum-expected-tests 7 --no-ansi --no-progress --output Detailed --maximum-parallel-tests 1 --timeout 5m`
