### PR TITLE
Add task outline clipboard settings and preview

### DIFF
--- a/specs/2026-04-28-task-outline-clipboard.md
+++ b/specs/2026-04-28-task-outline-clipboard.md
@@ -1,0 +1,187 @@
+# Копирование задач outline через буфер обмена
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; `dotnet-desktop-client`, `ui-automation-testing`
+- Владелец: Codex
+- Масштаб: medium
+- Целевая модель: gpt-5.5
+- Целевой релиз / ветка: текущая рабочая ветка
+- Ограничения: соблюдать существующие Avalonia/ViewModel паттерны; не менять формат хранения задач; UI-поведение покрыть Avalonia.Headless тестами
+- Связанные ссылки: `AGENTS.md`, `AGENTS.override.md`
+
+## 1. Overview / Цель
+Добавить копирование выбранной задачи вместе с подзадачами в текстовый outline в буфер обмена и вставку outline обратно как дерево задач.
+
+Outcome contract:
+- Success means: пользователь может скопировать текущую задачу как табулированный outline и вставить такой outline как новые задачи с сохранением иерархии.
+- Итоговый артефакт / output: команды ViewModel/UI, outline serializer/parser, тесты ViewModel и Avalonia.Headless UI.
+- Stop rules: остановиться после реализации, целевых тестов, build и доступного полного test-run; если full-run невозможен, зафиксировать причину.
+
+## 2. Текущее состояние (AS-IS)
+- `MainWindowViewModel` содержит команды создания/удаления/раскрытия и текущую выбранную задачу.
+- `TaskItemViewModel.ContainsTasks` уже содержит загруженные дочерние задачи.
+- `ITaskStorage` умеет добавлять корневую задачу и дочернюю задачу через `Add`/`AddChild`.
+- `MainControl.axaml` и `MainControl.axaml.cs` уже обрабатывают TreeView hotkeys/context menu.
+- Буфер обмена в текущем UI для задач не используется.
+
+## 3. Проблема
+Нет пользовательского пути для обмена задачами и подзадачами с внешними редакторами через простой текстовый outline.
+
+## 4. Цели дизайна
+- Разделение ответственности: сериализация/парсинг не зависят от Avalonia clipboard.
+- Повторное использование: ViewModel команды используют общий service/helper.
+- Тестируемость: serializer/parser проверяются unit-тестами, UI hotkeys/context menu проверяются headless тестом.
+- Консистентность: команды не создают задачи при пустом буфере, пустой текущей задаче или невалидном outline.
+- Обратная совместимость: существующее хранилище и relations model не меняются.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не копируем даты, статусы, важность, repeaters, блокировки и произвольные связи.
+- Не меняем JSON-схему задач.
+- Не добавляем drag/drop или import/export файлов.
+- Не реализуем rich clipboard formats.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `TaskOutlineClipboardService` -> построение outline из `TaskItemViewModel` или текущего `TaskWrapperViewModel`, парсинг текста в дерево заголовков.
+- `MainWindowViewModel` -> команды copy/paste outline и создание задач через `ITaskStorage`.
+- `MainControl.axaml` -> keybindings/context menu items для `Ctrl+Shift+C`/`Ctrl+Shift+V`.
+- `MainControl.axaml.cs` -> адаптер к `TopLevel.Clipboard`.
+- Тесты -> unit + Avalonia.Headless сценарии.
+
+### 6.2 Детальный дизайн
+- Outline format: одна задача на строку; уровень задаётся ведущими табами или группами из 4 пробелов; заголовок берётся после опциональных маркеров `- `, `* `, `+ `.
+- Copy: текущая задача становится корнем outline, дети выводятся рекурсивно по `ContainsTasks`.
+- Paste: если есть текущая задача, верхний уровень outline создаётся как дочерние задачи текущей; если текущей нет, верхний уровень создаётся в корне.
+- Ошибки: пустой/пробельный буфер или строки без текста игнорируются; jump indentation нормализуется к ближайшему родителю.
+- Производительность: рекурсивный обход по уже загруженным relations; объём clipboard считается пользовательским и малым/средним.
+
+## 7. Бизнес-правила / Алгоритмы
+- Copy outline:
+  - root: `CurrentTaskItem.Title`
+  - child: `\t` * depth + `Title`
+  - пустой title копируется как пустая строка только для root/child, но команда недоступна без текущей задачи.
+- Paste outline:
+  - строки whitespace-only пропускаются;
+  - leading tab = 1 level;
+  - каждые 4 leading spaces = 1 level;
+  - `- `, `* `, `+ ` удаляются после indentation;
+  - верхние элементы вставляются под текущую задачу или в корень.
+
+## 8. Точки интеграции и триггеры
+- `Ctrl+Shift+C` вызывает copy outline.
+- `Ctrl+Shift+V` вызывает paste outline.
+- Context menu TreeView получает пункты copy/paste outline.
+
+## 9. Изменения модели данных / состояния
+- Новых persisted fields нет.
+- Новые команды и clipboard delegates являются runtime state.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция не нужна.
+- Откат: удалить команды, UI bindings и service/helper без влияния на сохранённые задачи.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  - копирование выбранной задачи с потомками пишет expected outline в clipboard;
+  - вставка outline создаёт дерево задач под текущей задачей;
+  - вставка без текущей задачи создаёт корневые задачи;
+  - hotkeys не срабатывают в `TextBox`;
+  - UI menu/hotkeys покрыты Avalonia.Headless.
+- Какие тесты добавить/изменить:
+  - unit tests для outline service/parser;
+  - ViewModel tests для команд;
+  - `MainControlTreeCommandsUiTests` или отдельный UI test class для `Ctrl+Shift+C`/`Ctrl+Shift+V`.
+- Команды для проверки:
+  - `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj`
+  - `dotnet build src/Unlimotion.sln`
+  - `dotnet test src/Unlimotion.sln`
+- Stop rules для validation loops: после passing targeted UI/unit tests и build запустить full test; при внешнем blocker зафиксировать.
+
+## 12. Риски и edge cases
+- Outline hotkeys не должны перехватывать стандартные `Ctrl+C/V` в текстовых полях; для outline используется `Ctrl+Shift+C/V`.
+- Clipboard недоступен в headless: использовать injectable delegates для ViewModel и простой fake в тесте.
+- Множественный выбор: scope ограничен текущей задачей, не batch-selection.
+
+## 13. План выполнения
+1. Добавить outline service/helper и unit tests.
+2. Добавить команды ViewModel и injectable clipboard delegates.
+3. Подключить UI keybindings/context menu.
+4. Добавить/обновить Avalonia.Headless UI tests.
+5. Запустить targeted tests, build, full test.
+
+## 14. Открытые вопросы
+Нет блокирующих. Формат outline выбран как tab/4-space indentation с поддержкой Markdown bullet input.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client`, `ui-automation-testing`
+- Выполненные требования профиля: изменения UI flow покрываются UI tests; команды не блокируют UI thread длительной синхронной работой; selectors остаются стабильными через AutomationId.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.ViewModel/*` | outline logic и команды | Поведение copy/paste |
+| `src/Unlimotion/Views/MainControl.axaml*` | UI bindings/menu/clipboard adapter | Доступ пользователя |
+| `src/Unlimotion.Test/*` | unit и UI tests | Acceptance criteria |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Clipboard | Для задач не используется | Copy/paste outline |
+| Импорт дерева | Только ручное создание | Paste text outline создаёт дерево |
+| Экспорт дерева | Нет | Copy current subtree as text |
+
+## 18. Альтернативы и компромиссы
+- Вариант: хранить JSON в clipboard.
+- Плюсы: можно перенести больше полей.
+- Минусы: хуже редактируется вручную, больше coupling к модели хранения.
+- Почему выбранное решение лучше: пользователь попросил outline; простой текст совместим с заметками, markdown и внешними редакторами.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, goals и Non-Goals указаны |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, интеграция, данные и rollback описаны |
+| C. Безопасность изменений | 11-13 | PASS | Есть acceptance criteria, риски и план |
+| D. Проверяемость | 14-16 | PASS | Открытых blocker нет, file plan указан |
+| E. Готовность к автономной реализации | 17-19 | PASS | Было/стало, tradeoff и quality gate заполнены |
+| F. Соответствие профилю | 20 | PASS | UI tests обязательны и запланированы |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---|---|
+| 1. Ясность цели и границ | 5 | Copy/paste outline и non-goals зафиксированы |
+| 2. Понимание текущего состояния | 5 | Указаны ViewModel, storage и UI точки |
+| 3. Конкретность целевого дизайна | 5 | Формат outline, команды и обработка ошибок определены |
+| 4. Безопасность (миграция, откат) | 5 | Persisted model не меняется, rollback простой |
+| 5. Тестируемость | 5 | Unit, ViewModel и UI tests перечислены |
+| 6. Готовность к автономной реализации | 5 | Блокирующих вопросов нет |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: уточнены hotkey guards для text input и clipboard injection для headless tests.
+- Что осталось на решение пользователя: нет блокирующих решений.
+
+### Post-EXEC Review
+- Статус: PASS
+- Что исправлено до завершения: добавлен guard для fire-and-forget UI clipboard команд, чтобы ошибки clipboard/storage попадали в toast, а не в unobserved task.
+- Что проверено дополнительно для refactor / comments: новых устаревших комментариев и изменений persisted schema нет.
+- Остаточные риски / follow-ups: повторный полный `dotnet test src\Unlimotion.sln` после guard-правки не уложился в 20 минут без вывода; релевантный UI-класс после guard-правки прошёл.
+
+## Approval
+Пользователь уже запросил реализацию: "Реализуй Копирование задачи и подзадач в виде аутлайна в буфер обмена и обратно".
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | delivery-task | 0.90 | Нет блокирующих данных | Реализовать outline service и тесты | Нет | Пользователь запросил реализацию | Формат outline выбран простой и совместимый с текстовыми редакторами | `specs/2026-04-28-task-outline-clipboard.md` |
+| EXEC | implementation | 0.88 | Нет | Запустить целевые проверки | Нет | Нет | Добавлены outline service, ViewModel commands, UI hotkeys/context menu и локализация | `src/Unlimotion.ViewModel/TaskOutlineClipboardService.cs`, `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion/Views/MainControl.axaml`, `src/Unlimotion/Views/MainControl.axaml.cs`, `src/Unlimotion.ViewModel/Resources/Strings*.resx` |
+| EXEC | testing | 0.92 | Нет | Провести финальный sanity-pass | Нет | Нет | Добавлены unit/ViewModel/UI тесты; целевые проверки и первый full-run прошли | `src/Unlimotion.Test/TaskOutlineClipboardServiceTests.cs`, `src/Unlimotion.Test/MainWindowViewModelTests.cs`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs` |
+| EXEC | validation | 0.86 | Повторный full-run после guard-правки завис до таймаута | Завершить с указанием проверки и ограничения | Нет | Нет | Повторный UI-класс после guard-правки прошёл; зависшие dotnet-процессы от таймаута завершены | `specs/2026-04-28-task-outline-clipboard.md` |
+| EXEC | hotkey-fix | 0.94 | Нет | Завершить с результатом проверки | Нет | Пользователь сообщил конфликт `Ctrl+C/V` с текстовыми полями | Outline hotkeys перенесены на `Ctrl+Shift+C/V`; `MainControlTreeCommandsUiTests` прошёл 26/26 | `src/Unlimotion/Views/MainControl.axaml`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs`, `specs/2026-04-28-task-outline-clipboard.md` |
+| EXEC | filtered-copy | 0.91 | Нет | Завершить с результатом проверки | Нет | Пользователь уточнил, что copy должен учитывать фильтры и сортировку | Tree-copy теперь строит outline из текущего `TaskWrapperViewModel.SubTasks`; добавлен UI regression test; `dotnet build` и полный `dotnet test` прошли | `src/Unlimotion.ViewModel/TaskOutlineClipboardService.cs`, `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion/Views/MainControl.axaml.cs`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs` |

--- a/specs/2026-04-29-task-outline-markdown-description-settings.md
+++ b/specs/2026-04-29-task-outline-markdown-description-settings.md
@@ -1,0 +1,465 @@
+# Настройки Markdown и описаний для аутлайн-clipboard
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; `dotnet-desktop-client`, `ui-automation-testing`
+- Владелец: Codex
+- Масштаб: medium
+- Целевая модель: gpt-5.5
+- Целевой релиз / ветка: текущая рабочая ветка после подтверждения спеки
+- Ограничения: соблюдать существующие Avalonia/ViewModel паттерны; на фазе SPEC не менять код; UI-поведение настроек и clipboard flow покрыть Avalonia.Headless/TUnit тестами; не менять persisted task schema
+- Связанные ссылки: `AGENTS.md`, `AGENTS.override.md`, `specs/2026-04-28-task-outline-clipboard.md`
+
+Если секция не применима, это указано явно внутри секции.
+
+## 1. Overview / Цель
+Расширить копирование и вставку задач аутлайном так, чтобы пользователь мог настроить формат экспорта через настройки приложения:
+
+- включать Markdown checklist-формат для задач;
+- включать копирование описания задачи отдельными строками под строкой задачи;
+- вставлять обратно обычный outline, Markdown checklist-outline и outline с описаниями независимо от текущих пользовательских настроек.
+- перед фактической вставкой показывать подтверждение с предварительным просмотром распознанного дерева и целевого места вставки.
+
+Outcome contract:
+- Success means: настройки управляют только форматом копирования, а вставка автоматически распознаёт Markdown-чекбоксы и строки описания, показывает пользователю что и куда будет вставлено, и только после подтверждения создаёт заголовки, описания и статус выполненности задач.
+- Итоговый артефакт / output: обновлённая рабочая спека, после подтверждения - ViewModel/settings/UI/service/tests changes.
+- Stop rules: до фразы `Спеку подтверждаю` не выполнять EXEC-изменения; после реализации завершать только после targeted unit/ViewModel/UI tests, `dotnet build` и доступного `dotnet test`.
+
+## 2. Текущее состояние (AS-IS)
+- `TaskOutlineClipboardService` строит plain outline только из заголовков задач.
+- Текущий plain copy формат: одна задача на строку, вложенность через ведущие табы; при копировании из дерева уже учитываются текущие фильтры и сортировка через `TaskWrapperViewModel`.
+- `TaskOutlineNode` хранит только `Title` и `Children`.
+- `ParseOutline` умеет читать plain outline, leading tabs / groups of 4 spaces и простые bullet-маркеры `- `, `* `, `+ `, но не читает Markdown checklist state и description.
+- `MainWindowViewModel.CopyTaskOutline(...)` вызывает `TaskOutlineClipboardService.BuildOutline(...)` без параметров форматирования.
+- `MainWindowViewModel.PasteTaskOutline(...)` создаёт задачи только с `Title`; `Description` и `IsCompleted` не заполняются из текста.
+- `MainWindowViewModel.PasteTaskOutline(...)` создаёт задачи сразу после чтения clipboard, без пользовательского подтверждения и без preview целевого места вставки.
+- В проекте уже есть `INotificationManagerWrapper.Ask(header, message, yesAction, noAction)` и `NotificationManagerWrapper` на базе `DialogHost`, которые используются для подтверждений удаления, массовых операций и maintenance actions.
+- Текущий `Ask` dialog отображает `Message` простым `TextBlock` без прокрутки, поэтому он не подходит как есть для большого preview вставки.
+- `SettingsViewModel` уже persist-ит пользовательские настройки через `IConfiguration`, а `SettingsControl.axaml` содержит секции настроек, но настроек outline clipboard нет.
+- `TaskItemViewModel` содержит `Description` и nullable `IsCompleted`; `IsCompleted == true` означает выполненную задачу, `false` - невыполненную, `null` - архивную.
+
+## 3. Проблема
+Аутлайн-clipboard сейчас переносит только заголовки в одном формате и вставляет задачи без предварительного подтверждения, поэтому пользователь не может экспортировать задачи в Markdown checklist-вид, переносить описания и безопасно проверить результат распознавания перед созданием задач.
+
+## 4. Цели дизайна
+- Разделение ответственности: настройки хранятся в `SettingsViewModel`, форматирование/парсинг - в `TaskOutlineClipboardService`, clipboard adapter остаётся в UI/ViewModel.
+- Повторное использование: единый parser должен принимать все поддерживаемые форматы без зависимости от текущих настроек.
+- Тестируемость: форматирование/парсинг проверяются unit tests; ViewModel проверяет применение настроек и создание задач; Settings UI и copy/paste flow проверяются UI tests.
+- Консистентность: старый plain outline без описаний продолжает копироваться и вставляться как раньше, если новые настройки выключены.
+- Обратная совместимость: persisted task schema не меняется; новые пользовательские настройки получают безопасные default values.
+- Безопасность пользовательского действия: вставка clipboard считается потенциально массовой операцией и требует explicit confirmation после preview.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не импортируем и не экспортируем даты, planned fields, importance, wanted, repeaters, relations, blockers и archive state.
+- Не парсим дату/emoji из заголовка Markdown checklist; например `✅ 2026-04-21` остаётся частью `Title`.
+- Не добавляем rich clipboard formats, HTML clipboard, OPML или файловый import/export.
+- Не меняем hotkeys `Ctrl+Shift+C` / `Ctrl+Shift+V`.
+- Не меняем правила фильтрации и сортировки дерева, которые уже используются при copy из `TaskWrapperViewModel`.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `TaskOutlineClipboardSettings` или константы секции настроек -> имена persisted keys и default values.
+- `SettingsViewModel` -> свойства `CopyTaskOutlineAsMarkdown` и `CopyTaskOutlineDescription`, чтение/запись в `IConfiguration`.
+- `SettingsControl.axaml` -> отдельная группа настроек outline clipboard с двумя checkbox:
+  - `Копирование в Markdown формате`;
+  - `Копировать описание`.
+- `Resources/Strings*.resx` -> локализованные строки для новой секции, checkbox и hints.
+- `TaskOutlineClipboardService` -> options-aware build, auto-detect parse, модель node с title/description/completion state.
+- `TaskOutlinePastePreview` или helper в `TaskOutlineClipboardService` -> построение человекочитаемого preview из parse-result и destination.
+- `MainWindowViewModel` -> передача текущих settings в build, preflight parse, захват destination, запрос подтверждения и заполнение `Description`/`IsCompleted` только после positive confirmation.
+- `TaskOutlinePastePreviewViewModel` / `TaskOutlinePastePreviewDialogViewModel` -> данные dedicated preview dialog: destination label, task count, preview text, confirm/cancel commands.
+- `INotificationManagerWrapper` / `NotificationManagerWrapper` -> dedicated async confirmation API для paste preview; существующий `Ask(string message)` нельзя использовать без добавления bounded scrollable preview template.
+- `MainScreen.axaml` или отдельный dialog view -> bounded scrollable preview UI с AutomationId для preview container, confirm и cancel.
+- `MainControlTreeCommandsUiTests` / settings UI tests -> пользовательские сценарии checkbox + copy/paste + confirmation.
+
+### 6.2 Детальный дизайн
+Новые настройки:
+
+```text
+TaskOutlineClipboard:CopyAsMarkdown = false
+TaskOutlineClipboard:CopyDescription = false
+```
+
+Имена ключей могут быть вынесены в статический helper, чтобы не размазывать string literals по коду.
+
+Новая option-модель для сервиса:
+
+```csharp
+public sealed record TaskOutlineClipboardOptions(
+    bool CopyAsMarkdown,
+    bool CopyDescription);
+```
+
+Расширение parse/build model:
+
+```csharp
+public sealed class TaskOutlineNode
+{
+    public string Title { get; }
+    public string Description { get; }
+    public bool? IsCompleted { get; }
+    public List<TaskOutlineNode> Children { get; }
+}
+```
+
+`IsCompleted == null` в parse-result означает, что входной outline не задавал статус. При paste для такого node используется default state новой задачи, а не принудительное значение.
+
+Markdown copy format:
+
+```text
+- [x] Бекап настроек и ботстейта ✅ 2026-04-21
+- [ ] Показывать почту в аудите заказа и в самом заказе в бипиуме
+```
+
+Вложенность в Markdown copy должна использовать 4 пробела на уровень, чтобы результат корректно читался обычными Markdown-редакторами:
+
+```text
+- [ ] Родитель
+    - [x] Выполненная подзадача
+    - [ ] Невыполненная подзадача
+```
+
+Description copy format:
+
+```text
+- [ ] Родитель
+    Описание родителя
+    - [ ] Подзадача
+        Описание подзадачи
+```
+
+Описание пишется сразу после строки задачи, с дополнительным уровнем indentation относительно этой задачи. Для многострочного описания каждая строка описания получает тот же дополнительный отступ. Leading/trailing empty lines описания можно нормализовать, но внутренние непустые строки должны сохраняться.
+
+Чтобы не ломать legacy plain paste, description lines распознаются только в marked-outline mode:
+
+- если вход содержит Markdown checklist task markers `- [x]`, `- [X]`, `- [ ]`;
+- или если вход содержит plain bullet task markers `- `, `* `, `+ `.
+
+Для app-generated copy при `CopyDescription=true` и `CopyAsMarkdown=false` task lines должны выводиться с plain bullet marker `- `, чтобы строки описания были отличимы от дочерних задач:
+
+```text
+- Родитель
+    Описание родителя
+    - Подзадача
+        Описание подзадачи
+```
+
+При `CopyDescription=false` и `CopyAsMarkdown=false` нужно сохранить текущий legacy plain format без bullet markers, чтобы не менять привычный clipboard output:
+
+```text
+Родитель
+    Подзадача
+```
+
+Обработка ошибок:
+
+- пустой clipboard и whitespace-only строки игнорируются как сейчас;
+- невалидные checklist-маркеры не должны падать, строка обрабатывается как обычный title после снятия поддерживаемого bullet marker;
+- parser не должен зависеть от текущих settings, потому что пользователь может вставить текст из внешнего редактора или из старого clipboard.
+
+Paste confirmation:
+
+- `PasteTaskOutline(...)` сначала читает clipboard и строит `IReadOnlyList<TaskOutlineNode>`.
+- Если nodes пустые, диалог не показывается и задачи не создаются.
+- Destination вычисляется и захватывается до показа диалога:
+  - если есть `destination ?? CurrentTaskItem`, preview сообщает, что задачи будут вставлены внутрь этой задачи;
+  - если destination отсутствует, preview сообщает, что задачи будут вставлены в корень списка задач.
+- После подтверждения вставка обязана использовать тот же captured destination, который был показан в preview, а не текущий selection на момент нажатия `Да`.
+- Если captured destination был удалён или стал недоступен до подтверждения, paste отменяется без создания задач, показывает ошибку и не меняет selection.
+- Preview строится из parse-result, а не из raw clipboard, чтобы пользователь видел именно нормализованную структуру, которую создаст paste.
+- Preview должен показывать:
+  - количество задач, которые будут созданы;
+  - целевое место вставки;
+  - дерево заголовков с отступами;
+  - Markdown status marker, если status был распознан;
+  - наличие/текст описания под задачей, если description был распознан.
+- Preview dialog должен иметь ограниченную высоту и вертикальную прокрутку, чтобы пользователь мог просмотреть все распознанные задачи перед подтверждением.
+- Preview не должен обрезать дерево задач: все создаваемые задачи должны быть доступны через прокрутку.
+- Для больших clipboard preview должен рендериться как текстовый/виртуализируемый блок внутри scroll container, а не как неограниченно растущий набор вложенных контролов.
+- Минимальный UI-контракт preview dialog:
+  - `AutomationId="TaskOutlinePastePreviewDialog"`;
+  - `AutomationId="TaskOutlinePasteDestinationText"`;
+  - `AutomationId="TaskOutlinePastePreviewScrollViewer"`;
+  - `AutomationId="TaskOutlinePastePreviewText"`;
+  - `AutomationId="TaskOutlinePasteConfirmButton"`;
+  - `AutomationId="TaskOutlinePasteCancelButton"`.
+- Нажатие `Да` запускает создание задач из тех же parsed nodes; нажатие `Нет` не меняет хранилище и текущий selection.
+
+Производительность:
+
+- форматирование остаётся линейным по количеству видимых/copied задач;
+- parser остаётся линейным по количеству строк clipboard;
+- дополнительных обращений к storage при copy не требуется.
+- paste confirmation добавляет только построение preview из уже распарсенного дерева; дополнительных обращений к storage до подтверждения быть не должно.
+
+## 7. Бизнес-правила / Алгоритмы
+### 7.1 Copy
+- `CopyAsMarkdown=false`, `CopyDescription=false`: сохранить текущий plain output.
+- `CopyAsMarkdown=true`, `CopyDescription=false`: каждая task line получает marker `- [x] ` если `task.IsCompleted == true`, иначе `- [ ] `.
+- `CopyAsMarkdown=true`, `CopyDescription=true`: после каждой task line с непустым `Description` выводятся строки описания с одним дополнительным уровнем отступа.
+- `CopyAsMarkdown=false`, `CopyDescription=true`: task lines выводятся как bullet outline `- Title`, description lines - с дополнительным уровнем отступа без bullet marker.
+- Для `IsCompleted == false` и `IsCompleted == null` при Markdown copy используется unchecked marker `- [ ]`, потому что archive state не входит в scope экспорта.
+- Copy из дерева продолжает использовать текущий `TaskWrapperViewModel.SubTasks`, чтобы сохранять применённые фильтры и сортировку.
+
+### 7.2 Paste auto-detection
+- `- [x] Title` и `- [X] Title` -> `Title`, `IsCompleted=true`.
+- `- [ ] Title` -> `Title`, `IsCompleted=false`.
+- `- Title`, `* Title`, `+ Title` -> `Title`, `IsCompleted=null`.
+- Legacy plain line without marker -> task title, `IsCompleted=null`, description detection disabled unless input also contains supported task markers.
+- In marked-outline mode, indented non-empty line without supported task marker directly after a task belongs to nearest preceding task as description, not as child task.
+- Несколько description lines для одной задачи объединяются через `Environment.NewLine` или `\n` с нормализацией при сохранении.
+- Child task line всегда имеет supported task marker в marked-outline mode; это делает generated outline однозначным.
+- Jump indentation нормализуется как сейчас: слишком глубокий уровень привязывается к ближайшему доступному parent.
+
+### 7.3 Paste persistence
+- При создании task из node:
+  - всегда заполнить `Title`;
+  - если `Description` непустой, заполнить `Description`;
+  - если `IsCompleted.HasValue`, заполнить `IsCompleted`;
+  - вызвать `taskRepository.Update(created)` после заполнения полей.
+- Для `IsCompleted=true` запрещено напрямую обходить `TaskTreeManager.UpdateTask`; нужно задать `created.IsCompleted = true` перед `taskRepository.Update(created)`, чтобы существующий механизм выставил `CompletedDateTime` и пересчитал availability.
+- Acceptance для completed paste: после вставки `- [x]` созданная задача имеет `IsCompleted == true` и `CompletedDateTime != null`.
+- Если при реализации выяснится, что текущий `Update` не выставляет `CompletedDateTime` в этом path, это blocker EXEC: нужно исправить path через существующий completion update flow, а не сохранять completed-задачу с пустой датой.
+
+### 7.4 Paste confirmation
+- Любая непустая вставка требует подтверждения пользователя.
+- До подтверждения запрещено вызывать `taskRepository.Add`, `AddChild` или `Update`.
+- Confirmation message должен быть построен после parse и до storage mutations.
+- Positive path:
+  1. прочитать clipboard;
+  2. parse;
+  3. захватить destination и построить destination label + preview;
+  4. показать confirmation dialog;
+  5. после `Да` revalidate captured destination;
+  6. создать задачи под тем же captured destination;
+  7. выбрать первую созданную задачу и раскрыть parent nodes как сейчас.
+- Negative path:
+  1. пользователь нажимает `Нет` или закрывает dialog;
+  2. задачи не создаются;
+  3. `CurrentTaskItem` и tree selection не меняются;
+  4. toast не нужен, потому что cancel является штатным действием.
+- Destination label:
+  - при вставке внутрь задачи: `Внутрь: <TaskTitle>`; если title пустой, использовать id или локализованный fallback;
+  - при вставке в root: `В корень списка задач`.
+- Deleted destination path:
+  - если captured destination не найден при подтверждении, показать локализованную ошибку `PasteTaskOutlineDestinationUnavailable`;
+  - не выполнять fallback в root, потому что это не то место, которое пользователь подтвердил.
+
+## 8. Точки интеграции и триггеры
+- Settings tab отображает новую секцию/группу outline clipboard.
+- Изменение checkbox сразу persist-ится через `IConfiguration`, как остальные настройки.
+- `CopyTaskOutline(TaskItemViewModel?)` и `CopyTaskOutline(TaskWrapperViewModel?)` читают `Settings.CopyTaskOutlineAsMarkdown` и `Settings.CopyTaskOutlineDescription`.
+- `PasteTaskOutline(...)` всегда вызывает parser без передачи settings, затем показывает confirmation dialog с preview и destination.
+- `Ctrl+Shift+C`, `Ctrl+Shift+V` и context menu остаются текущими trigger points.
+
+## 9. Изменения модели данных / состояния
+- Persisted task data не меняется.
+- Добавляются persisted user settings в конфигурацию приложения:
+  - `TaskOutlineClipboard:CopyAsMarkdown`;
+  - `TaskOutlineClipboard:CopyDescription`.
+- Default values для отсутствующих ключей: `false`.
+- Runtime parse model расширяется description/status fields.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция не нужна: отсутствующие настройки читаются как `false`.
+- При первом запуске после обновления UI показывает оба checkbox выключенными, если пользователь их не менял.
+- Rollback: удалить новые settings properties/UI/resource keys и вернуть вызовы `BuildOutline` без options; persisted unknown keys можно оставить, они не влияют на старую версию.
+
+## 11. Тестирование и критерии приёмки
+Acceptance Criteria:
+
+- При выключенных новых настройках copy output совпадает с текущим plain outline.
+- При включённом `Копирование в Markdown формате` выполненная задача копируется как `- [x] Title`, невыполненная и архивная - как `- [ ] Title`.
+- При включённом `Копировать описание` описание каждой задачи копируется следующими строками с дополнительным отступом.
+- При включённых обеих настройках Markdown checklist, description и nested tasks roundtrip-ятся через copy/paste.
+- Paste распознаёт Markdown checklist и создаёт выполненные/невыполненные задачи независимо от текущих settings.
+- Paste для `- [x]` создаёт задачу с `IsCompleted == true` и непустым `CompletedDateTime`.
+- Paste распознаёт description lines в marked-outline input и заполняет `TaskItemViewModel.Description` независимо от текущих settings.
+- Paste показывает confirmation preview до создания задач.
+- Confirmation preview показывает destination: выбранная задача или root.
+- Большой confirmation preview прокручивается и позволяет просмотреть все вставляемые задачи, включая последние элементы дерева.
+- При отказе в confirmation dialog задачи не создаются, selection не меняется.
+- При подтверждении создаётся именно дерево, показанное в preview.
+- Если destination, показанный в preview, удалён до подтверждения, paste не создаёт задачи в другом месте.
+- Legacy paste обычного outline без markers не начинает ошибочно превращать первую дочернюю задачу в описание.
+- Settings UI содержит два checkbox с локализацией и стабильными selectors/AutomationId.
+
+Какие тесты добавить/изменить:
+
+- `TaskOutlineClipboardServiceTests`:
+  - legacy plain output unchanged;
+  - markdown checklist output for completed/uncompleted/archive;
+  - description output for Markdown and non-Markdown generated formats;
+  - parse Markdown checklist into title/status;
+  - parse descriptions into node descriptions;
+  - parse legacy plain nested outline without description regression.
+- `MainWindowViewModelTests`:
+  - copy passes settings into service;
+  - paste fills `Title`, `Description`, `IsCompleted`;
+  - paste completed checklist sets `CompletedDateTime`;
+  - paste remains independent of settings values.
+  - paste asks for confirmation before storage mutations;
+  - paste cancel path creates no tasks and keeps selection;
+  - paste confirmation message contains destination label and preview tree.
+  - paste uses captured destination after confirmation, not current selection changed while dialog is open;
+  - paste refuses to create tasks when captured destination is deleted before confirmation.
+- UI tests:
+  - Settings tab toggles both checkbox and persists values;
+  - tree copy hotkey/context menu respects settings;
+  - tree paste opens confirmation dialog with destination and preview;
+  - large paste preview is scrollable and exposes the last parsed task before confirmation;
+  - confirming dialog creates title/description/status from Markdown clipboard;
+  - cancelling dialog does not create tasks.
+
+Команды для проверки:
+
+```powershell
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/TaskOutlineClipboardServiceTests/*"
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*"
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/Settings*UiTests/*"
+dotnet build src\Unlimotion.sln --no-restore
+dotnet test src\Unlimotion.sln --no-build
+```
+
+Stop rules для test/retrieval/tool/validation loops:
+
+- если targeted UI tests падают, завершение EXEC блокируется;
+- если full test run невозможен из-за внешнего таймаута/окружения, нужно зафиксировать команду, длительность, последний вывод и результаты targeted tests;
+- если parser ambiguity обнаружит формат, который нельзя однозначно распознать без изменения output contract, остановиться и обновить spec до продолжения.
+- если existing `Ask` dialog не заменён/не расширен bounded scrollable template, завершение EXEC блокируется: paste preview нельзя реализовать простым `Message` `TextBlock`.
+- если completed paste создаёт `IsCompleted == true` без `CompletedDateTime`, завершение EXEC блокируется.
+
+## 12. Риски и edge cases
+- Plain outline с описаниями без task markers неоднозначен: строка с дополнительным отступом может быть и описанием, и дочерней задачей. Поэтому generated non-Markdown output при `CopyDescription=true` использует bullet task markers.
+- External Markdown может содержать обычные paragraphs под list item; parser должен трактовать их как description только в marked-outline mode.
+- `IsCompleted == null` при copy теряет archive state и становится unchecked; это осознанный non-goal, чтобы не придумывать несуществующий Markdown marker для архива.
+- Multiline descriptions могут содержать строки, похожие на task markers. В marked-outline mode такая строка будет распознана как child task, если стоит на task indentation level и начинается с marker; это допустимый tradeoff для текстового формата.
+- Settings UI не должен ломать адаптивность Settings tab; проверить существующие responsive UI tests, если они покрывают настройки.
+- Confirmation preview для большого clipboard может быть длинным; нужен bounded scroll container, а не рост dialog за пределы viewport.
+- Очень большой preview может быть тяжёлым для UI, если рендерить каждую строку отдельным контролом; предпочтителен один readonly text block/textbox или виртуализируемое представление.
+- Async yes-action в existing `Ask` не должен превращаться в unobserved task; создание задач после подтверждения должно запускаться через обработанный async path с toast/error handling.
+- Selection может измениться, пока confirmation dialog открыт; paste должен использовать captured destination из preview.
+- Captured destination может быть удалён до подтверждения; безопасное поведение - отмена с ошибкой, без fallback в root.
+
+## 13. План выполнения
+1. Расширить `TaskOutlineNode` и добавить `TaskOutlineClipboardOptions`.
+2. Обновить `TaskOutlineClipboardService` build/parse и добавить unit tests.
+3. Добавить persisted settings properties в `SettingsViewModel`.
+4. Добавить UI checkbox в `SettingsControl.axaml` и resource keys.
+5. Добавить paste preview builder, captured destination model и confirmation flow без storage mutations до подтверждения.
+6. Добавить dedicated scrollable preview dialog/template и async confirmation API.
+7. Обновить `MainWindowViewModel` copy/paste flow для options, confirmation, destination revalidation и новых node fields.
+8. Добавить/обновить ViewModel и UI tests.
+9. Запустить targeted tests, build и доступный full test run.
+10. Выполнить post-EXEC review и исправить найденные blocking issues.
+
+## 14. Открытые вопросы
+Нет блокирующих.
+
+Принятое решение для неоднозначности plain description: при `CopyDescription=true` и `CopyAsMarkdown=false` generated output использует plain bullet task lines `- Title`; это сохраняет возможность автоопределения описаний при paste и не меняет legacy output, пока описание не включено.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client`, `ui-automation-testing`
+- Выполненные требования профиля:
+  - UI-facing настройки и clipboard flow требуют UI tests.
+  - Стабильные selectors/AutomationId должны быть добавлены для новых checkbox.
+  - Длительных синхронных операций на UI thread не требуется.
+  - Перед завершением EXEC нужны `dotnet build`, targeted UI tests и `dotnet test` либо явный отчёт о невозможности full run.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.ViewModel/TaskOutlineClipboardService.cs` | Options-aware build, parser Markdown checklist/description, расширенный node | Форматирование и импорт outline |
+| `src/Unlimotion.ViewModel/SettingsViewModel.cs` | Два persisted checkbox свойства | Управление copy settings |
+| `src/Unlimotion.ViewModel/MainWindowViewModel.cs` | Передача options в copy, captured destination, confirmation preview, заполнение description/status при confirmed paste | Интеграция clipboard flow |
+| `src/Unlimotion.ViewModel/INotificationManagerWrapper.cs` | Dedicated async confirmation API для paste preview | Читаемый и тестируемый preview перед вставкой |
+| `src/Unlimotion/NotificationManagerWrapper.cs` | Реализация paste preview confirmation через DialogHost | Desktop confirmation UI |
+| `src/Unlimotion/Views/MainScreen.axaml` или новый view | Scrollable template для `TaskOutlinePastePreviewViewModel` | Просмотр всех задач перед подтверждением |
+| `src/Unlimotion/Views/SettingsControl.axaml` | Новая группа настроек и checkbox | UI для настроек |
+| `src/Unlimotion.ViewModel/Resources/Strings.resx` | Английские строки | Локализация UI |
+| `src/Unlimotion.ViewModel/Resources/Strings.ru.resx` | Русские строки | Локализация UI |
+| `src/Unlimotion.Test/TaskOutlineClipboardServiceTests.cs` | Unit tests форматов и parser regression | Контракт сервиса |
+| `src/Unlimotion.Test/MainWindowViewModelTests.cs` | ViewModel tests copy/paste fields/settings | Интеграция ViewModel |
+| `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs` и/или settings UI tests | UI regression для settings + copy/paste | Требования AGENTS.override.md |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Copy format | Только plain title outline | Plain title outline, Markdown checklist, outline с описаниями |
+| Copy settings | Нет | Два checkbox в Settings |
+| Paste parser | Title-only | Title + optional description + optional completion state |
+| Paste dependency on settings | Не применимо | Parser не зависит от settings |
+| Paste confirmation | Нет | Scrollable preview + captured destination + confirm/cancel до создания задач |
+| Paste destination | Текущий selection на момент вызова | Destination из preview фиксируется до dialog и revalidate-ится после confirm |
+| Legacy outline | Работает как task tree | Продолжает работать как task tree |
+
+## 18. Альтернативы и компромиссы
+- Вариант: для non-Markdown descriptions выводить description line без markers и без изменения task lines.
+- Плюсы: ближе к формулировке "описание на следующей строчке с дополнительным отступом".
+- Минусы: невозможно надёжно отличить описание от первой дочерней задачи в plain outline, что ломает legacy paste.
+- Почему выбранное решение лучше: bullet task markers включаются только когда description copy включён, дают однозначный roundtrip и сохраняют legacy output при default settings.
+
+- Вариант: сохранять archive state отдельным marker.
+- Плюсы: точнее переносит состояние.
+- Минусы: выходит за пользовательский запрос и не имеет очевидного Markdown checklist эквивалента.
+- Почему выбранное решение лучше: spec сохраняет только выполнено/не выполнено, как в requested examples.
+
+- Вариант: вставлять без подтверждения, как сейчас.
+- Плюсы: быстрее для power-user flow.
+- Минусы: пользователь не видит результат auto-detect parser и destination до создания задач; ошибка clipboard может массово создать неверное дерево.
+- Почему выбранное решение лучше: пользователь явно запросил подтверждение с preview; это снижает риск массовой ошибочной вставки.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели и Non-Goals зафиксированы |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, алгоритмы, confirmation flow, данные, rollback и ошибки описаны |
+| C. Безопасность изменений | 11-13 | PASS | Есть acceptance criteria, тест-план, риски и план выполнения |
+| D. Проверяемость | 14-16 | PASS | Открытых blocker нет, команды проверки и file plan указаны |
+| E. Готовность к автономной реализации | 17-19 | PASS | Было/стало, alternatives и quality gate заполнены |
+| F. Соответствие профилю | 20 | PASS | UI tests и desktop constraints явно учтены |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---|---|
+| 1. Ясность цели и границ | 5 | Настройки copy и auto-detect paste заданы измеримо |
+| 2. Понимание текущего состояния | 5 | Указаны текущие service/ViewModel/settings/UI ограничения |
+| 3. Конкретность целевого дизайна | 5 | Форматы, settings keys, parse rules и confirmation preview contract определены |
+| 4. Безопасность (миграция, откат) | 5 | Task schema не меняется, defaults и rollback описаны |
+| 5. Тестируемость | 5 | Unit, ViewModel и UI tests перечислены с командами |
+| 6. Готовность к автономной реализации | 5 | Блокирующих вопросов нет, ambiguity решена в spec |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: зафиксировано правило marked-outline mode, чтобы description lines не ломали legacy plain paste; добавлен explicit non-goal для archive state; добавлен обязательный paste confirmation preview с captured destination, cancel path и completed-state persistence checks.
+- Дополнение по preview: требование лимита заменено на bounded scrollable preview без обрезания дерева задач, чтобы пользователь мог просмотреть все вставляемые задачи.
+- Дополнение после review: existing `Ask` больше не считается достаточным UI; spec требует dedicated scrollable preview/template, revalidation captured destination и проверку `CompletedDateTime` для `- [x]`.
+- Что осталось на решение пользователя: нет блокирующих решений; пользователь может подтвердить или скорректировать выбранный non-Markdown формат с bullet task lines.
+
+### Post-EXEC Review
+- Статус: PASS
+- Реализовано: настройки copy Markdown/description, auto-detect paste Markdown checklist/plain bullet/legacy outline, заполнение `Description`, `IsCompleted` и `CompletedDateTime`, confirmation dialog с destination/task count/full scrollable preview, cancel path без storage mutations.
+- Исправлено по ходу EXEC: после `ITaskStorage.Update(...)` созданная задача повторно берётся из cache по `Id`, потому что storage может вернуть `null` при in-place update; иначе вложенные задачи теряли родителя после обновления заголовка/описания/статуса.
+- Исправлено по full-test feedback: `CompletedDateTime` для импортируемого `- [x]` выставляется в paste path детерминированно, потому что auto-save по `IsCompleted` может опередить явный update в параллельном test run.
+- Проверки: targeted unit/ViewModel/UI tests зелёные; `dotnet test src\Unlimotion.sln --no-build` прошёл 290/290; `dotnet build src\Unlimotion.sln --no-restore` и `git diff --check` прошли без ошибок.
+- Остаточные предупреждения: существующие NuGet vulnerability warnings, nullable warnings, preview .NET SDK message и LF->CRLF warnings.
+
+## Approval
+Подтверждено пользователем фразой `спеку подтверждаю`; EXEC выполнен.
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | delivery-task | 0.90 | Нет блокирующих данных; формат non-Markdown descriptions выбран как app-generated bullet outline | Ожидать подтверждение спеки | Да | Нет | Нужно согласовать output contract до EXEC, потому что parser/output меняют пользовательский clipboard формат | `specs/2026-04-29-task-outline-markdown-description-settings.md` |
+| SPEC | requirement-update | 0.91 | Нет блокирующих данных; при реализации нужно проверить, достаточно ли existing `Ask` dialog для multiline preview | Ожидать подтверждение спеки | Да | Пользователь добавил требование подтверждения paste с preview | Confirmation включён в paste contract до любых storage mutations, чтобы пользователь видел нормализованное дерево и destination | `specs/2026-04-29-task-outline-markdown-description-settings.md` |
+| SPEC | requirement-update | 0.93 | Нет блокирующих данных; при реализации нужно проверить scroll support в confirmation dialog | Ожидать подтверждение спеки | Да | Пользователь уточнил, что большое preview должно прокручиваться и показывать все задачи | Preview contract обновлён: bounded scroll container без обрезания дерева, с UI test на доступность последней задачи | `specs/2026-04-29-task-outline-markdown-description-settings.md` |
+| SPEC | review-fix | 0.94 | Нет блокирующих данных | Ожидать подтверждение спеки | Да | Пользователь попросил исправить review findings | Устранены недоопределённости: dedicated scrollable UI вместо plain Ask, captured destination + revalidation, completed paste must set CompletedDateTime | `specs/2026-04-29-task-outline-markdown-description-settings.md` |
+| EXEC | implementation | 0.92 | Нет | Запустить targeted проверки | Нет | Пользователь подтвердил спеку | Реализованы settings, parser/build options, confirmation preview dialog и ViewModel paste flow без создания задач до подтверждения | `TaskOutlineClipboardService.cs`, `SettingsViewModel.cs`, `MainWindowViewModel.cs`, `NotificationManagerWrapper.cs`, `SettingsControl.axaml`, `TaskOutlinePastePreviewControl.axaml`, resources, tests |
+| EXEC | test-fix | 0.95 | Нет | Повторить проверки и финализировать | Нет | Нет | Исправлена потеря родителя при рекурсивной вставке после `Update`, когда storage обновляет VM in-place и возвращает `null` | `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.Test/MainWindowViewModelTests.cs` |
+| EXEC | full-test-fix | 0.96 | Нет | Повторить полный test run | Нет | Нет | Full `dotnet test` выявил гонку `CompletedDateTime` для `- [x]`; paste теперь проставляет дату завершения сразу при импорте completed state | `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.Test/MainWindowViewModelTests.cs` |
+| EXEC | verification | 0.97 | Нет | Передать результат пользователю | Нет | Нет | Пройдены unit/ViewModel/UI тесты, полный `dotnet test` 290/290, build и diff check; warnings не блокируют задачу и не появились как ошибки | `src/Unlimotion.Test/*`, `tests/Unlimotion.UiTests.*`, `src/Unlimotion.sln`, `specs/2026-04-29-task-outline-markdown-description-settings.md` |

--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -110,6 +110,254 @@ public class MainControlTreeCommandsUiTests
     }
 
     [Test]
+    public async Task TreeCommandUi_CopyTaskOutline_HotkeyAndContextMenu_Work()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+                vm.DetailsAreOpen = true;
+
+                var parent = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
+                var child = await vm.taskRepository!.AddChild(parent!);
+                child.Title = "Outline UI copy child";
+                await vm.taskRepository.Update(child);
+                var grandchild = await vm.taskRepository.AddChild(child);
+                grandchild.Title = "Outline UI copy grandchild";
+                await vm.taskRepository.Update(grandchild);
+
+                var wrappersReady = WaitFor(() =>
+                    vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems) != null &&
+                    vm.FindTaskWrapperViewModel(child, vm.CurrentAllTasksItems) != null);
+                await Assert.That(wrappersReady).IsTrue();
+
+                var parentWrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
+                var childWrapper = vm.FindTaskWrapperViewModel(child, vm.CurrentAllTasksItems);
+                await Assert.That(parentWrapper).IsNotNull();
+                await Assert.That(childWrapper).IsNotNull();
+                parentWrapper!.IsExpanded = true;
+                childWrapper!.IsExpanded = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                string? clipboardText = null;
+                vm.SetClipboardTextAsync = text =>
+                {
+                    clipboardText = text;
+                    return Task.CompletedTask;
+                };
+
+                var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
+                await Assert.That(allTasksTree).IsNotNull();
+
+                var childControl = FindWrapperControl(allTasksTree!, child.Id);
+                await ClickControlAsync(window, childControl);
+                PressHotkey(window, Key.C, PhysicalKey.C, RawInputModifiers.Control | RawInputModifiers.Shift);
+
+                var copiedChild = WaitFor(() => clipboardText != null);
+                await Assert.That(copiedChild).IsTrue();
+                await Assert.That(NormalizeNewLines(clipboardText)).IsEqualTo(
+                    $"Outline UI copy child\n\tOutline UI copy grandchild");
+
+                clipboardText = null;
+                var parentControl = FindWrapperControl(allTasksTree, parent!.Id);
+                await ClickControlAsync(window, parentControl, MouseButton.Right);
+                var copyMenuItem = FindContextMenuItem(allTasksTree.ContextMenu!, "CopyOutline");
+                InvokeMenuItemClick(copyMenuItem);
+
+                var copiedParent = WaitFor(() => clipboardText != null);
+                await Assert.That(copiedParent).IsTrue();
+                await Assert.That(NormalizeNewLines(clipboardText)).IsEqualTo(
+                    $"{parent.Title}\n\tOutline UI copy child\n\t\tOutline UI copy grandchild");
+
+                clipboardText = "unchanged";
+                var titleTextBox = view.FindControl<TextBox>("CurrentTaskTitleTextBox");
+                await Assert.That(titleTextBox).IsNotNull();
+                titleTextBox!.Focus();
+                PressHotkey(window, Key.C, PhysicalKey.C, RawInputModifiers.Control);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(clipboardText).IsEqualTo("unchanged");
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TreeCommandUi_CopyTaskOutline_UsesCurrentFiltersAndSort()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+                vm.CurrentSortDefinition = vm.SortDefinitions.First(definition => definition.Id == "title-ascending");
+
+                var parent = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
+                var zuluChild = await vm.taskRepository!.AddChild(parent!);
+                zuluChild.Title = "Zulu visible outline child";
+                await vm.taskRepository.Update(zuluChild);
+
+                var hiddenChild = await vm.taskRepository.AddChild(parent);
+                hiddenChild.Title = "\u274C Alpha hidden excluded outline child";
+                await vm.taskRepository.Update(hiddenChild);
+
+                var alphaChild = await vm.taskRepository.AddChild(parent);
+                alphaChild.Title = "Alpha visible outline child";
+                await vm.taskRepository.Update(alphaChild);
+
+                var excludeFilterReady = WaitFor(() => vm.EmojiExcludeFilters.Any(filter => filter.Emoji == "\u274C"));
+                await Assert.That(excludeFilterReady).IsTrue();
+                vm.EmojiExcludeFilters.First(filter => filter.Emoji == "\u274C").ShowTasks = true;
+
+                var wrapperReady = WaitFor(() =>
+                {
+                    var wrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
+                    return wrapper?.SubTasks.Select(child => child.TaskItem.Title).SequenceEqual([
+                        "Alpha visible outline child",
+                        "Zulu visible outline child"
+                    ]) == true;
+                });
+                await Assert.That(wrapperReady).IsTrue();
+                await Assert.That(NormalizeNewLines(TaskOutlineClipboardService.BuildOutline(parent)))
+                    .Contains("Alpha hidden excluded outline child");
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                string? clipboardText = null;
+                vm.SetClipboardTextAsync = text =>
+                {
+                    clipboardText = text;
+                    return Task.CompletedTask;
+                };
+
+                var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
+                await Assert.That(allTasksTree).IsNotNull();
+
+                var parentControl = FindWrapperControl(allTasksTree!, parent!.Id);
+                await ClickControlAsync(window, parentControl);
+                PressHotkey(window, Key.C, PhysicalKey.C, RawInputModifiers.Control | RawInputModifiers.Shift);
+
+                var copied = WaitFor(() => clipboardText != null);
+                await Assert.That(copied).IsTrue();
+                await Assert.That(NormalizeNewLines(clipboardText)).IsEqualTo(
+                    $"{parent.Title}\n\tAlpha visible outline child\n\tZulu visible outline child");
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TreeCommandUi_PasteTaskOutline_Hotkey_CreatesTreeUnderSelectedTask()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+
+                var parent = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
+                var parentWrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
+                await Assert.That(parentWrapper).IsNotNull();
+                parentWrapper!.IsExpanded = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                const string outline =
+                    "Outline UI paste root\n" +
+                    "\tOutline UI paste child\n" +
+                    "\t\tOutline UI paste grandchild\n" +
+                    "Outline UI paste sibling";
+                var clipboardReadCount = 0;
+                vm.GetClipboardTextAsync = () =>
+                {
+                    clipboardReadCount++;
+                    return Task.FromResult<string?>(outline);
+                };
+
+                var countBefore = vm.taskRepository!.Tasks.Count;
+                var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
+                await Assert.That(allTasksTree).IsNotNull();
+
+                var titleTextBox = view.FindControl<TextBox>("CurrentTaskTitleTextBox");
+                await Assert.That(titleTextBox).IsNotNull();
+                titleTextBox!.Focus();
+                PressHotkey(window, Key.V, PhysicalKey.V, RawInputModifiers.Control);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(clipboardReadCount).IsEqualTo(0);
+                await Assert.That(vm.taskRepository.Tasks.Count).IsEqualTo(countBefore);
+
+                var parentControl = FindWrapperControl(allTasksTree!, parent!.Id);
+                await ClickControlAsync(window, parentControl);
+                PressHotkey(window, Key.V, PhysicalKey.V, RawInputModifiers.Control | RawInputModifiers.Shift);
+
+                var pasted = WaitFor(() =>
+                    vm.taskRepository.Tasks.Count == countBefore + 4 &&
+                    vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste root") &&
+                    vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste child") &&
+                    vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste grandchild") &&
+                    vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste sibling"));
+                await Assert.That(pasted).IsTrue();
+                await Assert.That(clipboardReadCount).IsEqualTo(1);
+
+                var pastedRoot = FindTaskByTitle(vm, "Outline UI paste root");
+                var pastedChild = FindTaskByTitle(vm, "Outline UI paste child");
+                var pastedGrandchild = FindTaskByTitle(vm, "Outline UI paste grandchild");
+                var pastedSibling = FindTaskByTitle(vm, "Outline UI paste sibling");
+
+                await Assert.That(parent.Contains).Contains(pastedRoot.Id);
+                await Assert.That(parent.Contains).Contains(pastedSibling.Id);
+                await Assert.That(pastedRoot.Parents).Contains(parent.Id);
+                await Assert.That(pastedRoot.Contains).Contains(pastedChild.Id);
+                await Assert.That(pastedChild.Contains).Contains(pastedGrandchild.Id);
+                await Assert.That(pastedGrandchild.Parents).Contains(pastedChild.Id);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
     public async Task TreeCommandUi_Hotkey_UsesSelectedItem_NotLastClickedWrapper()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
@@ -291,7 +539,7 @@ public class MainControlTreeCommandsUiTests
                 await Assert.That(vm.LastCreatedItems.All(IsExpandedRecursive)).IsTrue();
 
                 await ClickControlAsync(window, lastCreatedTree, MouseButton.Right);
-                var collapseAllMenuItem = lastCreatedTree.ContextMenu!.Items.OfType<MenuItem>().Last();
+                var collapseAllMenuItem = FindContextMenuItem(lastCreatedTree.ContextMenu!, "CollapseAll");
                 InvokeMenuItemClick(collapseAllMenuItem);
 
                 await Assert.That(vm.LastCreatedItems.All(IsCollapsedRecursive)).IsTrue();
@@ -715,7 +963,7 @@ public class MainControlTreeCommandsUiTests
                 await Assert.That(roots.All(IsExpandedRecursive)).IsTrue();
 
                 await ClickControlAsync(window, tree, MouseButton.Right);
-                var collapseAllMenuItem = tree.ContextMenu.Items.OfType<MenuItem>().Last();
+                var collapseAllMenuItem = FindContextMenuItem(tree.ContextMenu, "CollapseAll");
                 InvokeMenuItemClick(collapseAllMenuItem);
 
                 await Assert.That(roots.All(IsCollapsedRecursive)).IsTrue();
@@ -760,7 +1008,7 @@ public class MainControlTreeCommandsUiTests
                 await Assert.That(relationTree).IsNotNull();
                 await Assert.That(titleTextBox).IsNotNull();
                 await Assert.That(relationTree!.ContextMenu).IsNotNull();
-                await Assert.That(relationTree.ContextMenu!.Items.OfType<MenuItem>().Count()).IsEqualTo(4);
+                await Assert.That(relationTree.ContextMenu!.Items.OfType<MenuItem>().Count()).IsEqualTo(6);
 
                 var childWrapper = vm.CurrentItemContains.SubTasks.First(wrapper => wrapper.TaskItem.Id == childTask.Id);
                 var grandchildWrapper = childWrapper.SubTasks.First(wrapper => wrapper.TaskItem.Id == grandchildTask.Id);
@@ -989,6 +1237,8 @@ public class MainControlTreeCommandsUiTests
                 await Assert.That(menuItems["CollapseCurrentNested"].InputGesture?.ToString()).IsEqualTo("Ctrl+Shift+Left");
                 await Assert.That(menuItems["ExpandAll"].InputGesture?.ToString()).IsEqualTo("Ctrl+Alt+Right");
                 await Assert.That(menuItems["CollapseAll"].InputGesture?.ToString()).IsEqualTo("Ctrl+Alt+Left");
+                await Assert.That(menuItems["CopyOutline"].InputGesture?.ToString()).IsEqualTo("Ctrl+Shift+C");
+                await Assert.That(menuItems["PasteOutline"].InputGesture?.ToString()).IsEqualTo("Ctrl+Shift+V");
             }
             finally
             {
@@ -1389,6 +1639,26 @@ public class MainControlTreeCommandsUiTests
     {
         menuItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent, menuItem));
         Dispatcher.UIThread.RunJobs();
+    }
+
+    private static MenuItem FindContextMenuItem(ContextMenu contextMenu, string tag)
+    {
+        return contextMenu.Items
+            .OfType<MenuItem>()
+            .First(item => string.Equals(item.Tag?.ToString(), tag, StringComparison.Ordinal));
+    }
+
+    private static string? NormalizeNewLines(string? text)
+    {
+        return text?
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n');
+    }
+
+    private static TaskItemViewModel FindTaskByTitle(MainWindowViewModel vm, string title)
+    {
+        return vm.taskRepository!.Tasks.Items
+            .First(task => string.Equals(task.Title, title, StringComparison.Ordinal));
     }
 
     private static void ClearStoredTreeCommandContext(MainControl view)

--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
@@ -23,6 +24,57 @@ namespace Unlimotion.Test;
 public class MainControlTreeCommandsUiTests
 {
     [Test]
+    public async Task TaskOutlinePastePreviewDialog_LargePreview_IsScrollableAndShowsLastTask()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            Window? window = null;
+
+            try
+            {
+                var previewLines = Enumerable.Range(1, 100)
+                    .Select(index => $"- Preview task {index:000}");
+                var preview = new TaskOutlinePastePreview(
+                    "Paste task outline?",
+                    "Into: Root",
+                    "Tasks to create: 100",
+                    string.Join(Environment.NewLine, previewLines),
+                    100);
+                var view = new TaskOutlinePastePreviewControl
+                {
+                    DataContext = new TaskOutlinePastePreviewDialogViewModel(preview)
+                };
+
+                window = CreateWindow(view);
+                window.Width = 760;
+                window.Height = 420;
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var scrollViewer = FindControlByAutomationId<ScrollViewer>(
+                    view,
+                    "TaskOutlinePastePreviewScrollViewer");
+                var previewText = FindControlByAutomationId<TextBlock>(
+                    view,
+                    "TaskOutlinePastePreviewText");
+
+                await Assert.That(previewText.Text).Contains("Preview task 100");
+                await Assert.That(scrollViewer.Bounds.Height).IsLessThan(previewText.Bounds.Height);
+
+                scrollViewer.Offset = new Vector(0, scrollViewer.Extent.Height);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(scrollViewer.Offset.Y).IsGreaterThan(0);
+            }
+            finally
+            {
+                window?.Close();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
     public async Task TreeCommandUi_Hotkey_UsesStickyActiveTabTreeAfterFocusMoves()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
@@ -36,6 +88,7 @@ public class MainControlTreeCommandsUiTests
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
                 vm.AllTasksMode = true;
+                ((NotificationManagerWrapperMock)vm.ManagerWrapper).AskResult = true;
                 vm.CollapseAllNodes(vm.CurrentAllTasksItems);
 
                 var view = new MainControl { DataContext = vm };
@@ -336,6 +389,8 @@ public class MainControlTreeCommandsUiTests
                     vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste sibling"));
                 await Assert.That(pasted).IsTrue();
                 await Assert.That(clipboardReadCount).IsEqualTo(1);
+                await Assert.That(((NotificationManagerWrapperMock)vm.ManagerWrapper).LastTaskOutlinePastePreview).IsNotNull();
+                await Assert.That(((NotificationManagerWrapperMock)vm.ManagerWrapper).LastTaskOutlinePastePreview!.TaskCount).IsEqualTo(4);
 
                 var pastedRoot = FindTaskByTitle(vm, "Outline UI paste root");
                 var pastedChild = FindTaskByTitle(vm, "Outline UI paste child");
@@ -1713,6 +1768,14 @@ public class MainControlTreeCommandsUiTests
         }, timeoutMilliseconds);
 
         return ready ? wrapper : null;
+    }
+
+    private static T FindControlByAutomationId<T>(Control root, string automationId)
+        where T : Control
+    {
+        return root.GetVisualDescendants()
+            .OfType<T>()
+            .First(control => AutomationProperties.GetAutomationId(control) == automationId);
     }
 
     private static Control FindWrapperControl(TreeView tree, string taskId)

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -136,6 +136,13 @@ namespace Unlimotion.Test
             return editor.Suggestions.Select(candidate => candidate.Task.Id).ToHashSet();
         }
 
+        private static string? NormalizeNewLines(string? text)
+        {
+            return text?
+                .Replace("\r\n", "\n")
+                .Replace('\r', '\n');
+        }
+
         private static async Task<(TaskWrapperViewModel RootWrapper, TaskWrapperViewModel ChildWrapper, TaskWrapperViewModel GrandchildWrapper)>
             CreateThreeLevelTreeCommandBranchAsync(MainWindowViewModel viewModel, ITaskStorage repository)
         {
@@ -317,6 +324,56 @@ namespace Unlimotion.Test
             await Assert.That(newTask.Wanted).IsTrue();
             await Assert.That(storedTask).IsNotNull();
             await Assert.That(storedTask!.Wanted).IsTrue();
+        }
+
+        [Test]
+        public async Task CopyTaskOutline_WritesCurrentTaskSubtreeToClipboard()
+        {
+            var parent = TestHelpers.GetTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            var child = await taskRepository.AddChild(parent!);
+            child.Title = "Outline VM copy child";
+            await taskRepository.Update(child);
+            var grandchild = await taskRepository.AddChild(child);
+            grandchild.Title = "Outline VM copy grandchild";
+            await taskRepository.Update(grandchild);
+
+            string? clipboardText = null;
+            mainWindowVM.SetClipboardTextAsync = text =>
+            {
+                clipboardText = text;
+                return Task.CompletedTask;
+            };
+
+            await mainWindowVM.CopyTaskOutline(parent);
+
+            await Assert.That(NormalizeNewLines(clipboardText)).IsEqualTo(
+                $"{parent.Title}\n\tOutline VM copy child\n\t\tOutline VM copy grandchild");
+        }
+
+        [Test]
+        public async Task PasteTaskOutline_CreatesNestedTasksUnderCurrentTask()
+        {
+            var parent = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            const string outline =
+                "Outline VM paste root\n" +
+                "\tOutline VM paste child\n" +
+                "\t\tOutline VM paste grandchild";
+            mainWindowVM.GetClipboardTextAsync = () => Task.FromResult<string?>(outline);
+
+            var countBefore = taskRepository.Tasks.Count;
+            await mainWindowVM.PasteTaskOutline(parent);
+
+            await Assert.That(taskRepository.Tasks.Count).IsEqualTo(countBefore + 3);
+
+            var pastedRoot = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste root");
+            var pastedChild = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste child");
+            var pastedGrandchild = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste grandchild");
+
+            await Assert.That(parent!.Contains).Contains(pastedRoot.Id);
+            await Assert.That(pastedRoot.Parents).Contains(parent.Id);
+            await Assert.That(pastedRoot.Contains).Contains(pastedChild.Id);
+            await Assert.That(pastedChild.Contains).Contains(pastedGrandchild.Id);
+            await Assert.That(pastedGrandchild.Parents).Contains(pastedChild.Id);
         }
 
         [Test]

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -354,6 +354,7 @@ namespace Unlimotion.Test
         public async Task PasteTaskOutline_CreatesNestedTasksUnderCurrentTask()
         {
             var parent = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            NotificationManager.AskResult = true;
             const string outline =
                 "Outline VM paste root\n" +
                 "\tOutline VM paste child\n" +
@@ -364,6 +365,10 @@ namespace Unlimotion.Test
             await mainWindowVM.PasteTaskOutline(parent);
 
             await Assert.That(taskRepository.Tasks.Count).IsEqualTo(countBefore + 3);
+            await Assert.That(NotificationManager.TaskOutlinePasteConfirmationCount).IsEqualTo(1);
+            await Assert.That(NotificationManager.LastTaskOutlinePastePreview).IsNotNull();
+            await Assert.That(NotificationManager.LastTaskOutlinePastePreview!.TaskCount).IsEqualTo(3);
+            await Assert.That(NotificationManager.LastTaskOutlinePastePreview.DestinationLabel).Contains(parent!.Title);
 
             var pastedRoot = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste root");
             var pastedChild = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste child");
@@ -374,6 +379,117 @@ namespace Unlimotion.Test
             await Assert.That(pastedRoot.Contains).Contains(pastedChild.Id);
             await Assert.That(pastedChild.Contains).Contains(pastedGrandchild.Id);
             await Assert.That(pastedGrandchild.Parents).Contains(pastedChild.Id);
+        }
+
+        [Test]
+        public async Task CopyTaskOutline_UsesMarkdownAndDescriptionSettings()
+        {
+            var parent = TestHelpers.GetTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            parent!.Description = "Parent description";
+            parent.IsCompleted = true;
+            await taskRepository.Update(parent);
+            var child = await taskRepository.AddChild(parent);
+            child.Title = "Outline markdown child";
+            child.Description = "Child description";
+            await taskRepository.Update(child);
+            mainWindowVM.Settings.CopyTaskOutlineAsMarkdown = true;
+            mainWindowVM.Settings.CopyTaskOutlineDescription = true;
+
+            string? clipboardText = null;
+            mainWindowVM.SetClipboardTextAsync = text =>
+            {
+                clipboardText = text;
+                return Task.CompletedTask;
+            };
+
+            await mainWindowVM.CopyTaskOutline(parent);
+
+            await Assert.That(NormalizeNewLines(clipboardText)).IsEqualTo(
+                $"- [x] {parent.Title}\n" +
+                "    Parent description\n" +
+                "    - [ ] Outline markdown child\n" +
+                "        Child description");
+        }
+
+        [Test]
+        public async Task PasteTaskOutline_FillsDescriptionCompletionAndCompletedDateAfterConfirmation()
+        {
+            var parent = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            NotificationManager.AskResult = true;
+            const string outline =
+                "- [x] Outline completed paste root\n" +
+                "    Imported description\n" +
+                "    - [ ] Outline incomplete paste child";
+            mainWindowVM.GetClipboardTextAsync = () => Task.FromResult<string?>(outline);
+
+            await mainWindowVM.PasteTaskOutline(parent);
+
+            var pastedRoot = taskRepository.Tasks.Items.First(task => task.Title == "Outline completed paste root");
+            var pastedChild = taskRepository.Tasks.Items.First(task => task.Title == "Outline incomplete paste child");
+
+            await Assert.That(pastedRoot.Description).IsEqualTo("Imported description");
+            await Assert.That(pastedRoot.IsCompleted).IsTrue();
+            await Assert.That(pastedRoot.CompletedDateTime).IsNotNull();
+            await Assert.That(pastedChild.IsCompleted).IsFalse();
+            await Assert.That(NotificationManager.LastTaskOutlinePastePreview).IsNotNull();
+            await Assert.That(NormalizeNewLines(NotificationManager.LastTaskOutlinePastePreview!.PreviewText)).IsEqualTo(
+                "- [x] Outline completed paste root\n" +
+                "    Imported description\n" +
+                "    - [ ] Outline incomplete paste child");
+        }
+
+        [Test]
+        public async Task PasteTaskOutline_CancelConfirmation_CreatesNoTasksAndKeepsSelection()
+        {
+            var parent = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            NotificationManager.AskResult = false;
+            mainWindowVM.GetClipboardTextAsync = () => Task.FromResult<string?>("Canceled paste root");
+            var countBefore = taskRepository.Tasks.Count;
+
+            await mainWindowVM.PasteTaskOutline(parent);
+
+            await Assert.That(taskRepository.Tasks.Count).IsEqualTo(countBefore);
+            await Assert.That(mainWindowVM.CurrentTaskItem).IsEqualTo(parent);
+            await Assert.That(NotificationManager.TaskOutlinePasteConfirmationCount).IsEqualTo(1);
+        }
+
+        [Test]
+        public async Task PasteTaskOutline_UsesCapturedDestination_WhenSelectionChangesBeforeConfirmation()
+        {
+            var parent = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            var other = TestHelpers.GetTask(mainWindowVM, MainWindowViewModelFixture.RootTask2Id);
+            mainWindowVM.GetClipboardTextAsync = () => Task.FromResult<string?>("Captured destination paste");
+            NotificationManager.ConfirmTaskOutlinePasteHandler = _ =>
+            {
+                mainWindowVM.CurrentTaskItem = other;
+                return Task.FromResult(true);
+            };
+
+            await mainWindowVM.PasteTaskOutline(parent);
+
+            var pasted = taskRepository.Tasks.Items.First(task => task.Title == "Captured destination paste");
+            await Assert.That(parent!.Contains).Contains(pasted.Id);
+            await Assert.That(other!.Contains).DoesNotContain(pasted.Id);
+        }
+
+        [Test]
+        public async Task PasteTaskOutline_DeletedCapturedDestination_CreatesNoTasks()
+        {
+            var parent = TestHelpers.SetCurrentTask(mainWindowVM, MainWindowViewModelFixture.RootTask1Id);
+            mainWindowVM.GetClipboardTextAsync = () => Task.FromResult<string?>("Deleted destination paste");
+            NotificationManager.ConfirmTaskOutlinePasteHandler = async _ =>
+            {
+                await taskRepository.Delete(parent!);
+                return true;
+            };
+            var countBefore = taskRepository.Tasks.Count;
+
+            await mainWindowVM.PasteTaskOutline(parent);
+
+            await Assert.That(taskRepository.Tasks.Items.Any(task => task.Title == "Deleted destination paste")).IsFalse();
+            await Assert.That(taskRepository.Tasks.Count).IsLessThan(countBefore);
+            await Assert.That(NotificationManager.LastErrorMessage).IsEqualTo(
+                Unlimotion.ViewModel.Localization.Localization.Get("PasteTaskOutlineDestinationUnavailable"));
         }
 
         [Test]

--- a/src/Unlimotion.Test/NotificationManagerWrapperMock.cs
+++ b/src/Unlimotion.Test/NotificationManagerWrapperMock.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Unlimotion.ViewModel;
 
 namespace Unlimotion.Test
@@ -11,7 +12,10 @@ namespace Unlimotion.Test
         public string? LastSuccessMessage { get; private set; }
         public string? LastAskHeader { get; private set; }
         public string? LastAskMessage { get; private set; }
+        public TaskOutlinePastePreview? LastTaskOutlinePastePreview { get; private set; }
         public int AskCount { get; private set; }
+        public int TaskOutlinePasteConfirmationCount { get; private set; }
+        public Func<TaskOutlinePastePreview, Task<bool>>? ConfirmTaskOutlinePasteHandler { get; set; }
         public List<string> ErrorMessages { get; } = new();
         public List<string> SuccessMessages { get; } = new();
 
@@ -29,6 +33,13 @@ namespace Unlimotion.Test
             {
                 noAction?.Invoke();
             }
+        }
+
+        public Task<bool> ConfirmTaskOutlinePasteAsync(TaskOutlinePastePreview preview)
+        {
+            TaskOutlinePasteConfirmationCount++;
+            LastTaskOutlinePastePreview = preview;
+            return ConfirmTaskOutlinePasteHandler?.Invoke(preview) ?? Task.FromResult(AskResult);
         }
 
         public void ErrorToast(string message)
@@ -49,7 +60,10 @@ namespace Unlimotion.Test
             LastSuccessMessage = null;
             LastAskHeader = null;
             LastAskMessage = null;
+            LastTaskOutlinePastePreview = null;
             AskCount = 0;
+            TaskOutlinePasteConfirmationCount = 0;
+            ConfirmTaskOutlinePasteHandler = null;
             ErrorMessages.Clear();
             SuccessMessages.Clear();
         }

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -3,9 +3,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
+using Avalonia.Input.Raw;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Unlimotion;
@@ -16,6 +18,47 @@ namespace Unlimotion.Test;
 [ParallelLimiter<SharedUiStateParallelLimit>]
 public class SettingsControlResponsiveUiTests
 {
+    [Test]
+    public async Task SettingsControl_TaskOutlineClipboardCheckBoxes_PersistSettings()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var settings = fixture.MainWindowViewModelTest.Settings;
+                var view = new SettingsControl
+                {
+                    DataContext = settings
+                };
+
+                window = CreateWindow(view, 720, 800);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var markdownCheckBox = FindControlByAutomationId<CheckBox>(view, "CopyTaskOutlineAsMarkdownCheckBox");
+                var descriptionCheckBox = FindControlByAutomationId<CheckBox>(view, "CopyTaskOutlineDescriptionCheckBox");
+
+                await Assert.That(markdownCheckBox.IsChecked).IsFalse();
+                await Assert.That(descriptionCheckBox.IsChecked).IsFalse();
+
+                await ClickControlAsync(window, markdownCheckBox);
+                await ClickControlAsync(window, descriptionCheckBox);
+
+                await Assert.That(settings.CopyTaskOutlineAsMarkdown).IsTrue();
+                await Assert.That(settings.CopyTaskOutlineDescription).IsTrue();
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
     [Test]
     public async Task SettingsControl_NarrowViewport_DoesNotOverflowHorizontally()
     {
@@ -93,6 +136,31 @@ public class SettingsControlResponsiveUiTests
             Height = height,
             Content = content
         };
+    }
+
+    private static async Task ClickControlAsync(Window window, Control control)
+    {
+        var point = control.TranslatePoint(
+            new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
+            window);
+
+        if (!point.HasValue)
+        {
+            throw new InvalidOperationException($"Cannot translate point for control {control.GetType().Name}.");
+        }
+
+        window.MouseDown(point.Value, MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(point.Value, MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        await Task.CompletedTask;
+    }
+
+    private static T FindControlByAutomationId<T>(Control root, string automationId)
+        where T : Control
+    {
+        return root.GetVisualDescendants()
+            .OfType<T>()
+            .First(control => AutomationProperties.GetAutomationId(control) == automationId);
     }
 
     private static bool IsVisibleAndArranged(Control control)

--- a/src/Unlimotion.Test/SettingsViewModelTests.cs
+++ b/src/Unlimotion.Test/SettingsViewModelTests.cs
@@ -78,6 +78,34 @@ public class SettingsViewModelTests : IDisposable
     }
 
     [Test]
+    public async System.Threading.Tasks.Task TaskOutlineClipboardSettings_PersistChoices()
+    {
+        IConfigurationRoot configuration = CreateConfiguration();
+        var settings = new SettingsViewModel(configuration);
+
+        await Assert.That(settings.CopyTaskOutlineAsMarkdown).IsFalse();
+        await Assert.That(settings.CopyTaskOutlineDescription).IsFalse();
+
+        settings.CopyTaskOutlineAsMarkdown = true;
+        settings.CopyTaskOutlineDescription = true;
+
+        await Assert.That(configuration
+                .GetSection("TaskOutlineClipboard")
+                .GetSection("CopyAsMarkdown")
+                .Get<bool>())
+            .IsTrue();
+        await Assert.That(configuration
+                .GetSection("TaskOutlineClipboard")
+                .GetSection("CopyDescription")
+                .Get<bool>())
+            .IsTrue();
+
+        var reloaded = new SettingsViewModel(configuration);
+        await Assert.That(reloaded.CopyTaskOutlineAsMarkdown).IsTrue();
+        await Assert.That(reloaded.CopyTaskOutlineDescription).IsTrue();
+    }
+
+    [Test]
     public async System.Threading.Tasks.Task Updates_AreDisabled_WhenUpdateServiceIsUnsupported()
     {
         IConfigurationRoot configuration = CreateConfiguration();

--- a/src/Unlimotion.Test/TaskOutlineClipboardServiceTests.cs
+++ b/src/Unlimotion.Test/TaskOutlineClipboardServiceTests.cs
@@ -1,11 +1,78 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Unlimotion;
+using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
 
 namespace Unlimotion.Test;
 
 public class TaskOutlineClipboardServiceTests
 {
+    [Test]
+    public async Task BuildOutline_DefaultOptions_KeepsLegacyTabIndentedFormat()
+    {
+        var storage = await CreateStorageAsync();
+        var root = await storage.Add();
+        root.Title = "Root";
+        await storage.Update(root);
+        var child = await storage.AddChild(root);
+        child.Title = "Child";
+        await storage.Update(child);
+
+        var outline = TaskOutlineClipboardService.BuildOutline(root);
+
+        await Assert.That(NormalizeNewLines(outline)).IsEqualTo("Root\n\tChild");
+    }
+
+    [Test]
+    public async Task BuildOutline_MarkdownWithDescriptions_UsesChecklistAndIndentedDescriptions()
+    {
+        var storage = await CreateStorageAsync();
+        var root = await storage.Add();
+        root.Title = "Root";
+        root.Description = "Root description\nSecond line";
+        root.IsCompleted = true;
+        await storage.Update(root);
+        var child = await storage.AddChild(root);
+        child.Title = "Child";
+        child.Description = "Child description";
+        child.IsCompleted = null;
+        await storage.Update(child);
+
+        var outline = TaskOutlineClipboardService.BuildOutline(
+            root,
+            new TaskOutlineClipboardOptions(CopyAsMarkdown: true, CopyDescription: true));
+
+        await Assert.That(NormalizeNewLines(outline)).IsEqualTo(
+            "- [x] Root\n" +
+            "    Root description\n" +
+            "    Second line\n" +
+            "    - [ ] Child\n" +
+            "        Child description");
+    }
+
+    [Test]
+    public async Task BuildOutline_PlainWithDescriptions_UsesBulletTasksToDisambiguateDescriptions()
+    {
+        var storage = await CreateStorageAsync();
+        var root = await storage.Add();
+        root.Title = "Root";
+        root.Description = "Root description";
+        await storage.Update(root);
+        var child = await storage.AddChild(root);
+        child.Title = "Child";
+        await storage.Update(child);
+
+        var outline = TaskOutlineClipboardService.BuildOutline(
+            root,
+            new TaskOutlineClipboardOptions(CopyAsMarkdown: false, CopyDescription: true));
+
+        await Assert.That(NormalizeNewLines(outline)).IsEqualTo(
+            "- Root\n" +
+            "    Root description\n" +
+            "    - Child");
+    }
+
     [Test]
     public async Task ParseOutline_SupportsTabsSpacesAndMarkdownBullets()
     {
@@ -25,6 +92,47 @@ public class TaskOutlineClipboardServiceTests
     }
 
     [Test]
+    public async Task ParseOutline_ReadsMarkdownChecklistStatusAndDescriptions()
+    {
+        const string outline =
+            "- [x] Root\n" +
+            "    Root description\n" +
+            "    second line\n" +
+            "    - [ ] Child\n" +
+            "        Child description\n" +
+            "- Plain sibling";
+
+        var nodes = TaskOutlineClipboardService.ParseOutline(outline);
+
+        await Assert.That(nodes.Count).IsEqualTo(2);
+        await Assert.That(nodes[0].Title).IsEqualTo("Root");
+        await Assert.That(nodes[0].IsCompleted).IsTrue();
+        await Assert.That(NormalizeNewLines(nodes[0].Description)).IsEqualTo("Root description\nsecond line");
+        await Assert.That(nodes[0].Children.Single().Title).IsEqualTo("Child");
+        await Assert.That(nodes[0].Children.Single().IsCompleted).IsFalse();
+        await Assert.That(nodes[0].Children.Single().Description).IsEqualTo("Child description");
+        await Assert.That(nodes[1].Title).IsEqualTo("Plain sibling");
+        await Assert.That(nodes[1].IsCompleted).IsNull();
+    }
+
+    [Test]
+    public async Task ParseOutline_LegacyPlainIndentation_RemainsTaskHierarchyNotDescriptions()
+    {
+        const string outline =
+            "Root\n" +
+            "    Child\n" +
+            "        Grandchild";
+
+        var nodes = TaskOutlineClipboardService.ParseOutline(outline);
+
+        await Assert.That(nodes).HasSingleItem();
+        await Assert.That(nodes[0].Description).IsEmpty();
+        await Assert.That(nodes[0].Children.Single().Title).IsEqualTo("Child");
+        await Assert.That(nodes[0].Children.Single().Description).IsEmpty();
+        await Assert.That(nodes[0].Children.Single().Children.Single().Title).IsEqualTo("Grandchild");
+    }
+
+    [Test]
     public async Task ParseOutline_ClampsIndentationJumpsToPreviousNode()
     {
         const string outline =
@@ -35,5 +143,37 @@ public class TaskOutlineClipboardServiceTests
 
         await Assert.That(nodes).HasSingleItem();
         await Assert.That(nodes[0].Children.Single().Title).IsEqualTo("Jumped child");
+    }
+
+    [Test]
+    public async Task BuildPreviewText_IncludesAllParsedTasksAndDescriptions()
+    {
+        const string outline =
+            "- [x] Root\n" +
+            "    Root description\n" +
+            "    - [ ] Child";
+
+        var nodes = TaskOutlineClipboardService.ParseOutline(outline);
+        var preview = TaskOutlineClipboardService.BuildPreviewText(nodes);
+
+        await Assert.That(TaskOutlineClipboardService.CountNodes(nodes)).IsEqualTo(2);
+        await Assert.That(NormalizeNewLines(preview)).IsEqualTo(
+            "- [x] Root\n" +
+            "    Root description\n" +
+            "    - [ ] Child");
+    }
+
+    private static async Task<UnifiedTaskStorage> CreateStorageAsync()
+    {
+        var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        await storage.Init();
+        return storage;
+    }
+
+    private static string? NormalizeNewLines(string? text)
+    {
+        return text?
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n');
     }
 }

--- a/src/Unlimotion.Test/TaskOutlineClipboardServiceTests.cs
+++ b/src/Unlimotion.Test/TaskOutlineClipboardServiceTests.cs
@@ -1,0 +1,39 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Test;
+
+public class TaskOutlineClipboardServiceTests
+{
+    [Test]
+    public async Task ParseOutline_SupportsTabsSpacesAndMarkdownBullets()
+    {
+        const string outline =
+            "- Root\n" +
+            "    - Child from spaces\n" +
+            "\t\t* Grandchild from tab\n" +
+            "+ Sibling";
+
+        var nodes = TaskOutlineClipboardService.ParseOutline(outline);
+
+        await Assert.That(nodes.Count).IsEqualTo(2);
+        await Assert.That(nodes[0].Title).IsEqualTo("Root");
+        await Assert.That(nodes[0].Children.Single().Title).IsEqualTo("Child from spaces");
+        await Assert.That(nodes[0].Children.Single().Children.Single().Title).IsEqualTo("Grandchild from tab");
+        await Assert.That(nodes[1].Title).IsEqualTo("Sibling");
+    }
+
+    [Test]
+    public async Task ParseOutline_ClampsIndentationJumpsToPreviousNode()
+    {
+        const string outline =
+            "Root\n" +
+            "\t\tJumped child";
+
+        var nodes = TaskOutlineClipboardService.ParseOutline(outline);
+
+        await Assert.That(nodes).HasSingleItem();
+        await Assert.That(nodes[0].Children.Single().Title).IsEqualTo("Jumped child");
+    }
+}

--- a/src/Unlimotion.ViewModel/INotificationManagerWrapper.cs
+++ b/src/Unlimotion.ViewModel/INotificationManagerWrapper.cs
@@ -1,10 +1,13 @@
-﻿using System;
+using System;
+using System.Threading.Tasks;
 
 namespace Unlimotion.ViewModel;
 
 public interface INotificationManagerWrapper
 {
     void Ask(string header, string message, Action yesAction, Action noAction = null);
+
+    Task<bool> ConfirmTaskOutlinePasteAsync(TaskOutlinePastePreview preview);
 
     void ErrorToast(string message);
 

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -24,7 +24,9 @@ namespace Unlimotion.ViewModel
         ExpandAll,
         CollapseAll,
         DeleteSelection,
-        SelectAll
+        SelectAll,
+        CopyOutline,
+        PasteOutline
     }
 
     [AddINotifyPropertyChangedInterface]
@@ -235,6 +237,18 @@ namespace Unlimotion.ViewModel
                 .AddToDisposeAndReturn(connectionDisposableList);
             SelectAllTreeItemsCommand = ReactiveCommand.Create(() =>
                 ExecuteTreeCommandAction?.Invoke(TreeCommandKind.SelectAll))
+                .AddToDisposeAndReturn(connectionDisposableList);
+            CopyTaskOutlineTreeCommand = ReactiveCommand.Create(() =>
+                ExecuteTreeCommandAction?.Invoke(TreeCommandKind.CopyOutline))
+                .AddToDisposeAndReturn(connectionDisposableList);
+            PasteTaskOutlineTreeCommand = ReactiveCommand.Create(() =>
+                ExecuteTreeCommandAction?.Invoke(TreeCommandKind.PasteOutline))
+                .AddToDisposeAndReturn(connectionDisposableList);
+            CopyTaskOutlineCommand = ReactiveCommand.CreateFromTask(async () =>
+                await CopyTaskOutline(CurrentTaskItem))
+                .AddToDisposeAndReturn(connectionDisposableList);
+            PasteTaskOutlineCommand = ReactiveCommand.CreateFromTask(async () =>
+                await PasteTaskOutline(CurrentTaskItem))
                 .AddToDisposeAndReturn(connectionDisposableList);
 
             //Select CurrentTaskItem from all tabs
@@ -1589,6 +1603,101 @@ namespace Unlimotion.ViewModel
             CurrentRelationEditor.Open(kind, CurrentTaskItem);
         }
 
+        public async Task CopyTaskOutline(TaskItemViewModel? task = null)
+        {
+            var source = task ?? CurrentTaskItem;
+            if (source == null)
+            {
+                return;
+            }
+
+            if (SetClipboardTextAsync == null)
+            {
+                ManagerWrapper?.ErrorToast(L10n.Get("ClipboardUnavailable"));
+                return;
+            }
+
+            var outline = TaskOutlineClipboardService.BuildOutline(source);
+            await SetClipboardTextAsync(outline);
+        }
+
+        public async Task CopyTaskOutline(TaskWrapperViewModel? wrapper)
+        {
+            if (wrapper == null)
+            {
+                await CopyTaskOutline(CurrentTaskItem);
+                return;
+            }
+
+            if (SetClipboardTextAsync == null)
+            {
+                ManagerWrapper?.ErrorToast(L10n.Get("ClipboardUnavailable"));
+                return;
+            }
+
+            var outline = TaskOutlineClipboardService.BuildOutline(wrapper);
+            await SetClipboardTextAsync(outline);
+        }
+
+        public async Task PasteTaskOutline(TaskItemViewModel? destination = null)
+        {
+            if (taskRepository == null)
+            {
+                ManagerWrapper?.ErrorToast(L10n.Get("TaskStorageNotConfigured"));
+                return;
+            }
+
+            if (GetClipboardTextAsync == null)
+            {
+                ManagerWrapper?.ErrorToast(L10n.Get("ClipboardUnavailable"));
+                return;
+            }
+
+            var outline = await GetClipboardTextAsync();
+            var nodes = TaskOutlineClipboardService.ParseOutline(outline);
+            if (nodes.Count == 0)
+            {
+                return;
+            }
+
+            var parent = destination ?? CurrentTaskItem;
+            TaskItemViewModel? firstCreated = null;
+
+            foreach (var node in nodes)
+            {
+                var created = await CreateTaskFromOutlineNode(node, parent);
+                firstCreated ??= created;
+            }
+
+            if (firstCreated == null)
+            {
+                return;
+            }
+
+            CurrentTaskItem = firstCreated;
+            SelectCurrentTask();
+            ExpandParentNodesForTask(firstCreated);
+        }
+
+        private async Task<TaskItemViewModel> CreateTaskFromOutlineNode(
+            TaskOutlineNode node,
+            TaskItemViewModel? parent)
+        {
+            var created = parent == null
+                ? await taskRepository!.Add()
+                : await taskRepository!.AddChild(parent);
+
+            created.Title = node.Title;
+            await taskRepository.Update(created);
+
+            foreach (var child in node.Children)
+            {
+                await CreateTaskFromOutlineNode(child, created);
+            }
+
+            return created;
+        }
+
         private TaskItemViewModel? FindTaskById(string taskId)
         {
             if (taskRepository == null || string.IsNullOrWhiteSpace(taskId))
@@ -1849,7 +1958,19 @@ namespace Unlimotion.ViewModel
 
         public ICommand SelectAllTreeItemsCommand { get; set; }
 
+        public ICommand CopyTaskOutlineTreeCommand { get; set; }
+
+        public ICommand PasteTaskOutlineTreeCommand { get; set; }
+
+        public ICommand CopyTaskOutlineCommand { get; set; }
+
+        public ICommand PasteTaskOutlineCommand { get; set; }
+
         public Action<TreeCommandKind>? ExecuteTreeCommandAction { get; set; }
+
+        public Func<string, Task>? SetClipboardTextAsync { get; set; }
+
+        public Func<Task<string?>>? GetClipboardTextAsync { get; set; }
 
         private IConfiguration _configuration = null!;
 

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -1617,7 +1617,7 @@ namespace Unlimotion.ViewModel
                 return;
             }
 
-            var outline = TaskOutlineClipboardService.BuildOutline(source);
+            var outline = TaskOutlineClipboardService.BuildOutline(source, GetTaskOutlineClipboardOptions());
             await SetClipboardTextAsync(outline);
         }
 
@@ -1635,7 +1635,7 @@ namespace Unlimotion.ViewModel
                 return;
             }
 
-            var outline = TaskOutlineClipboardService.BuildOutline(wrapper);
+            var outline = TaskOutlineClipboardService.BuildOutline(wrapper, GetTaskOutlineClipboardOptions());
             await SetClipboardTextAsync(outline);
         }
 
@@ -1661,6 +1661,27 @@ namespace Unlimotion.ViewModel
             }
 
             var parent = destination ?? CurrentTaskItem;
+            var capturedParentId = parent?.Id;
+            var preview = CreateTaskOutlinePastePreview(nodes, parent);
+            if (!await ManagerWrapper.ConfirmTaskOutlinePasteAsync(preview))
+            {
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(capturedParentId))
+            {
+                parent = FindTaskById(capturedParentId);
+                if (parent == null)
+                {
+                    ManagerWrapper?.ErrorToast(L10n.Get("PasteTaskOutlineDestinationUnavailable"));
+                    return;
+                }
+            }
+            else
+            {
+                parent = null;
+            }
+
             TaskItemViewModel? firstCreated = null;
 
             foreach (var node in nodes)
@@ -1688,7 +1709,25 @@ namespace Unlimotion.ViewModel
                 : await taskRepository!.AddChild(parent);
 
             created.Title = node.Title;
-            await taskRepository.Update(created);
+            if (!string.IsNullOrWhiteSpace(node.Description))
+            {
+                created.Description = node.Description;
+            }
+
+            if (node.IsCompleted.HasValue)
+            {
+                created.IsCompleted = node.IsCompleted.Value;
+                created.ArchiveDateTime = null;
+                created.CompletedDateTime = node.IsCompleted.Value
+                    ? created.CompletedDateTime ?? DateTimeOffset.UtcNow
+                    : null;
+            }
+
+            var createdId = created.Id;
+            var updated = await taskRepository.Update(created);
+            created = updated?.Id == createdId
+                ? updated
+                : FindTaskById(createdId) ?? created;
 
             foreach (var child in node.Children)
             {
@@ -1696,6 +1735,40 @@ namespace Unlimotion.ViewModel
             }
 
             return created;
+        }
+
+        private TaskOutlineClipboardOptions GetTaskOutlineClipboardOptions()
+        {
+            return new TaskOutlineClipboardOptions(
+                Settings.CopyTaskOutlineAsMarkdown,
+                Settings.CopyTaskOutlineDescription);
+        }
+
+        private TaskOutlinePastePreview CreateTaskOutlinePastePreview(
+            IReadOnlyList<TaskOutlineNode> nodes,
+            TaskItemViewModel? destination)
+        {
+            var destinationLabel = destination == null
+                ? L10n.Get("PasteTaskOutlineDestinationRoot")
+                : L10n.Format("PasteTaskOutlineDestinationInto", GetTaskOutlineDestinationName(destination));
+            var taskCount = TaskOutlineClipboardService.CountNodes(nodes);
+
+            return new TaskOutlinePastePreview(
+                L10n.Get("PasteTaskOutlineConfirmHeader"),
+                destinationLabel,
+                L10n.Format("PasteTaskOutlineTaskCount", taskCount),
+                TaskOutlineClipboardService.BuildPreviewText(nodes),
+                taskCount);
+        }
+
+        private static string GetTaskOutlineDestinationName(TaskItemViewModel destination)
+        {
+            if (!string.IsNullOrWhiteSpace(destination.Title))
+            {
+                return destination.Title;
+            }
+
+            return string.IsNullOrWhiteSpace(destination.Id) ? "?" : destination.Id;
         }
 
         private TaskItemViewModel? FindTaskById(string taskId)

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -70,6 +70,8 @@
   <data name="ContainingTasks" xml:space="preserve"><value>Containing tasks:</value></data>
   <data name="CopyPublicKey" xml:space="preserve"><value>Copy public key</value></data>
   <data name="CopyServerTasksToLocal" xml:space="preserve"><value>Copy tasks from server to local storage</value></data>
+  <data name="CopyTaskOutlineAsMarkdown" xml:space="preserve"><value>Copy in Markdown format</value></data>
+  <data name="CopyTaskOutlineDescription" xml:space="preserve"><value>Copy description</value></data>
   <data name="CopyTaskOutline" xml:space="preserve"><value>Copy task outline</value></data>
   <data name="CopyTasksHeader" xml:space="preserve"><value>Copy tasks</value></data>
   <data name="CopyTasksMessage" xml:space="preserve"><value>Are you sure you want to copy {0} selected tasks into "{1}"?</value></data>
@@ -163,6 +165,11 @@
   <data name="ParentsTasks" xml:space="preserve"><value>Parent tasks:</value></data>
   <data name="Password" xml:space="preserve"><value>Password</value></data>
   <data name="PasteTaskOutline" xml:space="preserve"><value>Paste task outline</value></data>
+  <data name="PasteTaskOutlineConfirmHeader" xml:space="preserve"><value>Paste task outline?</value></data>
+  <data name="PasteTaskOutlineDestinationInto" xml:space="preserve"><value>Into: {0}</value></data>
+  <data name="PasteTaskOutlineDestinationRoot" xml:space="preserve"><value>Into the task list root</value></data>
+  <data name="PasteTaskOutlineDestinationUnavailable" xml:space="preserve"><value>The paste destination is no longer available.</value></data>
+  <data name="PasteTaskOutlineTaskCount" xml:space="preserve"><value>Tasks to create: {0}</value></data>
   <data name="Period" xml:space="preserve"><value>Period</value></data>
   <data name="PlannedBegin" xml:space="preserve"><value>Planned Begin</value></data>
   <data name="PlannedDuration" xml:space="preserve"><value>Planned Duration</value></data>
@@ -267,6 +274,8 @@
   <data name="SyncErrorToast" xml:space="preserve"><value>Could not synchronize repository: {0}</value></data>
   <data name="SyncNow" xml:space="preserve"><value>Synchronize now</value></data>
   <data name="SyncingRepository" xml:space="preserve"><value>Synchronizing with repository...</value></data>
+  <data name="TaskOutlineClipboardSettingsHint" xml:space="preserve"><value>Choose how task outlines are copied. Pasted outlines are recognized automatically.</value></data>
+  <data name="TaskOutlineClipboardSettingsTitle" xml:space="preserve"><value>Task outline clipboard</value></data>
   <data name="TaskStorageNotConfigured" xml:space="preserve"><value>Task storage is not configured.</value></data>
   <data name="TenDays" xml:space="preserve"><value>10 days</value></data>
   <data name="TenMinutes" xml:space="preserve"><value>10 minutes</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -70,6 +70,7 @@
   <data name="ContainingTasks" xml:space="preserve"><value>Containing tasks:</value></data>
   <data name="CopyPublicKey" xml:space="preserve"><value>Copy public key</value></data>
   <data name="CopyServerTasksToLocal" xml:space="preserve"><value>Copy tasks from server to local storage</value></data>
+  <data name="CopyTaskOutline" xml:space="preserve"><value>Copy task outline</value></data>
   <data name="CopyTasksHeader" xml:space="preserve"><value>Copy tasks</value></data>
   <data name="CopyTasksMessage" xml:space="preserve"><value>Are you sure you want to copy {0} selected tasks into "{1}"?</value></data>
   <data name="CreatedLabelFormat" xml:space="preserve"><value>Created: {0:yyyy.MM.dd HH:mm}</value></data>
@@ -161,6 +162,7 @@
   <data name="ParamsSavedConnectRepository" xml:space="preserve"><value>Parameters saved. Click "Connect repository".</value></data>
   <data name="ParentsTasks" xml:space="preserve"><value>Parent tasks:</value></data>
   <data name="Password" xml:space="preserve"><value>Password</value></data>
+  <data name="PasteTaskOutline" xml:space="preserve"><value>Paste task outline</value></data>
   <data name="Period" xml:space="preserve"><value>Period</value></data>
   <data name="PlannedBegin" xml:space="preserve"><value>Planned Begin</value></data>
   <data name="PlannedDuration" xml:space="preserve"><value>Planned Duration</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -70,6 +70,7 @@
   <data name="ContainingTasks" xml:space="preserve"><value>Содержащие задачи:</value></data>
   <data name="CopyPublicKey" xml:space="preserve"><value>Копировать публичный ключ</value></data>
   <data name="CopyServerTasksToLocal" xml:space="preserve"><value>Скопировать задачи с сервера в локальное хранилище</value></data>
+  <data name="CopyTaskOutline" xml:space="preserve"><value>Копировать задачу аутлайном</value></data>
   <data name="CopyTasksHeader" xml:space="preserve"><value>Копировать задачи</value></data>
   <data name="CopyTasksMessage" xml:space="preserve"><value>Копировать {0} выбранных задач в "{1}"?</value></data>
   <data name="CreatedLabelFormat" xml:space="preserve"><value>Создано: {0:yyyy.MM.dd HH:mm}</value></data>
@@ -161,6 +162,7 @@
   <data name="ParamsSavedConnectRepository" xml:space="preserve"><value>Параметры сохранены. Нажмите "Подключить репозиторий".</value></data>
   <data name="ParentsTasks" xml:space="preserve"><value>Родительские задачи:</value></data>
   <data name="Password" xml:space="preserve"><value>Пароль</value></data>
+  <data name="PasteTaskOutline" xml:space="preserve"><value>Вставить задачу аутлайном</value></data>
   <data name="Period" xml:space="preserve"><value>Период</value></data>
   <data name="PlannedBegin" xml:space="preserve"><value>Планируемое начало</value></data>
   <data name="PlannedDuration" xml:space="preserve"><value>Планируемая длительность</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -70,6 +70,8 @@
   <data name="ContainingTasks" xml:space="preserve"><value>Содержащие задачи:</value></data>
   <data name="CopyPublicKey" xml:space="preserve"><value>Копировать публичный ключ</value></data>
   <data name="CopyServerTasksToLocal" xml:space="preserve"><value>Скопировать задачи с сервера в локальное хранилище</value></data>
+  <data name="CopyTaskOutlineAsMarkdown" xml:space="preserve"><value>Копирование в Markdown формате</value></data>
+  <data name="CopyTaskOutlineDescription" xml:space="preserve"><value>Копировать описание</value></data>
   <data name="CopyTaskOutline" xml:space="preserve"><value>Копировать задачу аутлайном</value></data>
   <data name="CopyTasksHeader" xml:space="preserve"><value>Копировать задачи</value></data>
   <data name="CopyTasksMessage" xml:space="preserve"><value>Копировать {0} выбранных задач в "{1}"?</value></data>
@@ -163,6 +165,11 @@
   <data name="ParentsTasks" xml:space="preserve"><value>Родительские задачи:</value></data>
   <data name="Password" xml:space="preserve"><value>Пароль</value></data>
   <data name="PasteTaskOutline" xml:space="preserve"><value>Вставить задачу аутлайном</value></data>
+  <data name="PasteTaskOutlineConfirmHeader" xml:space="preserve"><value>Вставить аутлайн задач?</value></data>
+  <data name="PasteTaskOutlineDestinationInto" xml:space="preserve"><value>Внутрь: {0}</value></data>
+  <data name="PasteTaskOutlineDestinationRoot" xml:space="preserve"><value>В корень списка задач</value></data>
+  <data name="PasteTaskOutlineDestinationUnavailable" xml:space="preserve"><value>Место вставки больше недоступно.</value></data>
+  <data name="PasteTaskOutlineTaskCount" xml:space="preserve"><value>Будет создано задач: {0}</value></data>
   <data name="Period" xml:space="preserve"><value>Период</value></data>
   <data name="PlannedBegin" xml:space="preserve"><value>Планируемое начало</value></data>
   <data name="PlannedDuration" xml:space="preserve"><value>Планируемая длительность</value></data>
@@ -267,6 +274,8 @@
   <data name="SyncErrorToast" xml:space="preserve"><value>Не удалось синхронизировать репозиторий: {0}</value></data>
   <data name="SyncNow" xml:space="preserve"><value>Синхронизировать сейчас</value></data>
   <data name="SyncingRepository" xml:space="preserve"><value>Синхронизация с репозиторием...</value></data>
+  <data name="TaskOutlineClipboardSettingsHint" xml:space="preserve"><value>Выберите, как копировать аутлайн задач. Вставляемые аутлайны распознаются автоматически.</value></data>
+  <data name="TaskOutlineClipboardSettingsTitle" xml:space="preserve"><value>Буфер обмена аутлайном задач</value></data>
   <data name="TaskStorageNotConfigured" xml:space="preserve"><value>Хранилище задач не настроено.</value></data>
   <data name="TenDays" xml:space="preserve"><value>10 дней</value></data>
   <data name="TenMinutes" xml:space="preserve"><value>10 минут</value></data>

--- a/src/Unlimotion.ViewModel/SettingsViewModel.cs
+++ b/src/Unlimotion.ViewModel/SettingsViewModel.cs
@@ -20,11 +20,15 @@ public class SettingsViewModel
     private const string ClientSettingsSectionName = "ClientSettings";
     private const string ClientLoginKey = "Login";
     private const string DefaultTaskStoragePath = "Tasks";
+    private const string TaskOutlineClipboardSectionName = "TaskOutlineClipboard";
+    private const string TaskOutlineCopyAsMarkdownKey = "CopyAsMarkdown";
+    private const string TaskOutlineCopyDescriptionKey = "CopyDescription";
 
     private readonly IConfiguration _configuration;
     private readonly IConfiguration _taskStorageSettings;
     private readonly IConfiguration _gitSettings;
     private readonly IConfiguration _appearanceSettings;
+    private readonly IConfiguration _taskOutlineClipboardSettings;
     private readonly IRemoteBackupService? _backupService;
     private readonly ILocalizationService _localization;
     private readonly bool _defaultIsDarkTheme;
@@ -53,6 +57,8 @@ public class SettingsViewModel
     private string? _gitCommitterEmail;
     private string? _gitSshPrivateKeyPath;
     private string? _gitSshPublicKeyPath;
+    private bool _copyTaskOutlineAsMarkdown;
+    private bool _copyTaskOutlineDescription;
 
     public SettingsViewModel(
         IConfiguration configuration,
@@ -65,6 +71,7 @@ public class SettingsViewModel
         _taskStorageSettings = configuration.GetSection("TaskStorage");
         _gitSettings = configuration.GetSection("Git");
         _appearanceSettings = configuration.GetSection(AppearanceSettings.SectionName);
+        _taskOutlineClipboardSettings = configuration.GetSection(TaskOutlineClipboardSectionName);
         _backupService = backupService;
         _localization = localizationService ?? LocalizationService.Current;
         _defaultIsDarkTheme = defaultIsDarkTheme;
@@ -96,6 +103,8 @@ public class SettingsViewModel
         _gitCommitterEmail = _gitSettings.GetSection(nameof(GitSettings.CommitterEmail)).Get<string>();
         _gitSshPrivateKeyPath = _gitSettings.GetSection(nameof(GitSettings.SshPrivateKeyPath)).Get<string>();
         _gitSshPublicKeyPath = _gitSettings.GetSection(nameof(GitSettings.SshPublicKeyPath)).Get<string>();
+        _copyTaskOutlineAsMarkdown = _taskOutlineClipboardSettings.GetSection(TaskOutlineCopyAsMarkdownKey).Get<bool>();
+        _copyTaskOutlineDescription = _taskOutlineClipboardSettings.GetSection(TaskOutlineCopyDescriptionKey).Get<bool>();
 
         ConnectedServerLogin = GetStoredClientLogin();
         StorageConnectionState = IsServerMode ? SettingsConnectionState.Disconnected : SettingsConnectionState.Connected;
@@ -284,6 +293,26 @@ public class SettingsViewModel
     {
         get => _configuration.GetSection(nameof(IsFuzzySearch)).Get<bool>();
         set => _configuration.GetSection(nameof(IsFuzzySearch)).Set(value);
+    }
+
+    public bool CopyTaskOutlineAsMarkdown
+    {
+        get => _copyTaskOutlineAsMarkdown;
+        set
+        {
+            _copyTaskOutlineAsMarkdown = value;
+            _taskOutlineClipboardSettings.GetSection(TaskOutlineCopyAsMarkdownKey).Set(value);
+        }
+    }
+
+    public bool CopyTaskOutlineDescription
+    {
+        get => _copyTaskOutlineDescription;
+        set
+        {
+            _copyTaskOutlineDescription = value;
+            _taskOutlineClipboardSettings.GetSection(TaskOutlineCopyDescriptionKey).Set(value);
+        }
     }
 
     public double FontSize

--- a/src/Unlimotion.ViewModel/TaskOutlineClipboardService.cs
+++ b/src/Unlimotion.ViewModel/TaskOutlineClipboardService.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Unlimotion.ViewModel;
+
+public sealed class TaskOutlineNode
+{
+    public TaskOutlineNode(string title)
+    {
+        Title = title;
+    }
+
+    public string Title { get; }
+
+    public List<TaskOutlineNode> Children { get; } = new();
+}
+
+public static class TaskOutlineClipboardService
+{
+    private const int SpacesPerLevel = 4;
+
+    public static string BuildOutline(TaskItemViewModel root)
+    {
+        if (root == null)
+        {
+            throw new ArgumentNullException(nameof(root));
+        }
+
+        var builder = new StringBuilder();
+        AppendTask(builder, root, 0, new HashSet<string>(StringComparer.Ordinal));
+        return builder.ToString().TrimEnd('\r', '\n');
+    }
+
+    public static string BuildOutline(TaskWrapperViewModel root)
+    {
+        if (root == null)
+        {
+            throw new ArgumentNullException(nameof(root));
+        }
+
+        var builder = new StringBuilder();
+        AppendWrapper(builder, root, 0, new HashSet<string>(StringComparer.Ordinal));
+        return builder.ToString().TrimEnd('\r', '\n');
+    }
+
+    public static IReadOnlyList<TaskOutlineNode> ParseOutline(string? outline)
+    {
+        if (string.IsNullOrWhiteSpace(outline))
+        {
+            return Array.Empty<TaskOutlineNode>();
+        }
+
+        var roots = new List<TaskOutlineNode>();
+        var stack = new List<TaskOutlineNode>();
+
+        foreach (var rawLine in SplitLines(outline))
+        {
+            if (string.IsNullOrWhiteSpace(rawLine))
+            {
+                continue;
+            }
+
+            var (level, title) = ParseLine(rawLine);
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                continue;
+            }
+
+            var node = new TaskOutlineNode(title);
+            var normalizedLevel = Math.Min(level, stack.Count);
+
+            if (normalizedLevel == 0)
+            {
+                roots.Add(node);
+            }
+            else
+            {
+                stack[normalizedLevel - 1].Children.Add(node);
+            }
+
+            if (stack.Count > normalizedLevel)
+            {
+                stack.RemoveRange(normalizedLevel, stack.Count - normalizedLevel);
+            }
+
+            stack.Add(node);
+        }
+
+        return roots;
+    }
+
+    private static void AppendTask(
+        StringBuilder builder,
+        TaskItemViewModel task,
+        int level,
+        ISet<string> path)
+    {
+        if (task == null || string.IsNullOrWhiteSpace(task.Id) || !path.Add(task.Id))
+        {
+            return;
+        }
+
+        if (builder.Length > 0)
+        {
+            builder.AppendLine();
+        }
+
+        AppendTaskLine(builder, task, level);
+
+        foreach (var child in task.ContainsTasks)
+        {
+            AppendTask(builder, child, level + 1, path);
+        }
+
+        path.Remove(task.Id);
+    }
+
+    private static void AppendWrapper(
+        StringBuilder builder,
+        TaskWrapperViewModel wrapper,
+        int level,
+        ISet<string> path)
+    {
+        var task = wrapper.TaskItem;
+        if (task == null || string.IsNullOrWhiteSpace(task.Id) || !path.Add(task.Id))
+        {
+            return;
+        }
+
+        if (builder.Length > 0)
+        {
+            builder.AppendLine();
+        }
+
+        AppendTaskLine(builder, task, level);
+
+        foreach (var child in wrapper.SubTasks)
+        {
+            AppendWrapper(builder, child, level + 1, path);
+        }
+
+        path.Remove(task.Id);
+    }
+
+    private static void AppendTaskLine(StringBuilder builder, TaskItemViewModel task, int level)
+    {
+        builder.Append('\t', level);
+        builder.Append(NormalizeTitle(task.Title));
+    }
+
+    private static string NormalizeTitle(string? title)
+    {
+        return (title ?? string.Empty)
+            .Replace("\r\n", " ")
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .TrimEnd();
+    }
+
+    private static IEnumerable<string> SplitLines(string outline)
+    {
+        return outline
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n')
+            .Split('\n');
+    }
+
+    private static (int Level, string Title) ParseLine(string line)
+    {
+        var index = 0;
+        var columns = 0;
+
+        while (index < line.Length)
+        {
+            if (line[index] == '\t')
+            {
+                columns += SpacesPerLevel;
+                index++;
+                continue;
+            }
+
+            if (line[index] == ' ')
+            {
+                columns++;
+                index++;
+                continue;
+            }
+
+            break;
+        }
+
+        var title = StripBulletMarker(line[index..]).Trim();
+        return (columns / SpacesPerLevel, title);
+    }
+
+    private static string StripBulletMarker(string text)
+    {
+        if (text.Length >= 2 && text[1] == ' ' && (text[0] == '-' || text[0] == '*' || text[0] == '+'))
+        {
+            return text[2..];
+        }
+
+        return text;
+    }
+}

--- a/src/Unlimotion.ViewModel/TaskOutlineClipboardService.cs
+++ b/src/Unlimotion.ViewModel/TaskOutlineClipboardService.cs
@@ -7,21 +7,71 @@ namespace Unlimotion.ViewModel;
 
 public sealed class TaskOutlineNode
 {
-    public TaskOutlineNode(string title)
+    public TaskOutlineNode(string title, string? description = null, bool? isCompleted = null)
     {
         Title = title;
+        Description = description ?? string.Empty;
+        IsCompleted = isCompleted;
     }
 
     public string Title { get; }
 
+    public string Description { get; private set; }
+
+    public bool? IsCompleted { get; }
+
     public List<TaskOutlineNode> Children { get; } = new();
+
+    internal void AppendDescriptionLine(string line)
+    {
+        if (string.IsNullOrWhiteSpace(line))
+        {
+            return;
+        }
+
+        Description = string.IsNullOrEmpty(Description)
+            ? line.TrimEnd()
+            : $"{Description}{Environment.NewLine}{line.TrimEnd()}";
+    }
+}
+
+public sealed record TaskOutlineClipboardOptions(bool CopyAsMarkdown, bool CopyDescription)
+{
+    public static TaskOutlineClipboardOptions Default { get; } = new(false, false);
+}
+
+public sealed class TaskOutlinePastePreview
+{
+    public TaskOutlinePastePreview(
+        string header,
+        string destinationLabel,
+        string taskCountText,
+        string previewText,
+        int taskCount)
+    {
+        Header = header;
+        DestinationLabel = destinationLabel;
+        TaskCountText = taskCountText;
+        PreviewText = previewText;
+        TaskCount = taskCount;
+    }
+
+    public string Header { get; }
+
+    public string DestinationLabel { get; }
+
+    public string TaskCountText { get; }
+
+    public string PreviewText { get; }
+
+    public int TaskCount { get; }
 }
 
 public static class TaskOutlineClipboardService
 {
     private const int SpacesPerLevel = 4;
 
-    public static string BuildOutline(TaskItemViewModel root)
+    public static string BuildOutline(TaskItemViewModel root, TaskOutlineClipboardOptions? options = null)
     {
         if (root == null)
         {
@@ -29,11 +79,11 @@ public static class TaskOutlineClipboardService
         }
 
         var builder = new StringBuilder();
-        AppendTask(builder, root, 0, new HashSet<string>(StringComparer.Ordinal));
+        AppendTask(builder, root, 0, new HashSet<string>(StringComparer.Ordinal), options ?? TaskOutlineClipboardOptions.Default);
         return builder.ToString().TrimEnd('\r', '\n');
     }
 
-    public static string BuildOutline(TaskWrapperViewModel root)
+    public static string BuildOutline(TaskWrapperViewModel root, TaskOutlineClipboardOptions? options = null)
     {
         if (root == null)
         {
@@ -41,7 +91,7 @@ public static class TaskOutlineClipboardService
         }
 
         var builder = new StringBuilder();
-        AppendWrapper(builder, root, 0, new HashSet<string>(StringComparer.Ordinal));
+        AppendWrapper(builder, root, 0, new HashSet<string>(StringComparer.Ordinal), options ?? TaskOutlineClipboardOptions.Default);
         return builder.ToString().TrimEnd('\r', '\n');
     }
 
@@ -52,23 +102,44 @@ public static class TaskOutlineClipboardService
             return Array.Empty<TaskOutlineNode>();
         }
 
+        var lines = SplitLines(outline).ToList();
+        var markedOutlineMode = lines.Any(line =>
+        {
+            var (_, content) = ParseIndent(line);
+            return TryParseTaskContent(content).HasMarker;
+        });
+
         var roots = new List<TaskOutlineNode>();
         var stack = new List<TaskOutlineNode>();
 
-        foreach (var rawLine in SplitLines(outline))
+        foreach (var rawLine in lines)
         {
             if (string.IsNullOrWhiteSpace(rawLine))
             {
                 continue;
             }
 
-            var (level, title) = ParseLine(rawLine);
+            var (level, content) = ParseIndent(rawLine);
+            var parsed = TryParseTaskContent(content);
+
+            if (markedOutlineMode && !parsed.HasMarker && stack.Count > 0 && level > 0)
+            {
+                var descriptionTargetIndex = Math.Min(level, stack.Count) - 1;
+                if (descriptionTargetIndex >= 0)
+                {
+                    stack[descriptionTargetIndex].AppendDescriptionLine(content.Trim());
+                }
+
+                continue;
+            }
+
+            var title = parsed.Title.Trim();
             if (string.IsNullOrWhiteSpace(title))
             {
                 continue;
             }
 
-            var node = new TaskOutlineNode(title);
+            var node = new TaskOutlineNode(title, isCompleted: parsed.IsCompleted);
             var normalizedLevel = Math.Min(level, stack.Count);
 
             if (normalizedLevel == 0)
@@ -91,11 +162,38 @@ public static class TaskOutlineClipboardService
         return roots;
     }
 
+    public static int CountNodes(IReadOnlyList<TaskOutlineNode> nodes)
+    {
+        if (nodes == null)
+        {
+            return 0;
+        }
+
+        return nodes.Sum(node => 1 + CountNodes(node.Children));
+    }
+
+    public static string BuildPreviewText(IReadOnlyList<TaskOutlineNode> nodes)
+    {
+        if (nodes == null || nodes.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        foreach (var node in nodes)
+        {
+            AppendPreviewNode(builder, node, 0);
+        }
+
+        return builder.ToString().TrimEnd('\r', '\n');
+    }
+
     private static void AppendTask(
         StringBuilder builder,
         TaskItemViewModel task,
         int level,
-        ISet<string> path)
+        ISet<string> path,
+        TaskOutlineClipboardOptions options)
     {
         if (task == null || string.IsNullOrWhiteSpace(task.Id) || !path.Add(task.Id))
         {
@@ -107,11 +205,12 @@ public static class TaskOutlineClipboardService
             builder.AppendLine();
         }
 
-        AppendTaskLine(builder, task, level);
+        AppendTaskLine(builder, task, level, options);
+        AppendDescription(builder, task.Description, level, options);
 
         foreach (var child in task.ContainsTasks)
         {
-            AppendTask(builder, child, level + 1, path);
+            AppendTask(builder, child, level + 1, path, options);
         }
 
         path.Remove(task.Id);
@@ -121,7 +220,8 @@ public static class TaskOutlineClipboardService
         StringBuilder builder,
         TaskWrapperViewModel wrapper,
         int level,
-        ISet<string> path)
+        ISet<string> path,
+        TaskOutlineClipboardOptions options)
     {
         var task = wrapper.TaskItem;
         if (task == null || string.IsNullOrWhiteSpace(task.Id) || !path.Add(task.Id))
@@ -134,20 +234,93 @@ public static class TaskOutlineClipboardService
             builder.AppendLine();
         }
 
-        AppendTaskLine(builder, task, level);
+        AppendTaskLine(builder, task, level, options);
+        AppendDescription(builder, task.Description, level, options);
 
         foreach (var child in wrapper.SubTasks)
         {
-            AppendWrapper(builder, child, level + 1, path);
+            AppendWrapper(builder, child, level + 1, path, options);
         }
 
         path.Remove(task.Id);
     }
 
-    private static void AppendTaskLine(StringBuilder builder, TaskItemViewModel task, int level)
+    private static void AppendTaskLine(
+        StringBuilder builder,
+        TaskItemViewModel task,
+        int level,
+        TaskOutlineClipboardOptions options)
     {
-        builder.Append('\t', level);
+        AppendIndent(builder, level, options.CopyAsMarkdown || options.CopyDescription);
+        if (options.CopyAsMarkdown)
+        {
+            builder.Append(task.IsCompleted == true ? "- [x] " : "- [ ] ");
+        }
+        else if (options.CopyDescription)
+        {
+            builder.Append("- ");
+        }
+
         builder.Append(NormalizeTitle(task.Title));
+    }
+
+    private static void AppendDescription(
+        StringBuilder builder,
+        string? description,
+        int taskLevel,
+        TaskOutlineClipboardOptions options)
+    {
+        if (!options.CopyDescription)
+        {
+            return;
+        }
+
+        foreach (var line in NormalizeDescriptionLines(description))
+        {
+            builder.AppendLine();
+            AppendIndent(builder, taskLevel + 1, true);
+            builder.Append(line);
+        }
+    }
+
+    private static void AppendPreviewNode(StringBuilder builder, TaskOutlineNode node, int level)
+    {
+        if (builder.Length > 0)
+        {
+            builder.AppendLine();
+        }
+
+        AppendIndent(builder, level, true);
+        builder.Append(node.IsCompleted switch
+        {
+            true => "- [x] ",
+            false => "- [ ] ",
+            _ => "- "
+        });
+        builder.Append(NormalizeTitle(node.Title));
+
+        foreach (var line in NormalizeDescriptionLines(node.Description))
+        {
+            builder.AppendLine();
+            AppendIndent(builder, level + 1, true);
+            builder.Append(line);
+        }
+
+        foreach (var child in node.Children)
+        {
+            AppendPreviewNode(builder, child, level + 1);
+        }
+    }
+
+    private static void AppendIndent(StringBuilder builder, int level, bool spaces)
+    {
+        if (spaces)
+        {
+            builder.Append(' ', Math.Max(level, 0) * SpacesPerLevel);
+            return;
+        }
+
+        builder.Append('\t', Math.Max(level, 0));
     }
 
     private static string NormalizeTitle(string? title)
@@ -159,6 +332,35 @@ public static class TaskOutlineClipboardService
             .TrimEnd();
     }
 
+    private static IReadOnlyList<string> NormalizeDescriptionLines(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return Array.Empty<string>();
+        }
+
+        var lines = description
+            .Replace("\r\n", "\n")
+            .Replace('\r', '\n')
+            .Split('\n')
+            .ToList();
+
+        while (lines.Count > 0 && string.IsNullOrWhiteSpace(lines[0]))
+        {
+            lines.RemoveAt(0);
+        }
+
+        while (lines.Count > 0 && string.IsNullOrWhiteSpace(lines[^1]))
+        {
+            lines.RemoveAt(lines.Count - 1);
+        }
+
+        return lines
+            .Select(line => line.TrimEnd())
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .ToList();
+    }
+
     private static IEnumerable<string> SplitLines(string outline)
     {
         return outline
@@ -167,7 +369,7 @@ public static class TaskOutlineClipboardService
             .Split('\n');
     }
 
-    private static (int Level, string Title) ParseLine(string line)
+    private static (int Level, string Content) ParseIndent(string line)
     {
         var index = 0;
         var columns = 0;
@@ -191,17 +393,53 @@ public static class TaskOutlineClipboardService
             break;
         }
 
-        var title = StripBulletMarker(line[index..]).Trim();
-        return (columns / SpacesPerLevel, title);
+        return (columns / SpacesPerLevel, line[index..]);
     }
 
-    private static string StripBulletMarker(string text)
+    private static ParsedTaskContent TryParseTaskContent(string text)
     {
-        if (text.Length >= 2 && text[1] == ' ' && (text[0] == '-' || text[0] == '*' || text[0] == '+'))
+        if (TryParseMarkdownChecklist(text, out var checklistTitle, out var isCompleted))
         {
-            return text[2..];
+            return new ParsedTaskContent(checklistTitle, isCompleted, true);
         }
 
-        return text;
+        if (text.Length >= 2 && text[1] == ' ' && (text[0] == '-' || text[0] == '*' || text[0] == '+'))
+        {
+            return new ParsedTaskContent(text[2..], null, true);
+        }
+
+        return new ParsedTaskContent(text, null, false);
     }
+
+    private static bool TryParseMarkdownChecklist(string text, out string title, out bool isCompleted)
+    {
+        title = string.Empty;
+        isCompleted = false;
+
+        if (text.Length < 6 ||
+            text[0] != '-' ||
+            text[1] != ' ' ||
+            text[2] != '[' ||
+            text[4] != ']' ||
+            text[5] != ' ')
+        {
+            return false;
+        }
+
+        switch (text[3])
+        {
+            case 'x':
+            case 'X':
+                title = text[6..];
+                isCompleted = true;
+                return true;
+            case ' ':
+                title = text[6..];
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private readonly record struct ParsedTaskContent(string Title, bool? IsCompleted, bool HasMarker);
 }

--- a/src/Unlimotion/NotificationManagerWrapper.cs
+++ b/src/Unlimotion/NotificationManagerWrapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using Avalonia.Notification;
 using Avalonia.Threading;
@@ -36,6 +37,34 @@ public class NotificationManagerWrapper : INotificationManagerWrapper
         askViewModel.CloseAction = () => DialogHost.GetDialogSession("Ask")?.Close(false);
     }
 
+    public Task<bool> ConfirmTaskOutlinePasteAsync(TaskOutlinePastePreview preview)
+    {
+        var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Dispatcher.UIThread.Post(() =>
+        {
+            try
+            {
+                var dialogViewModel = new TaskOutlinePastePreviewDialogViewModel(preview)
+                {
+                    ConfirmAction = () => completion.TrySetResult(true),
+                    CancelAction = () => completion.TrySetResult(false),
+                };
+
+                var dialogTask = DialogHost.Show(dialogViewModel, "Ask");
+                dialogViewModel.CloseAction = () => DialogHost.GetDialogSession("Ask")?.Close(false);
+                _ = dialogTask.ContinueWith(
+                    _ => completion.TrySetResult(false),
+                    TaskScheduler.Default);
+            }
+            catch (Exception ex)
+            {
+                completion.TrySetException(ex);
+            }
+        });
+
+        return completion.Task;
+    }
 
     public void ErrorToast(string message)
     {
@@ -81,4 +110,41 @@ public class AskViewModel
         CloseAction?.Invoke();
     });
     public Action CloseAction { get; set; }
+}
+
+public class TaskOutlinePastePreviewDialogViewModel
+{
+    public TaskOutlinePastePreviewDialogViewModel(TaskOutlinePastePreview preview)
+    {
+        Header = preview.Header;
+        DestinationLabel = preview.DestinationLabel;
+        TaskCountText = preview.TaskCountText;
+        PreviewText = preview.PreviewText;
+    }
+
+    public string Header { get; }
+
+    public string DestinationLabel { get; }
+
+    public string TaskCountText { get; }
+
+    public string PreviewText { get; }
+
+    public Action ConfirmAction { get; set; }
+
+    public Action CancelAction { get; set; }
+
+    public Action CloseAction { get; set; }
+
+    public ICommand ConfirmCommand => ReactiveCommand.Create(() =>
+    {
+        ConfirmAction?.Invoke();
+        CloseAction?.Invoke();
+    });
+
+    public ICommand CancelCommand => ReactiveCommand.Create(() =>
+    {
+        CancelAction?.Invoke();
+        CloseAction?.Invoke();
+    });
 }

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -79,6 +79,17 @@ x:Class="Unlimotion.Views.MainControl">
                                   InputGesture="Ctrl+Alt+Left"
                                   Click="TaskTreeContextMenuItem_OnClick"
                                   AutomationProperties.AutomationId="CollapseAllTreeMenuItem"/>
+                        <Separator/>
+                        <MenuItem Header="{DynamicResource CopyTaskOutline}"
+                                  Tag="CopyOutline"
+                                  InputGesture="Ctrl+Shift+C"
+                                  Click="TaskTreeContextMenuItem_OnClick"
+                                  AutomationProperties.AutomationId="CopyTaskOutlineTreeMenuItem"/>
+                        <MenuItem Header="{DynamicResource PasteTaskOutline}"
+                                  Tag="PasteOutline"
+                                  InputGesture="Ctrl+Shift+V"
+                                  Click="TaskTreeContextMenuItem_OnClick"
+                                  AutomationProperties.AutomationId="PasteTaskOutlineTreeMenuItem"/>
                     </ContextMenu>
                 </Setter.Value>
             </Setter>
@@ -147,6 +158,8 @@ Content="❌"
         <KeyBinding Gesture="Ctrl+Shift+Left" Command="{Binding CollapseCurrentNestedCommand}"/>
         <KeyBinding Gesture="Ctrl+Alt+Right" Command="{Binding ExpandAllTreeNodesCommand}"/>
         <KeyBinding Gesture="Ctrl+Alt+Left" Command="{Binding CollapseAllTreeNodesCommand}"/>
+        <KeyBinding Gesture="Ctrl+Shift+C" Command="{Binding CopyTaskOutlineTreeCommand}"/>
+        <KeyBinding Gesture="Ctrl+Shift+V" Command="{Binding PasteTaskOutlineTreeCommand}"/>
     </UserControl.KeyBindings>
 
     <Grid RowDefinitions="Auto,*">

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -109,6 +109,8 @@ namespace Unlimotion.Views
             if (_treeCommandViewModel != null)
             {
                 _treeCommandViewModel.ExecuteTreeCommandAction = null;
+                _treeCommandViewModel.SetClipboardTextAsync = null;
+                _treeCommandViewModel.GetClipboardTextAsync = null;
                 _treeCommandViewModel = null;
             }
 
@@ -120,6 +122,8 @@ namespace Unlimotion.Views
             {
                 _treeCommandViewModel = vm;
                 vm.ExecuteTreeCommandAction = ExecuteTreeCommand;
+                vm.SetClipboardTextAsync = SetClipboardTextAsync;
+                vm.GetClipboardTextAsync = GetClipboardTextAsync;
                 _titleFocusSubscription = vm.WhenAnyValue(m => m.TitleFocusRequestVersion)
                     .Subscribe(requestVersion => QueueTitleFocus(requestVersion, vm.CurrentTaskItem?.Id, MaxTitleFocusRetries));
                 _relationEditorFocusSubscription = vm.CurrentRelationEditor
@@ -169,6 +173,38 @@ namespace Unlimotion.Views
                     }
                 });
             }
+        }
+
+        private async Task SetClipboardTextAsync(string text)
+        {
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard == null)
+            {
+                if (DataContext is MainWindowViewModel vm)
+                {
+                    vm.ManagerWrapper?.ErrorToast(L10n.Get("ClipboardUnavailable"));
+                }
+
+                return;
+            }
+
+            await clipboard.SetTextAsync(text);
+        }
+
+        private async Task<string?> GetClipboardTextAsync()
+        {
+            var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+            if (clipboard == null)
+            {
+                if (DataContext is MainWindowViewModel vm)
+                {
+                    vm.ManagerWrapper?.ErrorToast(L10n.Get("ClipboardUnavailable"));
+                }
+
+                return null;
+            }
+
+            return await clipboard.GetTextAsync();
         }
 
         private void QueueTitleFocus(long requestVersion, string? targetTaskId, int retriesRemaining)
@@ -1043,6 +1079,20 @@ namespace Unlimotion.Views
                     case TreeCommandKind.SelectAll:
                         tree.SelectAll();
                         break;
+                    case TreeCommandKind.CopyOutline:
+                    {
+                        var current = GetCurrentWrapperForRoute(vm, tree, route);
+                        ExecuteTaskOutlineCommandAsync(vm, () => current != null
+                            ? vm.CopyTaskOutline(current)
+                            : vm.CopyTaskOutline(vm.CurrentTaskItem));
+                        break;
+                    }
+                    case TreeCommandKind.PasteOutline:
+                    {
+                        var destination = GetCurrentWrapperForRoute(vm, tree, route)?.TaskItem ?? vm.CurrentTaskItem;
+                        ExecuteTaskOutlineCommandAsync(vm, () => vm.PasteTaskOutline(destination));
+                        break;
+                    }
                 }
             }
             finally
@@ -1051,6 +1101,18 @@ namespace Unlimotion.Views
                 {
                     ClearContextMenuContext();
                 }
+            }
+        }
+
+        private static async void ExecuteTaskOutlineCommandAsync(MainWindowViewModel vm, Func<Task> action)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                vm.ManagerWrapper?.ErrorToast(L10n.Format("ReactiveUnhandledError", ex.Message));
             }
         }
 

--- a/src/Unlimotion/Views/MainScreen.axaml
+++ b/src/Unlimotion/Views/MainScreen.axaml
@@ -47,6 +47,9 @@
                         </Grid>
                     </Grid>
                 </DataTemplate>
+                <DataTemplate DataType="unlimotion:TaskOutlinePastePreviewDialogViewModel">
+                    <views:TaskOutlinePastePreviewControl />
+                </DataTemplate>
             </dialogHostAvalonia:DialogHost.DataTemplates>
             <!-- put the content over which the dialog is shown here (e.g. your main window grid)-->
             <Panel>

--- a/src/Unlimotion/Views/SettingsControl.axaml
+++ b/src/Unlimotion/Views/SettingsControl.axaml
@@ -115,6 +115,25 @@
 
             <Border Classes="SettingsSection">
                 <StackPanel>
+                    <TextBlock Classes="SectionTitle" Text="{DynamicResource TaskOutlineClipboardSettingsTitle}" />
+                    <TextBlock Classes="SectionHint" Text="{DynamicResource TaskOutlineClipboardSettingsHint}" />
+
+                    <StackPanel Classes="FieldGroup">
+                        <CheckBox IsChecked="{Binding CopyTaskOutlineAsMarkdown}"
+                                  Content="{DynamicResource CopyTaskOutlineAsMarkdown}"
+                                  AutomationProperties.AutomationId="CopyTaskOutlineAsMarkdownCheckBox" />
+                    </StackPanel>
+
+                    <StackPanel Classes="FieldGroup">
+                        <CheckBox IsChecked="{Binding CopyTaskOutlineDescription}"
+                                  Content="{DynamicResource CopyTaskOutlineDescription}"
+                                  AutomationProperties.AutomationId="CopyTaskOutlineDescriptionCheckBox" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+
+            <Border Classes="SettingsSection">
+                <StackPanel>
                     <TextBlock Classes="SectionTitle" Text="{DynamicResource UpdatesTitle}" />
                     <TextBlock Classes="SectionHint" Text="{DynamicResource UpdatesHint}" />
 

--- a/src/Unlimotion/Views/TaskOutlinePastePreviewControl.axaml
+++ b/src/Unlimotion/Views/TaskOutlinePastePreviewControl.axaml
@@ -1,0 +1,62 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:unlimotion="clr-namespace:Unlimotion"
+             mc:Ignorable="d"
+             d:DesignWidth="720"
+             d:DesignHeight="560"
+             x:DataType="unlimotion:TaskOutlinePastePreviewDialogViewModel"
+             x:Class="Unlimotion.Views.TaskOutlinePastePreviewControl"
+             AutomationProperties.AutomationId="TaskOutlinePastePreviewDialog">
+    <Grid Margin="16"
+          Width="720"
+          MaxWidth="720"
+          MaxHeight="640"
+          RowDefinitions="Auto,Auto,Auto,*,Auto">
+        <TextBlock Text="{Binding Header}"
+                   TextAlignment="Center"
+                   TextWrapping="Wrap"
+                   FontWeight="Bold" />
+        <TextBlock Grid.Row="1"
+                   Margin="0,8,0,0"
+                   Text="{Binding DestinationLabel}"
+                   TextWrapping="Wrap"
+                   AutomationProperties.AutomationId="TaskOutlinePasteDestinationText" />
+        <TextBlock Grid.Row="2"
+                   Margin="0,4,0,8"
+                   Text="{Binding TaskCountText}"
+                   Opacity="0.8" />
+        <Border Grid.Row="3"
+                BorderBrush="{DynamicResource ThemeControlMidBrush}"
+                BorderThickness="1"
+                Padding="8">
+            <ScrollViewer MaxHeight="420"
+                          HorizontalScrollBarVisibility="Auto"
+                          VerticalScrollBarVisibility="Auto"
+                          AutomationProperties.AutomationId="TaskOutlinePastePreviewScrollViewer">
+                <TextBlock Text="{Binding PreviewText}"
+                           FontFamily="Consolas"
+                           TextWrapping="NoWrap"
+                           AutomationProperties.AutomationId="TaskOutlinePastePreviewText" />
+            </ScrollViewer>
+        </Border>
+        <Grid Grid.Row="4"
+              Margin="0,12,0,0"
+              ColumnDefinitions="*,*">
+            <Button Grid.Column="0"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Center"
+                    Command="{Binding ConfirmCommand}"
+                    Content="{DynamicResource DialogYes}"
+                    AutomationProperties.AutomationId="TaskOutlinePasteConfirmButton" />
+            <Button Grid.Column="1"
+                    Margin="8,0,0,0"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Center"
+                    Command="{Binding CancelCommand}"
+                    Content="{DynamicResource DialogNo}"
+                    AutomationProperties.AutomationId="TaskOutlinePasteCancelButton" />
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Unlimotion/Views/TaskOutlinePastePreviewControl.axaml.cs
+++ b/src/Unlimotion/Views/TaskOutlinePastePreviewControl.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace Unlimotion.Views;
+
+public partial class TaskOutlinePastePreviewControl : UserControl
+{
+    public TaskOutlinePastePreviewControl()
+    {
+        InitializeComponent();
+    }
+}

--- a/tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs
+++ b/tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs
@@ -442,6 +442,11 @@ public static class UnlimotionAppLaunchHost
             noAction?.Invoke();
         }
 
+        public Task<bool> ConfirmTaskOutlinePasteAsync(TaskOutlinePastePreview preview)
+        {
+            return Task.FromResult(false);
+        }
+
         public void ErrorToast(string message)
         {
         }


### PR DESCRIPTION
## Summary
- Adds task outline clipboard settings for Markdown checklist export and description export.
- Extends outline parsing/import to auto-detect Markdown checklist state, descriptions, and legacy/plain outlines independently of settings.
- Adds a confirmation dialog with destination, task count, and scrollable preview before creating pasted tasks.
- Preserves filter/sort-aware copy behavior and covers paste cancellation, destination revalidation, and completed task import.

## Validation
- `dotnet build src\Unlimotion.sln --no-restore`
- `dotnet test src\Unlimotion.sln --no-build` (295 passed)

## Notes
- Build still reports existing project warnings for NuGet advisories, nullable analysis, preview .NET SDK, and Android page-size warnings; no build errors.