### PR TITLE
Fix Ctrl+A in text inputs

### DIFF
--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -1477,13 +1477,112 @@ public class MainControlTreeCommandsUiTests
                 Dispatcher.UIThread.RunJobs();
 
                 var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
+                var completedCheckBox = view.GetVisualDescendants()
+                    .OfType<CheckBox>()
+                    .First(control => string.Equals(control.Content?.ToString(), "Completed", StringComparison.Ordinal));
                 await Assert.That(allTasksTree).IsNotNull();
 
                 await ClickControlAsync(window, allTasksTree!);
+                completedCheckBox.Focus();
                 PressHotkey(window, Key.A, PhysicalKey.A, RawInputModifiers.Control);
                 Dispatcher.UIThread.RunJobs();
 
                 await Assert.That(GetSelectedWrappers(allTasksTree).Count).IsEqualTo(CountWrappers(vm.CurrentAllTasksItems));
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TreeCommandUi_CtrlA_UsesFocusedRelationTree()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+                vm.DetailsAreOpen = true;
+                TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask2Id);
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
+                var relationTree = view.FindControl<TreeView>("CurrentItemContainsTree");
+                await Assert.That(allTasksTree).IsNotNull();
+                await Assert.That(relationTree).IsNotNull();
+                await Assert.That(CountWrappers(vm.CurrentItemContains.SubTasks)).IsGreaterThan(0);
+
+                await ClickControlAsync(window, allTasksTree!);
+                var focused = relationTree!.Focus();
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(focused).IsTrue();
+
+                PressHotkey(window, Key.A, PhysicalKey.A, RawInputModifiers.Control);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(GetSelectedWrappers(relationTree).Count)
+                    .IsEqualTo(CountWrappers(vm.CurrentItemContains.SubTasks));
+                await Assert.That(GetSelectedWrappers(allTasksTree).Count)
+                    .IsNotEqualTo(CountWrappers(vm.CurrentAllTasksItems));
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task TreeCommandUi_CtrlA_SelectsTextWhenTextInputFocused()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+                vm.DetailsAreOpen = true;
+                var currentTask = TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask2Id);
+                await Assert.That(currentTask).IsNotNull();
+                currentTask!.Title = "Ctrl A text selection";
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
+                var titleTextBox = view.FindControl<TextBox>("CurrentTaskTitleTextBox");
+                await Assert.That(allTasksTree).IsNotNull();
+                await Assert.That(titleTextBox).IsNotNull();
+
+                titleTextBox!.Focus();
+                titleTextBox.CaretIndex = 5;
+                titleTextBox.ClearSelection();
+                PressHotkey(window, Key.A, PhysicalKey.A, RawInputModifiers.Control);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(titleTextBox.SelectedText).IsEqualTo(titleTextBox.Text);
+                await Assert.That(GetSelectedWrappers(allTasksTree!).Count).IsNotEqualTo(CountWrappers(vm.CurrentAllTasksItems));
             }
             finally
             {

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -170,7 +170,6 @@
 
     <UserControl.KeyBindings>
         <KeyBinding Gesture="Shift+Delete" Command="{Binding DeleteSelectedTreeItemsCommand}"/>
-        <KeyBinding Gesture="Ctrl+A" Command="{Binding SelectAllTreeItemsCommand}"/>
         <KeyBinding Gesture="Ctrl+Enter" Command="{Binding CreateSibling}"/>
         <KeyBinding Gesture="Shift+Enter" Command="{Binding CreateBlockedSibling}"/>
         <KeyBinding Gesture="Ctrl+Tab" Command="{Binding CreateInner}"/>

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -100,9 +100,21 @@ namespace Unlimotion.Views
         public MainControl()
         {
             InitializeComponent();
+            AddHandler(KeyDownEvent, MainControl_OnKeyDown, RoutingStrategies.Tunnel);
             AddHandler(DragDrop.DropEvent, Drop);
             AddHandler(DragDrop.DragOverEvent, DragOver);
             DataContextChanged += MainWindow_DataContextChanged;
+        }
+
+        private void MainControl_OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            if (e.Handled || !IsSelectAllHotkey(e) || IsTextInputFocused())
+            {
+                return;
+            }
+
+            ExecuteTreeCommand(TreeCommandKind.SelectAll);
+            e.Handled = true;
         }
 
         private void MainWindow_DataContextChanged(object? sender, EventArgs e)
@@ -1029,6 +1041,11 @@ namespace Unlimotion.Views
                 ClearInlineTitleClickState();
                 e.Handled = FocusCurrentTaskInlineTitleEditor(tree, vm.CurrentTaskItem?.Id);
             }
+        }
+
+        private static bool IsSelectAllHotkey(KeyEventArgs e)
+        {
+            return e.KeyModifiers == KeyModifiers.Control && e.Key == Key.A;
         }
 
         private static bool IsInlineTitleEditKey(KeyEventArgs e)


### PR DESCRIPTION
## Summary

Fixes `Ctrl+A` so text inputs keep the standard select-all behavior while task trees still support selecting all visible task items.

## Root Cause

`Ctrl+A` was registered as a global `UserControl.KeyBinding` on `MainControl`. When focus was inside a `TextBox`, the global binding intercepted the gesture before the text box could handle it. The first fix scoped handling directly to `TaskTree_OnKeyDown`, but that bypassed the existing `ExecuteTreeCommand` hotkey routing and regressed active-tree/focused-relation-tree scenarios.

## Changes

- Removed the global `Ctrl+A` key binding from `MainControl`.
- Added a tunneling `KeyDown` handler that lets text inputs handle `Ctrl+A` themselves.
- Routed non-text `Ctrl+A` through the existing `ExecuteTreeCommand(TreeCommandKind.SelectAll)` path, preserving `TryGetHotkeyTree` and active-tree fallback behavior.
- Added headless UI coverage for:
  - `Ctrl+A` with focus moved to a non-text control after activating a tree.
  - `Ctrl+A` with focus in a relation tree.
  - `Ctrl+A` inside the current task title text box.

## Validation

- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*" --no-progress`

Result: 34 tests passed. Existing NuGet/nullable warnings remain unrelated.