### PR TITLE
Add per-tab reset filters confirmation

### DIFF
--- a/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
+++ b/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
@@ -1,0 +1,481 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Input.Raw;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Unlimotion.ViewModel;
+using Unlimotion.Views;
+using L10n = Unlimotion.ViewModel.Localization.Localization;
+
+namespace Unlimotion.Test;
+
+[ParallelLimiter<SharedUiStateParallelLimit>]
+public class MainControlResetFiltersUiTests
+{
+    private static readonly (int TabIndex, string ButtonAutomationId)[] TaskTabs =
+    [
+        (0, "AllTasksResetFiltersButton"),
+        (1, "LastCreatedResetFiltersButton"),
+        (2, "LastUpdatedResetFiltersButton"),
+        (3, "UnlockedResetFiltersButton"),
+        (4, "CompletedResetFiltersButton"),
+        (5, "ArchivedResetFiltersButton"),
+        (6, "LastOpenedResetFiltersButton"),
+        (7, "RoadmapResetFiltersButton")
+    ];
+
+    [Test]
+    public async Task ResetFiltersButton_IsAvailableOnTaskTabs()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                AssertResetButtonsOnTaskTabs(view);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task ResetFiltersButton_AsksConfirmation_AndCancelKeepsFilters()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                SetActiveFilters(vm);
+
+                var notificationManager = (NotificationManagerWrapperMock)vm.ManagerWrapper;
+                notificationManager.ClearMessages();
+                notificationManager.AskResult = false;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                SelectTab(view, 0);
+                var resetButton = FindControlByAutomationId<Button>(view, "AllTasksResetFiltersButton");
+                await ClickControlAsync(window, resetButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(notificationManager.AskCount).IsEqualTo(1);
+                await Assert.That(notificationManager.LastAskHeader).IsEqualTo(L10n.Get("ResetFiltersConfirmHeader"));
+                await Assert.That(notificationManager.LastAskMessage).IsEqualTo(L10n.Get("ResetFiltersConfirmMessage"));
+                await AssertActiveFilters(vm);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task AllTasksResetFilters_AfterConfirmation_ResetsOnlyAllTasksFiltersToDefaults()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                var defaultShowCompleted = vm.ShowCompleted;
+                var defaultShowArchived = vm.ShowArchived;
+                SetActiveFilters(vm);
+
+                var notificationManager = (NotificationManagerWrapperMock)vm.ManagerWrapper;
+                notificationManager.ClearMessages();
+                notificationManager.AskResult = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                SelectTab(view, 0);
+                var resetButton = FindControlByAutomationId<Button>(view, "AllTasksResetFiltersButton");
+                await ClickControlAsync(window, resetButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(notificationManager.AskCount).IsEqualTo(1);
+                await Assert.That(vm.Search.SearchText).IsEqualTo(string.Empty);
+                await Assert.That(vm.ShowCompleted).IsEqualTo(defaultShowCompleted);
+                await Assert.That(vm.ShowArchived).IsEqualTo(defaultShowArchived);
+                await Assert.That(vm.ShowWanted).IsEqualTo(true);
+                await Assert.That(vm.Graph.OnlyUnlocked).IsTrue();
+                await AssertToggleFiltersReset(vm.EmojiFilters);
+                await AssertToggleFiltersReset(vm.EmojiExcludeFilters);
+                await AssertFirstFilterActive(vm.UnlockedTimeFilters);
+                await AssertFirstFilterActive(vm.DurationFilters);
+                await AssertCustomDateFilter(vm.CompletedDateFilter);
+                await AssertCustomDateFilter(vm.ArchivedDateFilter);
+                await AssertCustomDateFilter(vm.LastCreatedDateFilter);
+                await AssertCustomDateFilter(vm.LastUpdatedDateFilter);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task LastCreatedResetFilters_AfterConfirmation_ResetsCurrentDateFilterToDefault()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                var defaultShowCompleted = vm.ShowCompleted;
+                var defaultShowArchived = vm.ShowArchived;
+                SetActiveFilters(vm);
+
+                var notificationManager = (NotificationManagerWrapperMock)vm.ManagerWrapper;
+                notificationManager.ClearMessages();
+                notificationManager.AskResult = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                SelectTab(view, 1);
+                var resetButton = FindControlByAutomationId<Button>(view, "LastCreatedResetFiltersButton");
+                await ClickControlAsync(window, resetButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(notificationManager.AskCount).IsEqualTo(1);
+                await Assert.That(vm.Search.SearchText).IsEqualTo(string.Empty);
+                await Assert.That(vm.ShowCompleted).IsEqualTo(defaultShowCompleted);
+                await Assert.That(vm.ShowArchived).IsEqualTo(defaultShowArchived);
+                await Assert.That(vm.ShowWanted).IsEqualTo(true);
+                await Assert.That(vm.Graph.OnlyUnlocked).IsTrue();
+                await AssertToggleFiltersReset(vm.EmojiFilters);
+                await AssertToggleFiltersReset(vm.EmojiExcludeFilters);
+                await AssertDateFilterDefault(vm.LastCreatedDateFilter);
+                await AssertCustomDateFilter(vm.CompletedDateFilter);
+                await AssertCustomDateFilter(vm.ArchivedDateFilter);
+                await AssertCustomDateFilter(vm.LastUpdatedDateFilter);
+                await AssertFirstFilterActive(vm.UnlockedTimeFilters);
+                await AssertFirstFilterActive(vm.DurationFilters);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapResetFilters_WhenCompletionFiltersAreVisible_DoesNotResetHiddenWantedFilter()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                var defaultShowCompleted = vm.ShowCompleted;
+                var defaultShowArchived = vm.ShowArchived;
+                SetActiveFilters(vm);
+                vm.Graph.OnlyUnlocked = false;
+
+                var notificationManager = (NotificationManagerWrapperMock)vm.ManagerWrapper;
+                notificationManager.ClearMessages();
+                notificationManager.AskResult = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                SelectTab(view, 7);
+                var resetButton = FindControlByAutomationId<Button>(view, "RoadmapResetFiltersButton");
+                await ClickControlAsync(window, resetButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(notificationManager.AskCount).IsEqualTo(1);
+                await Assert.That(vm.Search.SearchText).IsEqualTo(string.Empty);
+                await Assert.That(vm.ShowCompleted).IsEqualTo(defaultShowCompleted);
+                await Assert.That(vm.ShowArchived).IsEqualTo(defaultShowArchived);
+                await Assert.That(vm.ShowWanted).IsEqualTo(true);
+                await Assert.That(vm.Graph.OnlyUnlocked).IsFalse();
+                await AssertToggleFiltersReset(vm.EmojiFilters);
+                await AssertToggleFiltersReset(vm.EmojiExcludeFilters);
+                await AssertFirstFilterActive(vm.UnlockedTimeFilters);
+                await AssertFirstFilterActive(vm.DurationFilters);
+                await AssertCustomDateFilter(vm.CompletedDateFilter);
+                await AssertCustomDateFilter(vm.ArchivedDateFilter);
+                await AssertCustomDateFilter(vm.LastCreatedDateFilter);
+                await AssertCustomDateFilter(vm.LastUpdatedDateFilter);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapResetFilters_WhenWantedFilterIsVisible_DoesNotResetHiddenCompletionFilters()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                SetActiveFilters(vm);
+
+                var notificationManager = (NotificationManagerWrapperMock)vm.ManagerWrapper;
+                notificationManager.ClearMessages();
+                notificationManager.AskResult = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                SelectTab(view, 7);
+                var resetButton = FindControlByAutomationId<Button>(view, "RoadmapResetFiltersButton");
+                await ClickControlAsync(window, resetButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(notificationManager.AskCount).IsEqualTo(1);
+                await Assert.That(vm.Search.SearchText).IsEqualTo(string.Empty);
+                await Assert.That(vm.ShowCompleted).IsTrue();
+                await Assert.That(vm.ShowArchived).IsTrue();
+                await Assert.That(vm.ShowWanted).IsEqualTo(false);
+                await Assert.That(vm.Graph.OnlyUnlocked).IsFalse();
+                await AssertToggleFiltersReset(vm.EmojiFilters);
+                await AssertToggleFiltersReset(vm.EmojiExcludeFilters);
+                await AssertFirstFilterActive(vm.UnlockedTimeFilters);
+                await AssertFirstFilterActive(vm.DurationFilters);
+                await AssertCustomDateFilter(vm.CompletedDateFilter);
+                await AssertCustomDateFilter(vm.ArchivedDateFilter);
+                await AssertCustomDateFilter(vm.LastCreatedDateFilter);
+                await AssertCustomDateFilter(vm.LastUpdatedDateFilter);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    private static void SetActiveFilters(MainWindowViewModel vm)
+    {
+        vm.Search.SearchText = "Task";
+        vm.ShowCompleted = true;
+        vm.ShowArchived = true;
+        vm.ShowWanted = true;
+        vm.Graph.OnlyUnlocked = true;
+
+        SetFirstFilter(vm.EmojiFilters);
+        SetFirstFilter(vm.EmojiExcludeFilters);
+        SetFirstFilter(vm.UnlockedTimeFilters);
+        SetFirstFilter(vm.DurationFilters);
+
+        SetCustomDateFilter(vm.CompletedDateFilter);
+        SetCustomDateFilter(vm.ArchivedDateFilter);
+        SetCustomDateFilter(vm.LastCreatedDateFilter);
+        SetCustomDateFilter(vm.LastUpdatedDateFilter);
+    }
+
+    private static void SetFirstFilter(IEnumerable<EmojiFilter> filters)
+    {
+        filters.First().ShowTasks = true;
+    }
+
+    private static void SetFirstFilter(IEnumerable<UnlockedTimeFilter> filters)
+    {
+        filters.First().ShowTasks = true;
+    }
+
+    private static void SetFirstFilter(IEnumerable<DurationFilter> filters)
+    {
+        filters.First().ShowTasks = true;
+    }
+
+    private static void SetCustomDateFilter(DateFilter filter)
+    {
+        filter.CurrentOption = DateFilterDefinition.AllTime;
+        filter.IsCustom = true;
+        filter.From = DateTime.Today.AddDays(-7);
+        filter.To = DateTime.Today.AddDays(-1);
+    }
+
+    private static void AssertResetButtonsOnTaskTabs(MainControl view)
+    {
+        foreach (var (tabIndex, buttonAutomationId) in TaskTabs)
+        {
+            SelectTab(view, tabIndex);
+            FindControlByAutomationId<Button>(view, buttonAutomationId);
+        }
+    }
+
+    private static async Task AssertActiveFilters(MainWindowViewModel vm)
+    {
+        await Assert.That(vm.Search.SearchText).IsEqualTo("Task");
+        await Assert.That(vm.ShowCompleted).IsTrue();
+        await Assert.That(vm.ShowArchived).IsTrue();
+        await Assert.That(vm.ShowWanted).IsEqualTo(true);
+        await Assert.That(vm.Graph.OnlyUnlocked).IsTrue();
+
+        await AssertFirstFilterActive(vm.EmojiFilters);
+        await AssertFirstFilterActive(vm.EmojiExcludeFilters);
+        await AssertFirstFilterActive(vm.UnlockedTimeFilters);
+        await AssertFirstFilterActive(vm.DurationFilters);
+        await AssertCustomDateFilter(vm.CompletedDateFilter);
+        await AssertCustomDateFilter(vm.ArchivedDateFilter);
+        await AssertCustomDateFilter(vm.LastCreatedDateFilter);
+        await AssertCustomDateFilter(vm.LastUpdatedDateFilter);
+    }
+
+    private static async Task AssertFirstFilterActive(IEnumerable<EmojiFilter> filters)
+    {
+        await Assert.That(filters.First().ShowTasks).IsTrue();
+    }
+
+    private static async Task AssertFirstFilterActive(IEnumerable<UnlockedTimeFilter> filters)
+    {
+        await Assert.That(filters.First().ShowTasks).IsTrue();
+    }
+
+    private static async Task AssertFirstFilterActive(IEnumerable<DurationFilter> filters)
+    {
+        await Assert.That(filters.First().ShowTasks).IsTrue();
+    }
+
+    private static async Task AssertToggleFiltersReset(IEnumerable<EmojiFilter> filters)
+    {
+        await Assert.That(filters.All(static filter => !filter.ShowTasks)).IsTrue();
+    }
+
+    private static async Task AssertCustomDateFilter(DateFilter filter)
+    {
+        await Assert.That(filter.IsCustom).IsTrue();
+        await Assert.That(filter.CurrentOption.Id).IsEqualTo(DateFilterDefinition.AllTime.Id);
+        await Assert.That(filter.From).IsEqualTo(DateTime.Today.AddDays(-7));
+        await Assert.That(filter.To).IsEqualTo(DateTime.Today.AddDays(-1));
+    }
+
+    private static async Task AssertDateFilterDefault(DateFilter filter)
+    {
+        DateTime? today = DateTime.Today;
+        await Assert.That(filter.IsCustom).IsFalse();
+        await Assert.That(filter.CurrentOption.Id).IsEqualTo(DateFilterDefinition.Today.Id);
+        await Assert.That(filter.From).IsEqualTo(today);
+        await Assert.That(filter.To).IsEqualTo(today);
+    }
+
+    private static Window CreateWindow(Control content)
+    {
+        return new Window
+        {
+            Width = 1800,
+            Height = 1000,
+            Content = content
+        };
+    }
+
+    private static T FindControlByAutomationId<T>(Control root, string automationId)
+        where T : Control
+    {
+        var control = root.GetVisualDescendants()
+            .OfType<T>()
+            .FirstOrDefault(candidate =>
+                string.Equals(
+                    AutomationProperties.GetAutomationId(candidate),
+                    automationId,
+                    StringComparison.Ordinal));
+
+        return control ?? throw new InvalidOperationException($"Control with AutomationId '{automationId}' was not found.");
+    }
+
+    private static void SelectTab(MainControl view, int index)
+    {
+        var tabControl = view.GetVisualDescendants().OfType<TabControl>().First();
+        tabControl.SelectedIndex = index;
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static async Task ClickControlAsync(Window window, Control control)
+    {
+        var point = GetControlCenterPoint(window, control);
+        window.MouseDown(point, MouseButton.Left, RawInputModifiers.None);
+        window.MouseUp(point, MouseButton.Left, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        await Task.CompletedTask;
+    }
+
+    private static Point GetControlCenterPoint(Visual relativeTo, Control control)
+    {
+        var point = control.TranslatePoint(
+            new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
+            relativeTo);
+
+        if (!point.HasValue)
+        {
+            throw new InvalidOperationException($"Cannot translate point for control {control.GetType().Name}.");
+        }
+
+        return point.Value;
+    }
+}

--- a/src/Unlimotion.ViewModel/DateFilter.cs
+++ b/src/Unlimotion.ViewModel/DateFilter.cs
@@ -74,6 +74,7 @@ namespace Unlimotion.ViewModel
     public static class DateFilterDefinition
     {
         public static readonly DateFilterOption Today = new("Today", "DateFilterToday");
+        public static readonly DateFilterOption AllTime = new("All Time", "DateFilterAllTime");
 
         public static ReadOnlyObservableCollection<DateFilterOption> GetDefinitions()
         {
@@ -88,7 +89,7 @@ namespace Unlimotion.ViewModel
                 new("Last Week", "DateFilterLastWeek"),
                 new("Last Month", "DateFilterLastMonth"),
                 new("Last Year", "DateFilterLastYear"),
-                new("All Time", "DateFilterAllTime")
+                AllTime
             });
         }
 

--- a/src/Unlimotion.ViewModel/GraphViewModel.cs
+++ b/src/Unlimotion.ViewModel/GraphViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 using DynamicData.Binding;
 using PropertyChanged;
 
@@ -75,4 +76,6 @@ public class GraphViewModel
     }
 
     public SearchDefinition Search { get; set; } = new();
+
+    public ICommand? ResetTaskFiltersCommand => _mainWindowViewModel?.ResetTaskFiltersCommand;
 }

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -41,6 +41,9 @@ namespace Unlimotion.ViewModel
         private bool _isRoadmapTabInitialized;
         private bool _isUnlockedTabInitialized;
         private bool _isLastOpenedTabInitialized;
+        private readonly bool _defaultShowCompleted;
+        private readonly bool _defaultShowArchived;
+        private readonly bool? _defaultShowWanted;
         private static readonly ReadOnlyObservableCollection<TaskWrapperViewModel> EmptyTaskWrappers =
             new(new ObservableCollectionExtended<TaskWrapperViewModel>());
 
@@ -71,10 +74,15 @@ namespace Unlimotion.ViewModel
             LastOpenedItems = EmptyTaskWrappers;
             Graph.SetMainWindowViewModel(this);
             Graph.Search = Search;
+            ResetTaskFiltersCommand = ReactiveCommand.Create(ConfirmResetTaskFilters)
+                .AddToDisposeAndReturn(this);
             Search.IsFuzzySearch = Settings.IsFuzzySearch;
             ShowCompleted = _configuration?.GetSection("AllTasks:ShowCompleted").Get<bool?>() == true;
             ShowArchived = _configuration?.GetSection("AllTasks:ShowArchived").Get<bool?>() == true;
             ShowWanted = _configuration?.GetSection("AllTasks:ShowWanted").Get<bool?>() == true;
+            _defaultShowCompleted = ShowCompleted;
+            _defaultShowArchived = ShowArchived;
+            _defaultShowWanted = ShowWanted;
             var sortName = _configuration?.GetSection("AllTasks:CurrentSortDefinition").Get<string>();
             var sortNameForUnlocked = _configuration?.GetSection("AllTasks:CurrentSortDefinitionForUnlocked").Get<string>();
             CurrentSortDefinition = SortDefinitions.FirstOrDefault(s => s.MatchesPersistedValue(sortName)) ?? SortDefinitions.First();
@@ -1412,6 +1420,178 @@ namespace Unlimotion.ViewModel
             }
         }
 
+        public void ConfirmResetTaskFilters()
+        {
+            ManagerWrapper.Ask(
+                L10n.Get("ResetFiltersConfirmHeader"),
+                L10n.Get("ResetFiltersConfirmMessage"),
+                ResetCurrentTabFilters);
+        }
+
+        public void ResetCurrentTabFilters()
+        {
+            if (AllTasksMode)
+            {
+                ResetAllTasksTabFilters();
+            }
+            else if (LastCreatedMode)
+            {
+                ResetLastCreatedTabFilters();
+            }
+            else if (LastUpdatedMode)
+            {
+                ResetLastUpdatedTabFilters();
+            }
+            else if (UnlockedMode)
+            {
+                ResetUnlockedTabFilters();
+            }
+            else if (CompletedMode)
+            {
+                ResetCompletedTabFilters();
+            }
+            else if (ArchivedMode)
+            {
+                ResetArchivedTabFilters();
+            }
+            else if (LastOpenedMode)
+            {
+                ResetSearchFilter();
+            }
+            else if (GraphMode)
+            {
+                ResetRoadmapTabFilters();
+            }
+        }
+
+        private void ResetAllTasksTabFilters()
+        {
+            ResetSearchFilter();
+            ResetEmojiFilters();
+            ResetCompletionVisibilityFilters();
+        }
+
+        private void ResetLastCreatedTabFilters()
+        {
+            ResetSearchFilter();
+            ResetEmojiFilters();
+            ResetCompletionVisibilityFilters();
+            ResetDateFilter(LastCreatedDateFilter);
+        }
+
+        private void ResetLastUpdatedTabFilters()
+        {
+            ResetSearchFilter();
+            ResetEmojiFilters();
+            ResetCompletionVisibilityFilters();
+            ResetDateFilter(LastUpdatedDateFilter);
+        }
+
+        private void ResetUnlockedTabFilters()
+        {
+            ResetSearchFilter();
+            ResetEmojiFilters();
+            ShowWanted = _defaultShowWanted;
+            ResetToggleFilters(UnlockedTimeFilters);
+            ResetToggleFilters(DurationFilters);
+        }
+
+        private void ResetCompletedTabFilters()
+        {
+            ResetSearchFilter();
+            ResetEmojiFilters();
+            ResetDateFilter(CompletedDateFilter);
+        }
+
+        private void ResetArchivedTabFilters()
+        {
+            ResetSearchFilter();
+            ResetEmojiFilters();
+            ResetDateFilter(ArchivedDateFilter);
+        }
+
+        private void ResetRoadmapTabFilters()
+        {
+            var onlyUnlocked = Graph.OnlyUnlocked;
+
+            ResetSearchFilter();
+            ResetEmojiFilters();
+
+            if (onlyUnlocked)
+            {
+                ShowWanted = _defaultShowWanted;
+            }
+            else
+            {
+                ResetCompletionVisibilityFilters();
+            }
+
+            Graph.OnlyUnlocked = false;
+        }
+
+        private void ResetSearchFilter()
+        {
+            Search.SearchText = string.Empty;
+        }
+
+        private void ResetEmojiFilters()
+        {
+            ResetToggleFilters(EmojiFilters);
+            ResetToggleFilters(EmojiExcludeFilters);
+        }
+
+        private void ResetCompletionVisibilityFilters()
+        {
+            ShowCompleted = _defaultShowCompleted;
+            ShowArchived = _defaultShowArchived;
+        }
+
+        private static void ResetToggleFilters(IEnumerable<EmojiFilter>? filters)
+        {
+            if (filters == null)
+            {
+                return;
+            }
+
+            foreach (var filter in filters)
+            {
+                filter.ShowTasks = false;
+            }
+        }
+
+        private static void ResetToggleFilters(IEnumerable<UnlockedTimeFilter>? filters)
+        {
+            if (filters == null)
+            {
+                return;
+            }
+
+            foreach (var filter in filters)
+            {
+                filter.ShowTasks = false;
+            }
+        }
+
+        private static void ResetToggleFilters(IEnumerable<DurationFilter>? filters)
+        {
+            if (filters == null)
+            {
+                return;
+            }
+
+            foreach (var filter in filters)
+            {
+                filter.ShowTasks = false;
+            }
+        }
+
+        private static void ResetDateFilter(DateFilter filter)
+        {
+            filter.IsCustom = false;
+            filter.CurrentOption = DateFilterDefinition.Today;
+            filter.SetDateTimes(DateFilterDefinition.Today);
+        }
+
         private async void RemoveTask(TaskWrapperViewModel task)
         {
             if (task.TaskItem.RemoveRequiresConfirmation(task.Parent?.TaskItem.Id))
@@ -2038,6 +2218,8 @@ namespace Unlimotion.ViewModel
         public ICommand CopyTaskOutlineCommand { get; set; }
 
         public ICommand PasteTaskOutlineCommand { get; set; }
+
+        public ICommand ResetTaskFiltersCommand { get; set; }
 
         public Action<TreeCommandKind>? ExecuteTreeCommandAction { get; set; }
 

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -204,6 +204,9 @@
   <data name="RepositoryConnectErrorStatus" xml:space="preserve"><value>Repository connection error: {0}</value></data>
   <data name="RepositoryConnectErrorToast" xml:space="preserve"><value>Could not connect repository: {0}</value></data>
   <data name="RepositoryWorkingDirectoryUnavailable" xml:space="preserve"><value>Repository working directory is unavailable.</value></data>
+  <data name="ResetFilters" xml:space="preserve"><value>Reset filters</value></data>
+  <data name="ResetFiltersConfirmHeader" xml:space="preserve"><value>Reset filters?</value></data>
+  <data name="ResetFiltersConfirmMessage" xml:space="preserve"><value>Filters on the current tab will be reset to defaults. Continue?</value></data>
   <data name="ResaveAllTasks" xml:space="preserve"><value>Resave all tasks</value></data>
   <data name="ResaveConfirmHeader" xml:space="preserve"><value>Resave all tasks</value></data>
   <data name="ResaveConfirmMessage" xml:space="preserve"><value>All tasks will be read and saved again in local storage. Continue?</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -204,6 +204,9 @@
   <data name="RepositoryConnectErrorStatus" xml:space="preserve"><value>Ошибка подключения репозитория: {0}</value></data>
   <data name="RepositoryConnectErrorToast" xml:space="preserve"><value>Не удалось подключить репозиторий: {0}</value></data>
   <data name="RepositoryWorkingDirectoryUnavailable" xml:space="preserve"><value>Рабочая папка репозитория недоступна.</value></data>
+  <data name="ResetFilters" xml:space="preserve"><value>Сбросить фильтры</value></data>
+  <data name="ResetFiltersConfirmHeader" xml:space="preserve"><value>Сбросить фильтры?</value></data>
+  <data name="ResetFiltersConfirmMessage" xml:space="preserve"><value>Фильтры на текущей вкладке будут сброшены к значениям по умолчанию. Продолжить?</value></data>
   <data name="ResaveAllTasks" xml:space="preserve"><value>Пересохранить все задачи</value></data>
   <data name="ResaveConfirmHeader" xml:space="preserve"><value>Пересохранить все задачи</value></data>
   <data name="ResaveConfirmMessage" xml:space="preserve"><value>Все задачи будут перечитаны и сохранены заново в локальном хранилище. Продолжить?</value></data>

--- a/src/Unlimotion/Views/GraphControl.axaml
+++ b/src/Unlimotion/Views/GraphControl.axaml
@@ -28,6 +28,10 @@
             <searchControl:SearchControl
                 SearchText="{Binding Search.SearchText, Mode=TwoWay}"
                 Watermark="{DynamicResource Search}"/>
+            <Button Content="{DynamicResource ResetFilters}"
+                    Command="{Binding ResetTaskFiltersCommand}"
+                    Margin="0,0,10,0"
+                    AutomationProperties.AutomationId="RoadmapResetFiltersButton"/>
         </WrapPanel>
 		<ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto"
 					  HorizontalScrollBarVisibility="Auto">

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -230,6 +230,10 @@
                                     <ComboBox ItemsSource= "{Binding SortDefinitions}" SelectedItem= "{Binding CurrentSortDefinition}" Margin= "0,0,10,0"/>
                                     <CheckBox Content="{DynamicResource Completed}" IsChecked= "{Binding ShowCompleted}" Margin= "0,0,10,0"/>
                                     <CheckBox Content="{DynamicResource Archived}" IsChecked= "{Binding ShowArchived}" Margin= "0,0,10,0"/>
+                                    <Button Content="{DynamicResource ResetFilters}"
+                                            Command="{Binding ResetTaskFiltersCommand}"
+                                            Margin="0,0,10,0"
+                                            AutomationProperties.AutomationId="AllTasksResetFiltersButton"/>
                                 </WrapPanel>
                                 <searchControl:SearchBar Grid.Column="1" Classes="FilterToolbarSearch" DataContext="{Binding Search}"/>
                             </Grid>
@@ -272,6 +276,10 @@
                                     <ComboBox IsVisible="{Binding !LastCreatedDateFilter.IsCustom}" ItemsSource="{Binding DateFilterDefinitions}" SelectedItem="{Binding LastCreatedDateFilter.CurrentOption}" VerticalAlignment="Center" Margin="0,0,10,0" />
                                     <CheckBox Content="{DynamicResource Completed}" IsChecked="{Binding ShowCompleted}" Margin="0,0,10,0"/>
                                     <CheckBox Content="{DynamicResource Archived}" IsChecked="{Binding ShowArchived}" Margin="0,0,10,0"/>
+                                    <Button Content="{DynamicResource ResetFilters}"
+                                            Command="{Binding ResetTaskFiltersCommand}"
+                                            Margin="0,0,10,0"
+                                            AutomationProperties.AutomationId="LastCreatedResetFiltersButton"/>
                                 </WrapPanel>
                                 <searchControl:SearchBar Grid.Column="1" Classes="FilterToolbarSearch" DataContext="{Binding Search}"/>
                             </Grid>
@@ -335,6 +343,10 @@
                                     <ComboBox IsVisible="{Binding !LastUpdatedDateFilter.IsCustom}" ItemsSource="{Binding DateFilterDefinitions}" SelectedItem="{Binding LastUpdatedDateFilter.CurrentOption}" VerticalAlignment="Center" Margin="0,0,10,0" />
                                     <CheckBox Content="{DynamicResource Completed}" IsChecked="{Binding ShowCompleted}" Margin="0,0,10,0"/>
                                     <CheckBox Content="{DynamicResource Archived}" IsChecked="{Binding ShowArchived}" Margin="0,0,10,0"/>
+                                    <Button Content="{DynamicResource ResetFilters}"
+                                            Command="{Binding ResetTaskFiltersCommand}"
+                                            Margin="0,0,10,0"
+                                            AutomationProperties.AutomationId="LastUpdatedResetFiltersButton"/>
                                 </WrapPanel>
                                 <searchControl:SearchBar Grid.Column="1" Classes="FilterToolbarSearch" DataContext="{Binding Search}"/>
                             </Grid>
@@ -388,6 +400,10 @@
                                     <ComboBox ItemsSource="{Binding SortDefinitions}" SelectedItem="{Binding CurrentSortDefinitionForUnlocked}" Margin="0,0,10,0"/>
                                     <ComboBox ItemsSource="{Binding UnlockedTimeFilters}" Margin="0,0,10,0" />
                                     <ComboBox ItemsSource="{Binding DurationFilters}" Margin="0,0,10,0" />
+                                    <Button Content="{DynamicResource ResetFilters}"
+                                            Command="{Binding ResetTaskFiltersCommand}"
+                                            Margin="0,0,10,0"
+                                            AutomationProperties.AutomationId="UnlockedResetFiltersButton"/>
                                 </WrapPanel>
                                 <searchControl:SearchBar Grid.Column="1" Classes="FilterToolbarSearch" DataContext="{Binding Search}"/>
                             </Grid>
@@ -448,6 +464,10 @@
                                                         IsTodayHighlighted="True"
                                                         DisplayDate="{Binding CompletedDateFilter.To, Converter={converters:DayOrTodayValueConverter}}"/>
                                     <ComboBox IsVisible="{Binding !CompletedDateFilter.IsCustom}" ItemsSource="{Binding DateFilterDefinitions}" SelectedItem="{Binding CompletedDateFilter.CurrentOption}" VerticalAlignment="Center" Margin="0,0,10,0" />
+                                    <Button Content="{DynamicResource ResetFilters}"
+                                            Command="{Binding ResetTaskFiltersCommand}"
+                                            Margin="0,0,10,0"
+                                            AutomationProperties.AutomationId="CompletedResetFiltersButton"/>
                                 </WrapPanel>
                                 <searchControl:SearchBar Grid.Column="1" Classes="FilterToolbarSearch" DataContext="{Binding Search}"/>
                             </Grid>
@@ -510,6 +530,10 @@
                                                         IsTodayHighlighted="True"
                                                         DisplayDate="{Binding ArchivedDateFilter.To, Converter={converters:DayOrTodayValueConverter}}"/>
                                     <ComboBox IsVisible="{Binding !ArchivedDateFilter.IsCustom}" ItemsSource="{Binding DateFilterDefinitions}" SelectedItem="{Binding ArchivedDateFilter.CurrentOption}" VerticalAlignment="Center" Margin="0,0,10,0" />
+                                    <Button Content="{DynamicResource ResetFilters}"
+                                            Command="{Binding ResetTaskFiltersCommand}"
+                                            Margin="0,0,10,0"
+                                            AutomationProperties.AutomationId="ArchivedResetFiltersButton"/>
                                 </WrapPanel>
                                 <searchControl:SearchBar Grid.Column="1" Classes="FilterToolbarSearch" DataContext="{Binding Search}"/>
                             </Grid>
@@ -557,6 +581,12 @@
                              AutomationProperties.AutomationId="LastOpenedTabItem">
                         <Grid RowDefinitions="Auto,*">
                             <Grid Classes="FilterToolbar" ColumnDefinitions="*,Auto">
+                                <WrapPanel Classes="FilterToolbarItems">
+                                    <Button Content="{DynamicResource ResetFilters}"
+                                            Command="{Binding ResetTaskFiltersCommand}"
+                                            Margin="0,0,10,0"
+                                            AutomationProperties.AutomationId="LastOpenedResetFiltersButton"/>
+                                </WrapPanel>
                                 <searchControl:SearchBar Grid.Column="1" Classes="FilterToolbarSearch" DataContext="{Binding Search}"/>
                             </Grid>
                             <TreeView Grid.Row="1" AutoScrollToSelectedItem="True"


### PR DESCRIPTION
## What changed
- Added reset filter actions on task tabs and Roadmap.
- Reset now asks for confirmation before changing filters.
- Reset applies only to filters visible on the current tab and restores their default values.
- Added localized confirmation strings and headless UI coverage for the reset flow.

## Why
The previous reset behavior cleared filter state globally. Users need a scoped reset that is predictable for the active task tab and guarded by confirmation.

## Validation
- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainControlResetFiltersUiTests/*"`