### PR TITLE
Fix Android git SSH and task folder access

### DIFF
--- a/.github/workflows/android-packaging.yml
+++ b/.github/workflows/android-packaging.yml
@@ -20,7 +20,8 @@ env:
   ANDROID_BUILD_TOOLS: 35.0.0
   ANDROID_NDK_VERSION: 27.2.12479018
   OPENSSL_VERSION: 3.0.14
-  LIBGIT2_NATIVE_PACKAGE_VERSION: 2.0.324-android.5
+  LIBSSH2_VERSION: 1.11.1
+  LIBGIT2_NATIVE_PACKAGE_VERSION: 2.0.324-android.6
 
 jobs:
   android-build:
@@ -71,42 +72,41 @@ jobs:
 
     - name: Build Android Native Dependencies
       run: |
-        bash ./scripts/build-openssl-android.sh
-        export OPENSSL_ROOT_DIR="${GITHUB_WORKSPACE}/artifacts/android-native/openssl-${OPENSSL_VERSION}-android-arm64/prefix"
-        export OPENSSL_INCLUDE_DIR="${OPENSSL_ROOT_DIR}/include"
-        export OPENSSL_SSL_LIBRARY="${OPENSSL_ROOT_DIR}/lib/libssl.so.3"
-        export OPENSSL_CRYPTO_LIBRARY="${OPENSSL_ROOT_DIR}/lib/libcrypto.so.3"
-        export LIB_OUTPUT_PATH="${GITHUB_WORKSPACE}/artifacts/android-native/libgit2-3f4182d.so"
-        export LIBGIT2_PATH="$LIB_OUTPUT_PATH"
-        bash ./scripts/build-libgit2-android.sh
+        for abi in arm64-v8a x86_64; do
+          export ANDROID_ABI="$abi"
+          bash ./scripts/build-openssl-android.sh
+          bash ./scripts/build-libssh2-android.sh
+          bash ./scripts/build-libgit2-android.sh
+        done
+        export ANDROID_ABIS="arm64-v8a x86_64"
         bash ./scripts/pack-libgit2sharp-nativebinaries-android.sh
 
-    - name: Build Android APK
+    - name: Build Android APKs
       run: |
-        dotnet build src/Unlimotion.Android/Unlimotion.Android.csproj \
-          -c Release \
-          -t:Package \
-          -p:RuntimeIdentifier=android-arm64 \
-          -p:ContinuousIntegrationBuild=true \
-          -p:GitHubRefName="${GITHUB_REF_NAME}" \
-          -p:AndroidSdkDirectory="${ANDROID_SDK_ROOT}" \
-          -p:JavaSdkDirectory="${JAVA_HOME}"
+        for rid in android-arm64 android-x64; do
+          rm -rf "src/Unlimotion.Android/bin/Release/net10.0-android"
+          dotnet build src/Unlimotion.Android/Unlimotion.Android.csproj \
+            -c Release \
+            -t:Package \
+            -p:RuntimeIdentifier="$rid" \
+            -p:ContinuousIntegrationBuild=true \
+            -p:GitHubRefName="${GITHUB_REF_NAME}" \
+            -p:AndroidSdkDirectory="${ANDROID_SDK_ROOT}" \
+            -p:JavaSdkDirectory="${JAVA_HOME}"
 
-    - name: Stage APK Artifact
-      run: |
-        apk_path="$(find src/Unlimotion.Android/bin/Release -type f -name '*-Signed.apk' | head -n 1)"
-        if [ -z "$apk_path" ]; then
-          echo "Signed APK not found under src/Unlimotion.Android/bin/Release" >&2
-          exit 1
-        fi
+          apk_path="$(find src/Unlimotion.Android/bin/Release -type f -name '*-Signed.apk' | head -n 1)"
+          if [ -z "$apk_path" ]; then
+            echo "Signed APK not found for $rid under src/Unlimotion.Android/bin/Release" >&2
+            exit 1
+          fi
 
-        asset_name="Unlimotion-android-arm64.apk"
-        if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
-          asset_name="Unlimotion-${GITHUB_REF_NAME}-android-arm64.apk"
-        fi
+          asset_name="Unlimotion-${rid}.apk"
+          if [ "${GITHUB_EVENT_NAME}" = "release" ]; then
+            asset_name="Unlimotion-${GITHUB_REF_NAME}-${rid}.apk"
+          fi
 
-        cp "$apk_path" "artifacts/android/${asset_name}"
-        echo "APK_ASSET_PATH=artifacts/android/${asset_name}" >> "$GITHUB_ENV"
+          cp "$apk_path" "artifacts/android/${asset_name}"
+        done
 
     - name: Upload APK Artifact
       uses: actions/upload-artifact@v4
@@ -119,4 +119,4 @@ jobs:
       if: github.event_name == 'release'
       uses: softprops/action-gh-release@v1
       with:
-        files: ${{ env.APK_ASSET_PATH }}
+        files: artifacts/android/*.apk

--- a/scripts/android-native-common.sh
+++ b/scripts/android-native-common.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+android_native_cpu_count() {
+  if command -v nproc >/dev/null 2>&1; then
+    nproc
+    return
+  fi
+
+  sysctl -n hw.ncpu
+}
+
+android_native_host_tag() {
+  case "$(uname -s)" in
+    Linux)
+      echo "linux-x86_64"
+      ;;
+    Darwin)
+      if [ "$(uname -m)" = "arm64" ]; then
+        echo "darwin-arm64"
+      else
+        echo "darwin-x86_64"
+      fi
+      ;;
+    MINGW*|MSYS*|CYGWIN*)
+      echo "windows-x86_64"
+      ;;
+    *)
+      echo "Unsupported host OS: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+android_native_normalize_host_path() {
+  local path="$1"
+  if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$path"
+    return
+  fi
+
+  echo "$path"
+}
+
+android_native_select_abi() {
+  ANDROID_ABI="${ANDROID_ABI:-arm64-v8a}"
+
+  case "$ANDROID_ABI" in
+    arm64-v8a|android-arm64|arm64)
+      ANDROID_ABI="arm64-v8a"
+      ANDROID_RID="android-arm64"
+      ANDROID_OPENSSL_TARGET="android-arm64"
+      ANDROID_CLANG_TARGET="aarch64-linux-android"
+      ;;
+    x86_64|android-x64|x64)
+      ANDROID_ABI="x86_64"
+      ANDROID_RID="android-x64"
+      ANDROID_OPENSSL_TARGET="android-x86_64"
+      ANDROID_CLANG_TARGET="x86_64-linux-android"
+      ;;
+    *)
+      echo "Unsupported Android ABI: $ANDROID_ABI. Supported values: arm64-v8a, x86_64." >&2
+      exit 1
+      ;;
+  esac
+
+  export ANDROID_ABI ANDROID_RID ANDROID_OPENSSL_TARGET ANDROID_CLANG_TARGET
+}
+
+android_native_find_ndk() {
+  ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+  if [ -z "$ANDROID_SDK_ROOT" ]; then
+    echo "ANDROID_SDK_ROOT or ANDROID_HOME must be set" >&2
+    exit 1
+  fi
+
+  if [ -z "${ANDROID_NDK_ROOT:-}" ]; then
+    if [ -d "$ANDROID_SDK_ROOT/ndk" ]; then
+      ANDROID_NDK_ROOT="$(ls -d "$ANDROID_SDK_ROOT/ndk/"* 2>/dev/null | sort -V | tail -1)"
+    elif [ -d "$ANDROID_SDK_ROOT/ndk-bundle" ]; then
+      ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk-bundle"
+    else
+      echo "ANDROID_NDK_ROOT not set and no NDK found under $ANDROID_SDK_ROOT" >&2
+      exit 1
+    fi
+  fi
+
+  ANDROID_SDK_ROOT="$(android_native_normalize_host_path "$ANDROID_SDK_ROOT")"
+  ANDROID_NDK_ROOT="$(android_native_normalize_host_path "$ANDROID_NDK_ROOT")"
+
+  export ANDROID_SDK_ROOT ANDROID_NDK_ROOT
+}
+
+android_native_toolchain_dir() {
+  local toolchain_dir="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$(android_native_host_tag)"
+  if [ ! -d "$toolchain_dir" ]; then
+    echo "Android LLVM toolchain not found: $toolchain_dir" >&2
+    exit 1
+  fi
+
+  echo "$toolchain_dir"
+}
+
+android_native_readelf() {
+  local toolchain_dir="$1"
+  local readelf_path="$toolchain_dir/bin/llvm-readelf"
+  if [ -x "$readelf_path" ]; then
+    echo "$readelf_path"
+    return
+  fi
+
+  if command -v llvm-readelf >/dev/null 2>&1; then
+    command -v llvm-readelf
+    return
+  fi
+
+  echo ""
+}

--- a/scripts/build-libgit2-android.sh
+++ b/scripts/build-libgit2-android.sh
@@ -2,30 +2,29 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/android-native-common.sh"
+
 SRC_DIR="${SRC_DIR:-$ROOT_DIR/.native/libgit2-src}"
-BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/.native/libgit2-build-android-arm64}"
 LIB_NAME="libgit2-3f4182d.so"
-LIB_OUTPUT_PATH="${LIB_OUTPUT_PATH:-$ROOT_DIR/$LIB_NAME}"
 ANDROID_API_LEVEL="${ANDROID_API_LEVEL:-24}"
 OPENSSL_VERSION="${OPENSSL_VERSION:-3.0.14}"
+LIBSSH2_VERSION="${LIBSSH2_VERSION:-1.11.1}"
 LIBGIT2_HTTPS_BACKEND="${LIBGIT2_HTTPS_BACKEND:-OpenSSL}"
+LIBGIT2_USE_SSH="${LIBGIT2_USE_SSH:-ON}"
 
+android_native_select_abi
 ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-/data/data/com.termux/files/home/android-sdk}}"
-OPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-android-arm64/prefix}"
+android_native_find_ndk
+
+BUILD_DIR="${BUILD_DIR:-$ROOT_DIR/.native/libgit2-build-$ANDROID_RID}"
+LIB_OUTPUT_PATH="${LIB_OUTPUT_PATH:-$ROOT_DIR/artifacts/android-native/libgit2-$ANDROID_RID/$LIB_NAME}"
+OPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-$ANDROID_RID/prefix}"
 OPENSSL_INCLUDE_DIR="${OPENSSL_INCLUDE_DIR:-$OPENSSL_ROOT_DIR/include}"
 OPENSSL_SSL_LIBRARY="${OPENSSL_SSL_LIBRARY:-$OPENSSL_ROOT_DIR/lib/libssl.so.3}"
 OPENSSL_CRYPTO_LIBRARY="${OPENSSL_CRYPTO_LIBRARY:-$OPENSSL_ROOT_DIR/lib/libcrypto.so.3}"
-
-if [ -z "${ANDROID_NDK_ROOT:-}" ]; then
-  if [ -d "$ANDROID_SDK_ROOT/ndk" ]; then
-    ANDROID_NDK_ROOT="$(ls -d "$ANDROID_SDK_ROOT/ndk/"* 2>/dev/null | sort -V | tail -1)"
-  elif [ -d "$ANDROID_SDK_ROOT/ndk-bundle" ]; then
-    ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk-bundle"
-  else
-    echo "ANDROID_NDK_ROOT not set and no NDK found under $ANDROID_SDK_ROOT"
-    exit 1
-  fi
-fi
+LIBSSH2_ROOT_DIR="${LIBSSH2_ROOT_DIR:-$ROOT_DIR/artifacts/android-native/libssh2-$LIBSSH2_VERSION-$ANDROID_RID/prefix}"
+LIBSSH2_INCLUDE_DIR="${LIBSSH2_INCLUDE_DIR:-$LIBSSH2_ROOT_DIR/include}"
+LIBSSH2_LIBRARY="${LIBSSH2_LIBRARY:-$LIBSSH2_ROOT_DIR/lib/libssh2.so}"
 
 if [ ! -d "$SRC_DIR" ] || ! git -C "$SRC_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Missing submodule at $SRC_DIR. Run: git submodule update --init --recursive"
@@ -43,14 +42,14 @@ CMAKE_ARGS=(
   -B "$BUILD_DIR"
   -G Ninja
   -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN"
-  -DANDROID_ABI=arm64-v8a
+  -DANDROID_ABI="$ANDROID_ABI"
   -DANDROID_PLATFORM="android-$ANDROID_API_LEVEL"
   -DBUILD_SHARED_LIBS=ON
   -DBUILD_TESTS=OFF
   -DBUILD_CLI=OFF
   -DBUILD_EXAMPLES=OFF
   -DBUILD_FUZZERS=OFF
-  -DUSE_SSH=OFF
+  -DUSE_SSH="$LIBGIT2_USE_SSH"
   -DUSE_HTTPS="$LIBGIT2_HTTPS_BACKEND"
   -DUSE_BUNDLED_ZLIB=ON
 )
@@ -81,6 +80,28 @@ case "$LIBGIT2_HTTPS_BACKEND" in
     fi
     ;;
 esac
+
+if [ "$LIBGIT2_USE_SSH" = "ON" ]; then
+  if [ ! -f "$LIBSSH2_INCLUDE_DIR/libssh2.h" ]; then
+    echo "Android libssh2 headers not found under $LIBSSH2_INCLUDE_DIR. Run: ANDROID_ABI=$ANDROID_ABI bash ./scripts/build-libssh2-android.sh"
+    exit 1
+  fi
+
+  if [ ! -f "$LIBSSH2_LIBRARY" ]; then
+    LIBSSH2_LIBRARY="$(find "$LIBSSH2_ROOT_DIR/lib" -type f -name "libssh2.so*" | sort | head -n 1 || true)"
+  fi
+
+  if [ -z "$LIBSSH2_LIBRARY" ] || [ ! -f "$LIBSSH2_LIBRARY" ]; then
+    echo "Android libssh2 shared library not found under $LIBSSH2_ROOT_DIR/lib. Run: ANDROID_ABI=$ANDROID_ABI bash ./scripts/build-libssh2-android.sh"
+    exit 1
+  fi
+
+  CMAKE_ARGS+=(
+    -DLIBSSH2_INCLUDE_DIR="$LIBSSH2_INCLUDE_DIR"
+    -DLIBSSH2_LIBRARY="$LIBSSH2_LIBRARY"
+    -DCMAKE_PREFIX_PATH="$OPENSSL_ROOT_DIR;$LIBSSH2_ROOT_DIR"
+  )
+fi
 
 cmake "${CMAKE_ARGS[@]}"
 

--- a/scripts/build-libssh2-android.sh
+++ b/scripts/build-libssh2-android.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/android-native-common.sh"
+
+LIBSSH2_VERSION="${LIBSSH2_VERSION:-1.11.1}"
+ANDROID_API_LEVEL="${ANDROID_API_LEVEL:-24}"
+OPENSSL_VERSION="${OPENSSL_VERSION:-3.0.14}"
+LIBSSH2_BASE_URL="${LIBSSH2_BASE_URL:-https://www.libssh2.org/download}"
+
+android_native_select_abi
+android_native_find_ndk
+
+BUILD_ROOT="${LIBSSH2_BUILD_ROOT:-$ROOT_DIR/artifacts/android-native/libssh2-$LIBSSH2_VERSION-$ANDROID_RID}"
+DOWNLOAD_DIR="$BUILD_ROOT/downloads"
+SOURCE_PARENT_DIR="$BUILD_ROOT/src"
+SOURCE_DIR="$SOURCE_PARENT_DIR/libssh2-$LIBSSH2_VERSION"
+INSTALL_DIR="${LIBSSH2_OUTPUT_DIR:-$BUILD_ROOT/prefix}"
+ARCHIVE_PATH="$DOWNLOAD_DIR/libssh2-$LIBSSH2_VERSION.tar.gz"
+OPENSSL_ROOT_DIR="${OPENSSL_ROOT_DIR:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-$ANDROID_RID/prefix}"
+OPENSSL_INCLUDE_DIR="${OPENSSL_INCLUDE_DIR:-$OPENSSL_ROOT_DIR/include}"
+OPENSSL_CRYPTO_LIBRARY="${OPENSSL_CRYPTO_LIBRARY:-$OPENSSL_ROOT_DIR/lib/libcrypto.so.3}"
+
+TOOLCHAIN_DIR="$(android_native_toolchain_dir)"
+CMAKE_TOOLCHAIN="$ANDROID_NDK_ROOT/build/cmake/android.toolchain.cmake"
+if [ ! -f "$CMAKE_TOOLCHAIN" ]; then
+  echo "Android toolchain not found: $CMAKE_TOOLCHAIN"
+  exit 1
+fi
+
+if [ -f "$INSTALL_DIR/include/libssh2.h" ] &&
+  compgen -G "$INSTALL_DIR/lib/libssh2.so*" >/dev/null &&
+  [ "${FORCE_REBUILD:-0}" != "1" ]; then
+  echo "Reusing existing Android libssh2 $ANDROID_ABI build in $INSTALL_DIR"
+  exit 0
+fi
+
+if [ ! -f "$OPENSSL_INCLUDE_DIR/openssl/ssl.h" ] || [ ! -f "$OPENSSL_CRYPTO_LIBRARY" ]; then
+  echo "Android OpenSSL artifacts not found for $ANDROID_ABI under $OPENSSL_ROOT_DIR. Run: ANDROID_ABI=$ANDROID_ABI bash ./scripts/build-openssl-android.sh"
+  exit 1
+fi
+
+mkdir -p "$DOWNLOAD_DIR" "$SOURCE_PARENT_DIR"
+
+if [ ! -f "$ARCHIVE_PATH" ]; then
+  curl -fL "$LIBSSH2_BASE_URL/libssh2-$LIBSSH2_VERSION.tar.gz" -o "$ARCHIVE_PATH"
+fi
+
+rm -rf "$SOURCE_DIR" "$INSTALL_DIR" "$BUILD_ROOT/build"
+tar -xzf "$ARCHIVE_PATH" -C "$SOURCE_PARENT_DIR"
+
+cmake \
+  -S "$SOURCE_DIR" \
+  -B "$BUILD_ROOT/build" \
+  -G Ninja \
+  -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TOOLCHAIN" \
+  -DANDROID_ABI="$ANDROID_ABI" \
+  -DANDROID_PLATFORM="android-$ANDROID_API_LEVEL" \
+  -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+  -DCMAKE_PREFIX_PATH="$OPENSSL_ROOT_DIR" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DBUILD_STATIC_LIBS=OFF \
+  -DBUILD_EXAMPLES=OFF \
+  -DBUILD_TESTING=OFF \
+  -DCRYPTO_BACKEND=OpenSSL \
+  -DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR" \
+  -DOPENSSL_INCLUDE_DIR="$OPENSSL_INCLUDE_DIR" \
+  -DOPENSSL_CRYPTO_LIBRARY="$OPENSSL_CRYPTO_LIBRARY"
+
+cmake --build "$BUILD_ROOT/build" --target install
+
+STRIP="$TOOLCHAIN_DIR/bin/llvm-strip"
+for library_path in "$INSTALL_DIR"/lib/libssh2.so*; do
+  if [ -f "$library_path" ]; then
+    "$STRIP" --strip-unneeded "$library_path" || true
+    echo "Wrote $library_path"
+  fi
+done

--- a/scripts/build-openssl-android.sh
+++ b/scripts/build-openssl-android.sh
@@ -2,50 +2,25 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/android-native-common.sh"
+
 OPENSSL_VERSION="${OPENSSL_VERSION:-3.0.14}"
 ANDROID_API_LEVEL="${ANDROID_API_LEVEL:-24}"
-ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
 OPENSSL_BASE_URL="${OPENSSL_BASE_URL:-https://www.openssl.org/source}"
-BUILD_ROOT="${OPENSSL_BUILD_ROOT:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-android-arm64}"
+
+android_native_select_abi
+android_native_find_ndk
+
+BUILD_ROOT="${OPENSSL_BUILD_ROOT:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-$ANDROID_RID}"
 DOWNLOAD_DIR="$BUILD_ROOT/downloads"
 SOURCE_PARENT_DIR="$BUILD_ROOT/src"
 SOURCE_DIR="$SOURCE_PARENT_DIR/openssl-$OPENSSL_VERSION"
 INSTALL_DIR="${OPENSSL_OUTPUT_DIR:-$BUILD_ROOT/prefix}"
 ARCHIVE_PATH="$DOWNLOAD_DIR/openssl-$OPENSSL_VERSION.tar.gz"
-
-cpu_count() {
-  if command -v nproc >/dev/null 2>&1; then
-    nproc
-    return
-  fi
-
-  sysctl -n hw.ncpu
-}
-
-host_tag() {
-  case "$(uname -s)" in
-    Linux)
-      echo "linux-x86_64"
-      ;;
-    Darwin)
-      if [ "$(uname -m)" = "arm64" ]; then
-        echo "darwin-arm64"
-      else
-        echo "darwin-x86_64"
-      fi
-      ;;
-    MINGW*|MSYS*|CYGWIN*)
-      echo "windows-x86_64"
-      ;;
-    *)
-      echo "Unsupported host OS: $(uname -s)" >&2
-      exit 1
-      ;;
-  esac
-}
+OPENSSL_MAKE_JOBS="${OPENSSL_MAKE_JOBS:-$(android_native_cpu_count)}"
 
 ensure_perl() {
-  if perl -MLocale::Maketext::Simple -e1 >/dev/null 2>&1; then
+  if perl -MLocale::Maketext::Simple -MExtUtils::MakeMaker -MPod::Usage -e1 >/dev/null 2>&1; then
     return
   fi
 
@@ -78,30 +53,10 @@ ensure_perl() {
   esac
 }
 
-if [ -z "$ANDROID_SDK_ROOT" ]; then
-  echo "ANDROID_SDK_ROOT or ANDROID_HOME must be set"
-  exit 1
-fi
-
-if [ -z "${ANDROID_NDK_ROOT:-}" ]; then
-  if [ -d "$ANDROID_SDK_ROOT/ndk" ]; then
-    ANDROID_NDK_ROOT="$(ls -d "$ANDROID_SDK_ROOT/ndk/"* 2>/dev/null | sort -V | tail -1)"
-  elif [ -d "$ANDROID_SDK_ROOT/ndk-bundle" ]; then
-    ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk-bundle"
-  else
-    echo "ANDROID_NDK_ROOT not set and no NDK found under $ANDROID_SDK_ROOT"
-    exit 1
-  fi
-fi
-
-TOOLCHAIN_DIR="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$(host_tag)"
-if [ ! -d "$TOOLCHAIN_DIR" ]; then
-  echo "Android LLVM toolchain not found: $TOOLCHAIN_DIR"
-  exit 1
-fi
+TOOLCHAIN_DIR="$(android_native_toolchain_dir)"
 
 if [ -f "$INSTALL_DIR/lib/libssl.so.3" ] && [ -f "$INSTALL_DIR/lib/libcrypto.so.3" ] && [ "${FORCE_REBUILD:-0}" != "1" ]; then
-  echo "Reusing existing Android OpenSSL build in $INSTALL_DIR"
+  echo "Reusing existing Android OpenSSL $ANDROID_ABI build in $INSTALL_DIR"
   exit 0
 fi
 
@@ -123,6 +78,9 @@ fi
 export PATH="$TOOLCHAIN_DIR/bin:$PATH"
 export ANDROID_NDK_ROOT
 export MSYS2_ENV_CONV_EXCL="PERL5LIB${MSYS2_ENV_CONV_EXCL:+;$MSYS2_ENV_CONV_EXCL}"
+export CC="$TOOLCHAIN_DIR/bin/${ANDROID_CLANG_TARGET}${ANDROID_API_LEVEL}-clang"
+export AR="$TOOLCHAIN_DIR/bin/llvm-ar"
+export RANLIB="$TOOLCHAIN_DIR/bin/llvm-ranlib"
 export STRIP="$TOOLCHAIN_DIR/bin/llvm-strip"
 
 if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
@@ -134,7 +92,7 @@ ensure_perl
 
 pushd "$SOURCE_DIR" >/dev/null
 perl ./Configure \
-  android-arm64 \
+  "$ANDROID_OPENSSL_TARGET" \
   "-D__ANDROID_API__=$ANDROID_API_LEVEL" \
   shared \
   no-tests \
@@ -142,13 +100,31 @@ perl ./Configure \
   --prefix="$INSTALL_DIR" \
   --openssldir="$INSTALL_DIR/ssl"
 
-if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
-  make -j"$(cpu_count)" build_generated libcrypto.a libssl.a libcrypto.ld libssl.ld crypto/libssl-shlib-packet.o
+if [ ! -f Makefile ]; then
+  echo "OpenSSL Configure did not produce $SOURCE_DIR/Makefile"
+  exit 1
+fi
 
-  if [ ! -f "crypto/libssl-shlib-packet.o" ]; then
-    echo "Expected OpenSSL shared packet object was not generated: $SOURCE_DIR/crypto/libssl-shlib-packet.o"
-    exit 1
-  fi
+if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
+  make -j"$OPENSSL_MAKE_JOBS" \
+    build_generated \
+    libcrypto.a \
+    libssl.a \
+    libcrypto.ld \
+    libssl.ld \
+    crypto/libssl-shlib-packet.o \
+    ssl/libdefault-lib-s3_cbc.o \
+    ssl/record/libcommon-lib-tls_pad.o
+
+  for object_file in \
+    crypto/libssl-shlib-packet.o \
+    ssl/libdefault-lib-s3_cbc.o \
+    ssl/record/libcommon-lib-tls_pad.o; do
+    if [ ! -f "$object_file" ]; then
+      echo "Expected OpenSSL object was not generated: $SOURCE_DIR/$object_file"
+      exit 1
+    fi
+  done
 
   for generated_file in libcrypto.ld libssl.ld; do
     if [ ! -f "$generated_file" ]; then
@@ -157,7 +133,7 @@ if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
     fi
   done
 
-  "$TOOLCHAIN_DIR/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang" \
+  "$TOOLCHAIN_DIR/bin/${ANDROID_CLANG_TARGET}${ANDROID_API_LEVEL}-clang" \
     -fPIC \
     -pthread \
     -Wa,--noexecstack \
@@ -167,6 +143,7 @@ if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
     -Wl,-znodelete \
     -shared \
     -Wl,-Bsymbolic \
+    -Wl,--no-undefined \
     -Wl,-soname=libcrypto.so.3 \
     -o libcrypto.so.3 \
     -Wl,--version-script=libcrypto.ld \
@@ -175,7 +152,7 @@ if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
     -ldl \
     -pthread
 
-  "$TOOLCHAIN_DIR/bin/aarch64-linux-android${ANDROID_API_LEVEL}-clang" \
+  "$TOOLCHAIN_DIR/bin/${ANDROID_CLANG_TARGET}${ANDROID_API_LEVEL}-clang" \
     -fPIC \
     -pthread \
     -Wa,--noexecstack \
@@ -185,10 +162,13 @@ if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
     -Wl,-znodelete \
     -shared \
     -Wl,-Bsymbolic \
+    -Wl,--no-undefined \
     -Wl,-soname=libssl.so.3 \
     -o libssl.so.3 \
     -Wl,--version-script=libssl.ld \
     crypto/libssl-shlib-packet.o \
+    ssl/libdefault-lib-s3_cbc.o \
+    ssl/record/libcommon-lib-tls_pad.o \
     -Wl,--whole-archive libssl.a \
     -Wl,--no-whole-archive \
     ./libcrypto.so.3 \
@@ -202,7 +182,7 @@ if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]]; then
 else
   # Android packaging only needs the shared libraries and headers; building the
   # full software bundle also pulls in target-side programs we never ship.
-  make -j"$(cpu_count)" build_generated libcrypto.so libssl.so
+  make -j"$OPENSSL_MAKE_JOBS" build_generated libcrypto.so libssl.so
 
   mkdir -p "$INSTALL_DIR/lib" "$INSTALL_DIR/include"
   cp -R include/openssl "$INSTALL_DIR/include/"
@@ -210,6 +190,14 @@ else
   install -m 0644 libssl.so "$INSTALL_DIR/lib/libssl.so.3"
 fi
 popd >/dev/null
+
+READELF="$(android_native_readelf "$TOOLCHAIN_DIR")"
+if [ -n "$READELF" ] &&
+  "$READELF" --dyn-syms "$INSTALL_DIR/lib/libssl.so.3" |
+    grep -E 'UND .* (ssl3_cbc_remove_padding_and_mac|tls1_cbc_remove_padding_and_mac|ssl3_cbc_digest_record)$' >/dev/null; then
+  echo "Built libssl.so.3 still contains unresolved OpenSSL CBC symbols."
+  exit 1
+fi
 
 "$STRIP" --strip-unneeded "$INSTALL_DIR/lib/libssl.so.3" "$INSTALL_DIR/lib/libcrypto.so.3"
 echo "Wrote $INSTALL_DIR/lib/libssl.so.3"

--- a/scripts/pack-libgit2sharp-nativebinaries-android.sh
+++ b/scripts/pack-libgit2sharp-nativebinaries-android.sh
@@ -4,11 +4,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_ID="${PACKAGE_ID:-LibGit2Sharp.NativeBinaries}"
 UPSTREAM_VERSION="${UPSTREAM_VERSION:-2.0.323}"
-PACKAGE_VERSION="${PACKAGE_VERSION:-${LIBGIT2_NATIVE_PACKAGE_VERSION:-2.0.324-android.5}}"
+PACKAGE_VERSION="${PACKAGE_VERSION:-${LIBGIT2_NATIVE_PACKAGE_VERSION:-2.0.324-android.6}}"
 OPENSSL_VERSION="${OPENSSL_VERSION:-3.0.14}"
+LIBSSH2_VERSION="${LIBSSH2_VERSION:-1.11.1}"
+ANDROID_ABIS="${ANDROID_ABIS:-arm64-v8a x86_64}"
 NUGET_LOCAL_FEED="${NUGET_LOCAL_FEED:-$ROOT_DIR/artifacts/nuget-local}"
-LIBGIT2_PATH="${LIBGIT2_PATH:-$ROOT_DIR/libgit2-3f4182d.so}"
-OPENSSL_LIB_DIR="${OPENSSL_LIB_DIR:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-android-arm64/prefix/lib}"
 DOWNLOAD_DIR="${PACKAGE_DOWNLOAD_DIR:-$ROOT_DIR/artifacts/android-native/nuget-downloads}"
 UPSTREAM_PACKAGE_PATH="$DOWNLOAD_DIR/${PACKAGE_ID}.${UPSTREAM_VERSION}.nupkg"
 OUTPUT_PACKAGE_PATH="$NUGET_LOCAL_FEED/${PACKAGE_ID}.${PACKAGE_VERSION}.nupkg"
@@ -71,15 +71,56 @@ PY
 
 trap cleanup EXIT
 
-for required_file in \
-  "$LIBGIT2_PATH" \
-  "$OPENSSL_LIB_DIR/libssl.so.3" \
-  "$OPENSSL_LIB_DIR/libcrypto.so.3"; do
-  if [ ! -f "$required_file" ]; then
-    echo "Missing required file: $required_file"
+rid_for_abi() {
+  case "$1" in
+    arm64-v8a|android-arm64|arm64)
+      echo "android-arm64"
+      ;;
+    x86_64|android-x64|x64)
+      echo "android-x64"
+      ;;
+    *)
+      echo "Unsupported Android ABI: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+stage_runtime() {
+  local abi="$1"
+  local rid
+  rid="$(rid_for_abi "$abi")"
+  local native_dir="$STAGING_DIR/runtimes/$rid/native"
+  local libgit2_path="${LIBGIT2_PATH:-$ROOT_DIR/artifacts/android-native/libgit2-$rid/libgit2-3f4182d.so}"
+  local openssl_lib_dir="${OPENSSL_LIB_DIR:-$ROOT_DIR/artifacts/android-native/openssl-$OPENSSL_VERSION-$rid/prefix/lib}"
+  local libssh2_lib_dir="${LIBSSH2_LIB_DIR:-$ROOT_DIR/artifacts/android-native/libssh2-$LIBSSH2_VERSION-$rid/prefix/lib}"
+
+  for required_file in \
+    "$libgit2_path" \
+    "$openssl_lib_dir/libssl.so.3" \
+    "$openssl_lib_dir/libcrypto.so.3"; do
+    if [ ! -f "$required_file" ]; then
+      echo "Missing required file for $rid: $required_file"
+      exit 1
+    fi
+  done
+
+  if ! compgen -G "$libssh2_lib_dir/libssh2.so*" >/dev/null; then
+    echo "Missing libssh2 shared library for $rid under $libssh2_lib_dir"
     exit 1
   fi
-done
+
+  mkdir -p "$native_dir"
+  install -m 0644 "$libgit2_path" "$native_dir/libgit2-3f4182d.so"
+  install -m 0644 "$openssl_lib_dir/libssl.so.3" "$native_dir/libssl.so.3"
+  install -m 0644 "$openssl_lib_dir/libcrypto.so.3" "$native_dir/libcrypto.so.3"
+
+  for libssh2_path in "$libssh2_lib_dir"/libssh2.so*; do
+    if [ -f "$libssh2_path" ]; then
+      install -m 0644 "$libssh2_path" "$native_dir/$(basename "$libssh2_path")"
+    fi
+  done
+}
 
 mkdir -p "$DOWNLOAD_DIR" "$NUGET_LOCAL_FEED" "$STAGING_DIR"
 
@@ -92,22 +133,29 @@ fi
 unzip -q "$UPSTREAM_PACKAGE_PATH" -d "$STAGING_DIR"
 rm -f "$STAGING_DIR/.signature.p7s"
 
-mkdir -p "$STAGING_DIR/runtimes/android-arm64/native"
-install -m 0644 "$LIBGIT2_PATH" "$STAGING_DIR/runtimes/android-arm64/native/libgit2-3f4182d.so"
-install -m 0644 "$OPENSSL_LIB_DIR/libssl.so.3" "$STAGING_DIR/runtimes/android-arm64/native/libssl.so.3"
-install -m 0644 "$OPENSSL_LIB_DIR/libcrypto.so.3" "$STAGING_DIR/runtimes/android-arm64/native/libcrypto.so.3"
+for abi in $ANDROID_ABIS; do
+  stage_runtime "$abi"
+done
 
 sed -i "s#<version>$UPSTREAM_VERSION</version>#<version>$PACKAGE_VERSION</version>#" "$STAGING_DIR/$PACKAGE_ID.nuspec"
 rm -f "$OUTPUT_PACKAGE_PATH"
 
 create_package_archive
 
-for required_entry in \
-  "runtimes/android-arm64/native/libgit2-3f4182d.so" \
-  "runtimes/android-arm64/native/libssl.so.3" \
-  "runtimes/android-arm64/native/libcrypto.so.3"; do
-  if ! unzip -l "$OUTPUT_PACKAGE_PATH" "$required_entry" >/dev/null 2>&1; then
-    echo "Packed package is missing $required_entry"
+for abi in $ANDROID_ABIS; do
+  rid="$(rid_for_abi "$abi")"
+  for required_entry in \
+    "runtimes/$rid/native/libgit2-3f4182d.so" \
+    "runtimes/$rid/native/libssl.so.3" \
+    "runtimes/$rid/native/libcrypto.so.3"; do
+    if ! unzip -l "$OUTPUT_PACKAGE_PATH" "$required_entry" >/dev/null 2>&1; then
+      echo "Packed package is missing $required_entry"
+      exit 1
+    fi
+  done
+
+  if ! unzip -l "$OUTPUT_PACKAGE_PATH" "runtimes/$rid/native/libssh2.so*" >/dev/null 2>&1; then
+    echo "Packed package is missing libssh2 for $rid"
     exit 1
   fi
 done

--- a/scripts/test-android-build-scripts.ps1
+++ b/scripts/test-android-build-scripts.ps1
@@ -145,8 +145,10 @@ Assert-Match $packScript 'Compress-Archive' 'pack-libgit2sharp-nativebinaries-an
 
 Assert-Match $nugetConfig '\.\./artifacts/nuget-local' 'src/nuget.config must reference repo-local NuGet feed.'
 Assert-Match $androidProject '<RuntimeIdentifiers>android-arm64;android-x64</RuntimeIdentifiers>' 'Unlimotion.Android.csproj must build both arm64 and x64 Android runtimes.'
+Assert-Match $androidProject 'runtimes\\android-arm64\\native\\libssh2\.so' 'Unlimotion.Android.csproj must explicitly package Android arm64 libssh2.so.'
 Assert-Match $androidProject 'runtimes\\android-x64\\native\\libcrypto\.so\.3' 'Unlimotion.Android.csproj must explicitly package Android x64 libcrypto.so.3.'
 Assert-Match $androidProject 'runtimes\\android-x64\\native\\libssl\.so\.3' 'Unlimotion.Android.csproj must explicitly package Android x64 libssl.so.3.'
+Assert-Match $androidProject 'runtimes\\android-x64\\native\\libssh2\.so' 'Unlimotion.Android.csproj must explicitly package Android x64 libssh2.so.'
 Assert-Match $gitattributes '(?m)^\*\.sh\s+text\s+eol=lf\s*$' '.gitattributes must pin shell scripts to LF line endings.'
 Assert-Match $workflow 'ANDROID_PLATFORM:\s+android-36' 'android-packaging workflow must install Android platform 36 for the current .NET Android workload.'
 Assert-Match $workflow 'artifacts/android artifacts/android-native artifacts/nuget-local' 'android-packaging workflow must create repo-local feed directory.'

--- a/scripts/test-android-build-scripts.ps1
+++ b/scripts/test-android-build-scripts.ps1
@@ -1,18 +1,31 @@
 $ErrorActionPreference = 'Stop'
 
 $rootDir = Split-Path -Parent $PSScriptRoot
+$commonScript = Get-Content -Raw (Join-Path $PSScriptRoot 'android-native-common.sh')
 $buildLibgit2Script = Get-Content -Raw (Join-Path $PSScriptRoot 'build-libgit2-android.sh')
+$buildLibssh2Script = Get-Content -Raw (Join-Path $PSScriptRoot 'build-libssh2-android.sh')
 $buildOpenSslScript = Get-Content -Raw (Join-Path $PSScriptRoot 'build-openssl-android.sh')
 $packScript = Get-Content -Raw (Join-Path $PSScriptRoot 'pack-libgit2sharp-nativebinaries-android.sh')
 $nugetConfig = Get-Content -Raw (Join-Path $rootDir 'src\nuget.config')
+$androidProject = Get-Content -Raw (Join-Path $rootDir 'src\Unlimotion.Android\Unlimotion.Android.csproj')
 $gitattributes = Get-Content -Raw (Join-Path $rootDir '.gitattributes')
 $workflow = Get-Content -Raw (Join-Path $rootDir '.github\workflows\android-packaging.yml')
 $submoduleGitFile = Join-Path $rootDir '.native\libgit2-src\.git'
 $shellScripts = @(
     @{
+        Name = 'android-native-common.sh'
+        Path = Join-Path $PSScriptRoot 'android-native-common.sh'
+        Content = $commonScript
+    },
+    @{
         Name = 'build-libgit2-android.sh'
         Path = Join-Path $PSScriptRoot 'build-libgit2-android.sh'
         Content = $buildLibgit2Script
+    },
+    @{
+        Name = 'build-libssh2-android.sh'
+        Path = Join-Path $PSScriptRoot 'build-libssh2-android.sh'
+        Content = $buildLibssh2Script
     },
     @{
         Name = 'build-openssl-android.sh'
@@ -70,11 +83,21 @@ Assert-NotMatch $buildLibgit2Script '\[ ! -d "\$SRC_DIR/\.git" \]' 'build-libgit
 
 Assert-Match $buildLibgit2Script '#!/usr/bin/env bash' 'build-libgit2-android.sh must use a portable bash shebang.'
 Assert-Match $buildLibgit2Script 'LIBGIT2_HTTPS_BACKEND="\$\{LIBGIT2_HTTPS_BACKEND:-OpenSSL\}"' 'build-libgit2-android.sh must default libgit2 HTTPS backend to OpenSSL for Android builds.'
-Assert-Match $buildLibgit2Script 'OPENSSL_ROOT_DIR="\$\{OPENSSL_ROOT_DIR:-\$ROOT_DIR/artifacts/android-native/openssl-\$OPENSSL_VERSION-android-arm64/prefix\}"' 'build-libgit2-android.sh must default OpenSSL root to repo-local Android artifacts.'
+Assert-Match $commonScript 'android-arm64' 'android-native-common.sh must map arm64-v8a to the android-arm64 RID.'
+Assert-Match $commonScript 'android-x64' 'android-native-common.sh must map x86_64 to the android-x64 RID.'
+Assert-Match $commonScript 'cygpath -u' 'android-native-common.sh must normalize Windows SDK and NDK paths for Git Bash.'
+Assert-Match $buildLibgit2Script 'OPENSSL_ROOT_DIR="\$\{OPENSSL_ROOT_DIR:-\$ROOT_DIR/artifacts/android-native/openssl-\$OPENSSL_VERSION-\$ANDROID_RID/prefix\}"' 'build-libgit2-android.sh must default OpenSSL root to ABI-specific repo-local Android artifacts.'
+Assert-Match $buildLibgit2Script 'LIBSSH2_ROOT_DIR="\$\{LIBSSH2_ROOT_DIR:-\$ROOT_DIR/artifacts/android-native/libssh2-\$LIBSSH2_VERSION-\$ANDROID_RID/prefix\}"' 'build-libgit2-android.sh must default libssh2 root to ABI-specific repo-local Android artifacts.'
 Assert-Match $buildLibgit2Script '-DBUILD_TESTS=OFF' 'build-libgit2-android.sh must disable libgit2 tests for Android packaging.'
 Assert-Match $buildLibgit2Script '-DBUILD_CLI=OFF' 'build-libgit2-android.sh must disable libgit2 CLI for Android packaging.'
+Assert-Match $buildLibgit2Script '-DUSE_SSH="\$LIBGIT2_USE_SSH"' 'build-libgit2-android.sh must enable SSH through libssh2 for Android builds.'
+Assert-Match $buildLibgit2Script '-DLIBSSH2_INCLUDE_DIR="\$LIBSSH2_INCLUDE_DIR"' 'build-libgit2-android.sh must pass libssh2 headers to libgit2 CMake.'
+Assert-Match $buildLibgit2Script '-DLIBSSH2_LIBRARY="\$LIBSSH2_LIBRARY"' 'build-libgit2-android.sh must pass libssh2 library to libgit2 CMake.'
 Assert-Match $buildLibgit2Script '--target libgit2package' 'build-libgit2-android.sh must build the shared libgit2 package target.'
-Assert-Match $buildOpenSslScript 'MINGW\*\|MSYS\*\|CYGWIN\*' 'build-openssl-android.sh must support Windows Git Bash/MSYS host detection.'
+Assert-Match $buildLibssh2Script 'CRYPTO_BACKEND=OpenSSL' 'build-libssh2-android.sh must build libssh2 against OpenSSL.'
+Assert-Match $buildLibssh2Script '-DBUILD_EXAMPLES=OFF' 'build-libssh2-android.sh must disable libssh2 examples for Android packaging.'
+Assert-Match $buildLibssh2Script '-DBUILD_TESTING=OFF' 'build-libssh2-android.sh must disable libssh2 tests for Android packaging.'
+Assert-Match $commonScript 'MINGW\*\|MSYS\*\|CYGWIN\*' 'android-native-common.sh must support Windows Git Bash/MSYS host detection.'
 Assert-Match $buildOpenSslScript 'Locale::Maketext::Simple' 'build-openssl-android.sh must validate a usable Perl runtime for OpenSSL on Windows.'
 Assert-Match $buildOpenSslScript '\$ROOT_DIR/artifacts/tools/strawberry-perl/perl' 'build-openssl-android.sh must source repo-local portable Strawberry Perl modules on Windows.'
 Assert-Match $buildOpenSslScript '\$ROOT_DIR/artifacts/tools/perl-lib' 'build-openssl-android.sh must stage portable Perl modules into repo-local perl-lib for Git Bash.'
@@ -89,17 +112,21 @@ Assert-Match $buildOpenSslScript 'if \(0 \\&\\& eval \{ require IPC::Cmd; 1; \}\
 Assert-Match $buildOpenSslScript '\$name\.exe' 'build-openssl-android.sh must teach OpenSSL Configure fallback tool lookup to probe .exe host tools.'
 Assert-Match $buildOpenSslScript 'Configurations/15-android\.conf' 'build-openssl-android.sh must patch OpenSSL Android config for Windows-host Android builds.'
 Assert-Match $buildOpenSslScript '\$ndk =~ s' 'build-openssl-android.sh must normalize Android NDK paths inside OpenSSL Android config on Windows hosts.'
-Assert-Match $buildOpenSslScript 'build_generated libcrypto\.a libssl\.a libcrypto\.ld libssl\.ld crypto/libssl-shlib-packet\.o' 'build-openssl-android.sh must build OpenSSL version scripts and shared packet object before Windows relinking.'
 Assert-Match $buildOpenSslScript 'crypto/libssl-shlib-packet\.o' 'build-openssl-android.sh must include the OpenSSL shared packet object in the Windows libssl.so.3 relink.'
+Assert-Match $buildOpenSslScript 'ssl/libdefault-lib-s3_cbc\.o' 'build-openssl-android.sh must include OpenSSL CBC digest object in the Windows libssl.so.3 relink.'
+Assert-Match $buildOpenSslScript 'ssl/record/libcommon-lib-tls_pad\.o' 'build-openssl-android.sh must include OpenSSL TLS padding object in the Windows libssl.so.3 relink.'
+Assert-Match $buildOpenSslScript '--no-undefined' 'build-openssl-android.sh must fail relinking when Android OpenSSL has unresolved symbols.'
 Assert-Match $buildOpenSslScript 'for generated_file in libcrypto\.ld libssl\.ld' 'build-openssl-android.sh must verify OpenSSL version scripts exist before Windows relinking.'
 Assert-Match $buildOpenSslScript '--whole-archive libcrypto\.a' 'build-openssl-android.sh must relink libcrypto.so.3 from libcrypto.a on Windows hosts.'
 Assert-Match $buildOpenSslScript '--whole-archive libssl\.a' 'build-openssl-android.sh must relink libssl.so.3 from libssl.a on Windows hosts.'
 Assert-NotMatch $buildOpenSslScript '-Wl,--version-script=libssl\.ld\s+-Wl,--whole-archive libssl\.a\s+-Wl,--no-whole-archive\s+\./libcrypto\.so\.3' 'build-openssl-android.sh must not relink libssl.so.3 without crypto/libssl-shlib-packet.o.'
-Assert-Match $buildOpenSslScript 'export ANDROID_NDK_ROOT' 'build-openssl-android.sh must export ANDROID_NDK_ROOT for OpenSSL Configure.'
+Assert-Match $commonScript 'export ANDROID_SDK_ROOT ANDROID_NDK_ROOT' 'android-native-common.sh must export ANDROID_NDK_ROOT for native Android builds.'
 Assert-Match $buildOpenSslScript 'perl \./Configure' 'build-openssl-android.sh must invoke OpenSSL Configure via the selected perl runtime.'
-Assert-NotMatch $buildOpenSslScript 'export CC=' 'build-openssl-android.sh must rely on NDK clang detection from PATH instead of hardwiring CC.'
+Assert-Match $buildOpenSslScript 'export CC="\$TOOLCHAIN_DIR/bin/\$\{ANDROID_CLANG_TARGET\}\$\{ANDROID_API_LEVEL\}-clang"' 'build-openssl-android.sh must select the NDK clang compiler explicitly because modern NDKs no longer provide GCC.'
+Assert-Match $buildOpenSslScript 'OpenSSL Configure did not produce' 'build-openssl-android.sh must fail when OpenSSL Configure does not create a Makefile.'
 Assert-NotMatch $buildOpenSslScript 'no-docs' 'build-openssl-android.sh must not pass unsupported no-docs to OpenSSL Configure.'
-Assert-Match $buildOpenSslScript 'make -j"\$\(cpu_count\)" build_generated libcrypto\.so libssl\.so' 'build-openssl-android.sh must build only the Android OpenSSL shared libraries on non-Windows hosts.'
+Assert-Match $buildOpenSslScript 'OPENSSL_MAKE_JOBS="\$\{OPENSSL_MAKE_JOBS:-\$\(android_native_cpu_count\)\}"' 'build-openssl-android.sh must allow limiting OpenSSL parallelism on Windows hosts.'
+Assert-Match $buildOpenSslScript 'make -j"\$OPENSSL_MAKE_JOBS" build_generated libcrypto\.so libssl\.so' 'build-openssl-android.sh must build only the Android OpenSSL shared libraries on non-Windows hosts.'
 Assert-Match $buildOpenSslScript 'install -m 0644 libcrypto\.so "\$INSTALL_DIR/lib/libcrypto\.so\.3"' 'build-openssl-android.sh must rename the non-Windows libcrypto.so output to libcrypto.so.3 when staging Android artifacts.'
 Assert-Match $buildOpenSslScript 'install -m 0644 libssl\.so "\$INSTALL_DIR/lib/libssl\.so\.3"' 'build-openssl-android.sh must rename the non-Windows libssl.so output to libssl.so.3 when staging Android artifacts.'
 Assert-NotMatch $buildOpenSslScript '(?s)else\s+.*build_sw' 'build-openssl-android.sh must not invoke OpenSSL build_sw on non-Windows hosts.'
@@ -107,7 +134,9 @@ Assert-NotMatch $buildOpenSslScript '(?s)else\s+.*make install_sw' 'build-openss
 
 Assert-Match $packScript '\$ROOT_DIR/artifacts/nuget-local' 'pack-libgit2sharp-nativebinaries-android.sh must default to repo-local NuGet feed.'
 Assert-NotMatch $packScript '/storage/emulated/0/nuget-local' 'pack-libgit2sharp-nativebinaries-android.sh must not hardcode Termux feed path.'
-Assert-Match $packScript '2\.0\.324-android\.5' 'pack-libgit2sharp-nativebinaries-android.sh must default to the fixed Android native package version.'
+Assert-Match $packScript '2\.0\.324-android\.6' 'pack-libgit2sharp-nativebinaries-android.sh must default to the fixed Android native package version.'
+Assert-Match $packScript 'ANDROID_ABIS="\$\{ANDROID_ABIS:-arm64-v8a x86_64\}"' 'pack-libgit2sharp-nativebinaries-android.sh must package arm64 and x86_64 Android runtimes by default.'
+Assert-Match $packScript 'libssh2\.so\*' 'pack-libgit2sharp-nativebinaries-android.sh must include libssh2 runtime libraries.'
 Assert-Match $packScript 'command -v zip' 'pack-libgit2sharp-nativebinaries-android.sh must probe for zip before packing.'
 Assert-Match $packScript 'command -v python3' 'pack-libgit2sharp-nativebinaries-android.sh must probe for a native Python archiver fallback.'
 Assert-Match $packScript 'zipfile' 'pack-libgit2sharp-nativebinaries-android.sh must support Python-based package creation when zip is unavailable.'
@@ -115,10 +144,15 @@ Assert-Match $packScript 'powershell\.exe' 'pack-libgit2sharp-nativebinaries-and
 Assert-Match $packScript 'Compress-Archive' 'pack-libgit2sharp-nativebinaries-android.sh must support PowerShell archive creation when zip is unavailable.'
 
 Assert-Match $nugetConfig '\.\./artifacts/nuget-local' 'src/nuget.config must reference repo-local NuGet feed.'
+Assert-Match $androidProject '<RuntimeIdentifiers>android-arm64;android-x64</RuntimeIdentifiers>' 'Unlimotion.Android.csproj must build both arm64 and x64 Android runtimes.'
+Assert-Match $androidProject 'runtimes\\android-x64\\native\\libcrypto\.so\.3' 'Unlimotion.Android.csproj must explicitly package Android x64 libcrypto.so.3.'
+Assert-Match $androidProject 'runtimes\\android-x64\\native\\libssl\.so\.3' 'Unlimotion.Android.csproj must explicitly package Android x64 libssl.so.3.'
 Assert-Match $gitattributes '(?m)^\*\.sh\s+text\s+eol=lf\s*$' '.gitattributes must pin shell scripts to LF line endings.'
 Assert-Match $workflow 'ANDROID_PLATFORM:\s+android-36' 'android-packaging workflow must install Android platform 36 for the current .NET Android workload.'
 Assert-Match $workflow 'artifacts/android artifacts/android-native artifacts/nuget-local' 'android-packaging workflow must create repo-local feed directory.'
-Assert-Match $workflow 'bash ./scripts/build-openssl-android\.sh[\s\S]*bash ./scripts/build-libgit2-android\.sh' 'android-packaging workflow must build Android OpenSSL before libgit2.'
+Assert-Match $workflow 'for abi in arm64-v8a x86_64' 'android-packaging workflow must build native dependencies for arm64 and x86_64.'
+Assert-Match $workflow 'bash ./scripts/build-openssl-android\.sh[\s\S]*bash ./scripts/build-libssh2-android\.sh[\s\S]*bash ./scripts/build-libgit2-android\.sh' 'android-packaging workflow must build Android OpenSSL and libssh2 before libgit2.'
+Assert-Match $workflow 'for rid in android-arm64 android-x64' 'android-packaging workflow must build arm64 and x64 Android APKs.'
 Assert-NotMatch $workflow '/storage/emulated/0/nuget-local' 'android-packaging workflow must not prepare Termux-only feed path.'
 
 foreach ($shellScript in $shellScripts) {

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="AvaloniaGraphControl" Version="0.6.1" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
-	<PackageVersion Include="LibGit2Sharp.NativeBinaries" Version="2.0.324-android.5" />
+	<PackageVersion Include="LibGit2Sharp.NativeBinaries" Version="2.0.324-android.6" />
     <PackageVersion Include="Mileeena.Notification.Avalonia" Version="2.1.2" />
     <PackageVersion Include="Packaging.Targets" Version="0.1.232" />
     <PackageVersion Include="Quartz" Version="3.8.1" />

--- a/src/Unlimotion.Android/MainActivity.cs
+++ b/src/Unlimotion.Android/MainActivity.cs
@@ -24,6 +24,7 @@ namespace Unlimotion.Android;
     Theme = "@style/MyTheme.NoActionBar",
     Icon = "@drawable/icon",
     MainLauncher = true,
+    LaunchMode = LaunchMode.SingleTask,
     ResizeableActivity = true,
     WindowSoftInputMode = SoftInput.AdjustResize,
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]

--- a/src/Unlimotion.Android/MainActivity.cs
+++ b/src/Unlimotion.Android/MainActivity.cs
@@ -3,6 +3,8 @@
 using System;
 using System.IO;
 using System.Runtime.Versioning;
+using System.Threading;
+using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.Content.PM;
@@ -16,6 +18,7 @@ using Avalonia.Android;
 using Avalonia.ReactiveUI;
 using Unlimotion;
 using Unlimotion.Services;
+using L10n = Unlimotion.ViewModel.Localization.Localization;
 
 namespace Unlimotion.Android;
 
@@ -30,6 +33,11 @@ namespace Unlimotion.Android;
     ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize | ConfigChanges.UiMode)]
 public class MainActivity : AvaloniaMainActivity<App>
 {
+    private const int OpenTaskFolderRequestCode = 4201;
+    private const int ManageExternalStorageRequestCode = 4202;
+    private TaskCompletionSource<string?>? _openTaskFolderCompletion;
+    private TaskCompletionSource<bool>? _manageExternalStorageCompletion;
+
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
@@ -62,6 +70,8 @@ public class MainActivity : AvaloniaMainActivity<App>
             }
 
             App.Init(configPath);
+            Dialogs.PlatformOpenFolderDialogAsync = ShowOpenDocumentTreeAsync;
+            TaskStorageFactory.PrepareFileStoragePathAsync = EnsureFileStoragePathAccessAsync;
 
             return base.CustomizeAppBuilder(builder)
                 .WithCustomFont()
@@ -90,6 +100,256 @@ public class MainActivity : AvaloniaMainActivity<App>
         }
 
         throw new InvalidOperationException("Could not resolve app data directory.");
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+        CompleteManageExternalStorageRequestIfPending();
+    }
+
+    private async Task<string?> ShowOpenDocumentTreeAsync(string? title, string? directory)
+    {
+        var path = await OpenDocumentTreeAsync();
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            await EnsureFileStoragePathAccessAsync(path);
+        }
+
+        return path;
+    }
+
+    private Task<string?> OpenDocumentTreeAsync()
+    {
+        var completion = new TaskCompletionSource<string?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var previousCompletion = Interlocked.Exchange(ref _openTaskFolderCompletion, completion);
+        previousCompletion?.TrySetResult(null);
+
+        try
+        {
+            var intent = new Intent(Intent.ActionOpenDocumentTree);
+            intent.AddFlags(
+                ActivityFlags.GrantReadUriPermission |
+                ActivityFlags.GrantWriteUriPermission |
+                ActivityFlags.GrantPersistableUriPermission |
+                ActivityFlags.GrantPrefixUriPermission);
+
+            StartActivityForResult(intent, OpenTaskFolderRequestCode);
+        }
+        catch (Exception ex)
+        {
+            Interlocked.CompareExchange(ref _openTaskFolderCompletion, null, completion);
+            completion.TrySetException(ex);
+        }
+
+        return completion.Task;
+    }
+
+    private async Task EnsureFileStoragePathAccessAsync(string? path)
+    {
+        if (!RequiresManageExternalStorage(path) || HasManageExternalStorageAccess())
+        {
+            return;
+        }
+
+        await RequestManageExternalStorageAccessAsync();
+        if (!HasManageExternalStorageAccess())
+        {
+            throw new InvalidOperationException(L10n.Get("AndroidAllFilesAccessRequired"));
+        }
+    }
+
+    private bool RequiresManageExternalStorage(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !OperatingSystem.IsAndroidVersionAtLeast(30))
+        {
+            return false;
+        }
+
+        var normalizedPath = NormalizeAndroidPath(path);
+        if (string.IsNullOrWhiteSpace(normalizedPath))
+        {
+            return false;
+        }
+
+        var externalFilesDir = GetExternalFilesDir(null)?.AbsolutePath;
+        if (IsPathWithinDirectory(normalizedPath, NormalizeAndroidPath(externalFilesDir)))
+        {
+            return false;
+        }
+
+        var internalFilesDir = ApplicationContext?.FilesDir?.AbsolutePath;
+        if (IsPathWithinDirectory(normalizedPath, NormalizeAndroidPath(internalFilesDir)))
+        {
+            return false;
+        }
+
+        return normalizedPath.StartsWith("/storage/", StringComparison.Ordinal) ||
+               normalizedPath.StartsWith("/sdcard/", StringComparison.Ordinal);
+    }
+
+    private static string NormalizeAndroidPath(string? path)
+    {
+        return string.IsNullOrWhiteSpace(path)
+            ? string.Empty
+            : path.Replace('\\', '/').TrimEnd('/');
+    }
+
+    private static bool IsPathWithinDirectory(string path, string directory)
+    {
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(directory))
+        {
+            return false;
+        }
+
+        if (string.Equals(path, directory, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return path.StartsWith(directory + "/", StringComparison.Ordinal);
+    }
+
+    private static bool HasManageExternalStorageAccess()
+    {
+        return !OperatingSystem.IsAndroidVersionAtLeast(30) ||
+               global::Android.OS.Environment.IsExternalStorageManager;
+    }
+
+    private Task RequestManageExternalStorageAccessAsync()
+    {
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var previousCompletion = Interlocked.Exchange(ref _manageExternalStorageCompletion, completion);
+        previousCompletion?.TrySetResult(HasManageExternalStorageAccess());
+
+        try
+        {
+            StartActivityForResult(CreateManageExternalStorageSettingsIntent(), ManageExternalStorageRequestCode);
+        }
+        catch
+        {
+            try
+            {
+                StartActivityForResult(new Intent(Settings.ActionManageAllFilesAccessPermission), ManageExternalStorageRequestCode);
+            }
+            catch (Exception ex)
+            {
+                Interlocked.CompareExchange(ref _manageExternalStorageCompletion, null, completion);
+                completion.TrySetException(ex);
+            }
+        }
+
+        return completion.Task;
+    }
+
+    private Intent CreateManageExternalStorageSettingsIntent()
+    {
+        var intent = new Intent(Settings.ActionManageAppAllFilesAccessPermission);
+        intent.SetData(global::Android.Net.Uri.Parse($"package:{PackageName}"));
+        return intent;
+    }
+
+    private void CompleteManageExternalStorageRequestIfPending()
+    {
+        var completion = _manageExternalStorageCompletion;
+        if (completion == null)
+        {
+            return;
+        }
+
+        new Handler(Looper.MainLooper!).PostDelayed(() =>
+        {
+            var pendingCompletion = Interlocked.Exchange(ref _manageExternalStorageCompletion, null);
+            pendingCompletion?.TrySetResult(HasManageExternalStorageAccess());
+        }, 250);
+    }
+
+    protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+    {
+        base.OnActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == ManageExternalStorageRequestCode)
+        {
+            CompleteManageExternalStorageRequestIfPending();
+            return;
+        }
+
+        if (requestCode != OpenTaskFolderRequestCode)
+        {
+            return;
+        }
+
+        var completion = Interlocked.Exchange(ref _openTaskFolderCompletion, null);
+        if (completion == null)
+        {
+            return;
+        }
+
+        if (resultCode != Result.Ok || data?.Data == null)
+        {
+            completion.TrySetResult(null);
+            return;
+        }
+
+        var uri = data.Data;
+        TryPersistFolderAccess(data, uri);
+        completion.TrySetResult(TryResolveDocumentTreeToPath(uri));
+    }
+
+    private void TryPersistFolderAccess(Intent data, global::Android.Net.Uri uri)
+    {
+        try
+        {
+            var flags = data.Flags & (ActivityFlags.GrantReadUriPermission | ActivityFlags.GrantWriteUriPermission);
+            if (flags != 0)
+            {
+                ContentResolver?.TakePersistableUriPermission(uri, flags);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    private static string? TryResolveDocumentTreeToPath(global::Android.Net.Uri uri)
+    {
+        try
+        {
+            var documentId = DocumentsContract.GetTreeDocumentId(uri);
+            if (string.IsNullOrWhiteSpace(documentId))
+            {
+                return null;
+            }
+
+            var separatorIndex = documentId.IndexOf(':');
+            if (separatorIndex < 0)
+            {
+                return null;
+            }
+
+            var volume = documentId[..separatorIndex];
+            var relative = documentId[(separatorIndex + 1)..].TrimStart('/');
+            var rootPath = volume switch
+            {
+                var value when string.Equals(value, "primary", StringComparison.OrdinalIgnoreCase)
+                    => "/storage/emulated/0",
+                var value when string.Equals(value, "home", StringComparison.OrdinalIgnoreCase)
+                    => "/storage/emulated/0/Documents",
+                _ => $"/storage/{volume}"
+            };
+
+            return string.IsNullOrWhiteSpace(relative)
+                ? rootPath
+                : $"{rootPath}/{relative}";
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static void WriteStartupError(Exception ex)

--- a/src/Unlimotion.Android/Properties/AndroidManifest.xml
+++ b/src/Unlimotion.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
 	<application android:label="Unlimotion" android:icon="@drawable/icon" />
 </manifest>

--- a/src/Unlimotion.Android/Unlimotion.Android.csproj
+++ b/src/Unlimotion.Android/Unlimotion.Android.csproj
@@ -33,8 +33,10 @@
   <ItemGroup>
     <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-arm64\native\libcrypto.so.3" />
     <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-arm64\native\libssl.so.3" />
+    <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-arm64\native\libssh2.so" />
     <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-x64\native\libcrypto.so.3" />
     <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-x64\native\libssl.so.3" />
+    <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-x64\native\libssh2.so" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Unlimotion.Android/Unlimotion.Android.csproj
+++ b/src/Unlimotion.Android/Unlimotion.Android.csproj
@@ -10,7 +10,7 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
-    <RuntimeIdentifiers>android-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>android-arm64;android-x64</RuntimeIdentifiers>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
     <AndroidAapt2NoCompress>dll;pdb</AndroidAapt2NoCompress>
@@ -31,11 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-  </ItemGroup>
-
-  <ItemGroup>
-    <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-arm64\native\libssl.so.3" />
     <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-arm64\native\libcrypto.so.3" />
+    <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-arm64\native\libssl.so.3" />
+    <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-x64\native\libcrypto.so.3" />
+    <AndroidNativeLibrary Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\android-x64\native\libssl.so.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Unlimotion.Test/BackupViaGitServiceTests.cs
+++ b/src/Unlimotion.Test/BackupViaGitServiceTests.cs
@@ -224,6 +224,107 @@ public sealed class BackupViaGitServiceTests : IDisposable
         await Assert.That(remote.Branches["main"].Tip.Tree["availability.migration.report"]).IsNull();
     }
 
+    [Test]
+    public async System.Threading.Tasks.Task GetCredentials_ReturnsSshPrivateKeyCredentialsForConfiguredSshUrl()
+    {
+        var privateKeyPath = Path.Combine(_rootPath, "id_unlimotion");
+        var publicKeyPath = $"{privateKeyPath}.pub";
+        File.WriteAllText(privateKeyPath, "private key");
+        File.WriteAllText(publicKeyPath, "public key");
+        var configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        if (configuration is IDisposable disposable)
+        {
+            _configurationDisposables.Add(disposable);
+        }
+
+        var service = new BackupViaGitService(configuration);
+
+        var credentials = service.GetCredentials(new GitSettings
+        {
+            SshPrivateKeyPath = privateKeyPath,
+            SshPublicKeyPath = publicKeyPath
+        })("git@github.com:owner/repo.git", "git", SupportedCredentialTypes.Default);
+
+        await Assert.That(credentials.GetType()).IsEqualTo(typeof(SshPrivateKeyCredentials));
+        var sshCredentials = (SshPrivateKeyCredentials)credentials;
+        await Assert.That(sshCredentials.Username).IsEqualTo("git");
+        await Assert.That(sshCredentials.PrivateKeyPath).IsEqualTo(privateKeyPath);
+        await Assert.That(sshCredentials.PublicKeyPath).IsEqualTo(publicKeyPath);
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task GetCredentials_ThrowsForSshUrlWhenPrivateKeyIsMissing()
+    {
+        var configuration = WritableJsonConfigurationFabric.Create(_configPath);
+        if (configuration is IDisposable disposable)
+        {
+            _configurationDisposables.Add(disposable);
+        }
+
+        var service = new BackupViaGitService(configuration);
+        var credentials = service.GetCredentials(new GitSettings
+        {
+            SshPrivateKeyPath = Path.Combine(_rootPath, "missing-key")
+        });
+
+        await Assert.That(() => credentials("git@github.com:owner/repo.git", "git", SupportedCredentialTypes.Default))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task GenerateManagedRsaSshKey_CreatesPemPrivateKeyAndOpenSshPublicKey()
+    {
+        var privateKeyPath = Path.Combine(_rootPath, "managed_rsa");
+        var publicKeyPath = $"{privateKeyPath}.pub";
+
+        BackupViaGitService.GenerateManagedRsaSshKey(privateKeyPath, publicKeyPath);
+
+        await Assert.That(File.ReadAllText(privateKeyPath)).Contains("BEGIN RSA PRIVATE KEY");
+        await Assert.That(File.ReadAllText(publicKeyPath)).Contains("ssh-rsa ");
+        await Assert.That(File.ReadAllText(publicKeyPath)).Contains(" unlimotion");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task IsKnownGitHubSshHostKey_AcceptsKnownGitHubFingerprint()
+    {
+        var ed25519Sha1 = Convert.FromHexString("E9619E2ED56C2F2A71729DB80BACC2CE9CCCE8D4");
+
+        await Assert.That(BackupViaGitService.IsKnownGitHubSshHostKey("github.com", ed25519Sha1)).IsTrue();
+        await Assert.That(BackupViaGitService.IsKnownGitHubSshHostKey("ssh.github.com:443", ed25519Sha1)).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task IsKnownGitHubSshHostKey_RejectsUnknownHostAndUnknownFingerprint()
+    {
+        var ed25519Sha1 = Convert.FromHexString("E9619E2ED56C2F2A71729DB80BACC2CE9CCCE8D4");
+        var unknownSha1 = Convert.FromHexString("0000000000000000000000000000000000000000");
+
+        await Assert.That(BackupViaGitService.IsKnownGitHubSshHostKey("gitlab.com", ed25519Sha1)).IsFalse();
+        await Assert.That(BackupViaGitService.IsKnownGitHubSshHostKey("github.com", unknownSha1)).IsFalse();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task IsKnownOrTrustFirstUseSshHostKey_StoresFirstSeenFingerprint()
+    {
+        var knownHostsPath = Path.Combine(_rootPath, ".ssh", "known_hosts_unlimotion");
+        var sha1 = Convert.FromHexString("1111111111111111111111111111111111111111");
+
+        await Assert.That(BackupViaGitService.IsKnownOrTrustFirstUseSshHostKey(knownHostsPath, "example.com:22", sha1)).IsTrue();
+        await Assert.That(File.ReadAllText(knownHostsPath)).Contains("example.com 1111111111111111111111111111111111111111");
+        await Assert.That(BackupViaGitService.IsKnownOrTrustFirstUseSshHostKey(knownHostsPath, "example.com", sha1)).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task IsKnownOrTrustFirstUseSshHostKey_RejectsChangedFingerprint()
+    {
+        var knownHostsPath = Path.Combine(_rootPath, ".ssh", "known_hosts_unlimotion");
+        var originalSha1 = Convert.FromHexString("1111111111111111111111111111111111111111");
+        var changedSha1 = Convert.FromHexString("2222222222222222222222222222222222222222");
+
+        await Assert.That(BackupViaGitService.IsKnownOrTrustFirstUseSshHostKey(knownHostsPath, "example.com", originalSha1)).IsTrue();
+        await Assert.That(BackupViaGitService.IsKnownOrTrustFirstUseSshHostKey(knownHostsPath, "example.com", changedSha1)).IsFalse();
+    }
+
     private string CreateLocalTaskFolder()
     {
         var localPath = Path.Combine(_rootPath, "Tasks");

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,7 @@ using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using ReactiveUI;
 using Unlimotion;
 using Unlimotion.Views;
 
@@ -122,6 +124,54 @@ public class SettingsControlResponsiveUiTests
             }
             finally
             {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task SettingsControl_BrowseTaskStoragePath_UpdatesPathFromFolderPicker()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            var previousPlatformPicker = Dialogs.PlatformOpenFolderDialogAsync;
+            Window? window = null;
+
+            try
+            {
+                var settings = fixture.MainWindowViewModelTest.Settings;
+                var selectedPath = Path.Combine(fixture.DefaultTasksFolderPath, "Selected");
+                Dialogs.PlatformOpenFolderDialogAsync = (_, _) => Task.FromResult<string?>(selectedPath);
+                settings.BrowseTaskStoragePathCommand = ReactiveCommand.CreateFromTask(async () =>
+                {
+                    var path = await new Dialogs().ShowOpenFolderDialogAsync("Data folder");
+                    if (!string.IsNullOrWhiteSpace(path))
+                    {
+                        settings.TaskStoragePath = path;
+                    }
+                });
+
+                var view = new SettingsControl
+                {
+                    DataContext = settings
+                };
+
+                window = CreateWindow(view, 720, 800);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var browseButton = FindControlByAutomationId<Button>(view, "BrowseTaskStoragePathButton");
+                await ClickControlAsync(window, browseButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(settings.TaskStoragePath).IsEqualTo(selectedPath);
+            }
+            finally
+            {
+                Dialogs.PlatformOpenFolderDialogAsync = previousPlatformPicker;
                 window?.Close();
                 fixture.CleanTasks();
             }

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -204,6 +204,7 @@
   <data name="RepositoryConnectErrorStatus" xml:space="preserve"><value>Repository connection error: {0}</value></data>
   <data name="RepositoryConnectErrorToast" xml:space="preserve"><value>Could not connect repository: {0}</value></data>
   <data name="RepositoryWorkingDirectoryUnavailable" xml:space="preserve"><value>Repository working directory is unavailable.</value></data>
+  <data name="RepositoryHeadUnavailable" xml:space="preserve"><value>Repository HEAD is unavailable.</value></data>
   <data name="ResetFilters" xml:space="preserve"><value>Reset filters</value></data>
   <data name="ResetFiltersConfirmHeader" xml:space="preserve"><value>Reset filters?</value></data>
   <data name="ResetFiltersConfirmMessage" xml:space="preserve"><value>Filters on the current tab will be reset to defaults. Continue?</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -341,6 +341,7 @@
   <data name="Wednesday" xml:space="preserve"><value>Wednesday</value></data>
   <data name="AllTasksResaved" xml:space="preserve"><value>All tasks were resaved.</value></data>
   <data name="AndroidAllFilesHint" xml:space="preserve"><value> Check the "All files access" permission.</value></data>
+  <data name="AndroidAllFilesAccessRequired" xml:space="preserve"><value>All files access is required for this folder.</value></data>
   <data name="BackupConnectCanceledNonEmpty" xml:space="preserve"><value>Connection canceled: the local tasks folder and the remote repository are not empty.</value></data>
   <data name="CannotResolveCloneDirectory" xml:space="preserve"><value>Cannot resolve clone directory for {0}.</value></data>
   <data name="CloneOrUpdateRepositoryFailed" xml:space="preserve"><value>Could not clone or update the repository: {0}</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -341,6 +341,7 @@
   <data name="Wednesday" xml:space="preserve"><value>Среда</value></data>
   <data name="AllTasksResaved" xml:space="preserve"><value>Все задачи пересохранены.</value></data>
   <data name="AndroidAllFilesHint" xml:space="preserve"><value> Проверьте разрешение "Доступ ко всем файлам".</value></data>
+  <data name="AndroidAllFilesAccessRequired" xml:space="preserve"><value>Для этой папки нужен доступ ко всем файлам.</value></data>
   <data name="BackupConnectCanceledNonEmpty" xml:space="preserve"><value>Подключение отменено: локальная папка задач и удаленный репозиторий не пустые.</value></data>
   <data name="CannotResolveCloneDirectory" xml:space="preserve"><value>Не удалось определить папку клонирования для {0}.</value></data>
   <data name="CloneOrUpdateRepositoryFailed" xml:space="preserve"><value>Не удалось клонировать или обновить репозиторий: {0}</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -204,6 +204,7 @@
   <data name="RepositoryConnectErrorStatus" xml:space="preserve"><value>Ошибка подключения репозитория: {0}</value></data>
   <data name="RepositoryConnectErrorToast" xml:space="preserve"><value>Не удалось подключить репозиторий: {0}</value></data>
   <data name="RepositoryWorkingDirectoryUnavailable" xml:space="preserve"><value>Рабочая папка репозитория недоступна.</value></data>
+  <data name="RepositoryHeadUnavailable" xml:space="preserve"><value>HEAD репозитория недоступен.</value></data>
   <data name="ResetFilters" xml:space="preserve"><value>Сбросить фильтры</value></data>
   <data name="ResetFiltersConfirmHeader" xml:space="preserve"><value>Сбросить фильтры?</value></data>
   <data name="ResetFiltersConfirmMessage" xml:space="preserve"><value>Фильтры на текущей вкладке будут сброшены к значениям по умолчанию. Продолжить?</value></data>

--- a/src/Unlimotion/App.axaml.cs
+++ b/src/Unlimotion/App.axaml.cs
@@ -149,6 +149,11 @@ public class App : Application
             settings.SetStorageConnectionState(SettingsConnectionState.Connecting);
             try
             {
+                if (!settings.IsServerMode)
+                {
+                    await PrepareFileStoragePathAsync(settings.TaskStoragePath);
+                }
+
                 _storageFactory?.SwitchStorage(settings.IsServerMode, _configuration!);
                 WireSettingsToCurrentStorage(settings);
                 if (_mainWindowViewModel != null)
@@ -350,10 +355,20 @@ public class App : Application
         settings.BrowseTaskStoragePathCommand = ReactiveCommand.CreateFromTask(async param =>
         {
             if (_dialogs == null) return;
-            var path = await _dialogs.ShowOpenFolderDialogAsync(L10n.Get("FolderPickerDataFolder"));
-            if (!string.IsNullOrWhiteSpace(path))
+            try
             {
-                settings.TaskStoragePath = path;
+                var path = await _dialogs.ShowOpenFolderDialogAsync(L10n.Get("FolderPickerDataFolder"));
+                if (!string.IsNullOrWhiteSpace(path))
+                {
+                    await PrepareFileStoragePathAsync(path);
+                    settings.TaskStoragePath = path;
+                }
+            }
+            catch (Exception ex)
+            {
+                settings.SetStorageConnectionState(SettingsConnectionState.Error);
+                var hint = OperatingSystem.IsAndroid() ? L10n.Get("AndroidAllFilesHint") : string.Empty;
+                _notificationManager?.ErrorToast(L10n.Format("ConnectStorageFailed", ex.Message, hint));
             }
         });
 
@@ -512,10 +527,19 @@ public class App : Application
             return;
         }
 
+        await PrepareFileStoragePathAsync(settings.TaskStoragePath);
         _storageFactory.SwitchStorage(isServerMode: false, _configuration);
         WireSettingsToCurrentStorage(settings);
         await _mainWindowViewModel.Connect();
         settings.SetStorageConnectionState(SettingsConnectionState.Connected);
+    }
+
+    private static Task PrepareFileStoragePathAsync(string? path)
+    {
+        var prepareFileStoragePathAsync = TaskStorageFactory.PrepareFileStoragePathAsync;
+        return prepareFileStoragePathAsync == null
+            ? Task.CompletedTask
+            : prepareFileStoragePathAsync(path);
     }
 
     private void ConfirmAndRun(

--- a/src/Unlimotion/DialogExtensions.cs
+++ b/src/Unlimotion/DialogExtensions.cs
@@ -11,8 +11,16 @@ namespace Unlimotion;
 
 public class Dialogs : IDialogs
 {
+    public static Func<string?, string?, Task<string?>>? PlatformOpenFolderDialogAsync { get; set; }
+
     public async Task<string> ShowOpenFolderDialogAsync(string title = null, string directory = null)
     {
+        var platformOpenFolderDialogAsync = PlatformOpenFolderDialogAsync;
+        if (platformOpenFolderDialogAsync != null)
+        {
+            return await platformOpenFolderDialogAsync(title, directory) ?? string.Empty;
+        }
+
         var topLevel = DialogExtensions.GetTopLevel();
         var storageProvider = topLevel?.StorageProvider;
         if (storageProvider != null && storageProvider.CanPickFolder)
@@ -46,7 +54,8 @@ public class Dialogs : IDialogs
             dialog.Directory = directory;
         }
 
-        return await dialog.ShowAsync() ?? string.Empty;
+        var resultTask = dialog.ShowAsync();
+        return resultTask == null ? string.Empty : await resultTask ?? string.Empty;
     }
 }
 
@@ -54,7 +63,12 @@ public static class DialogExtensions
 {
     public static Task<string?>? ShowAsync(this OpenFolderDialog? dlg)
     {
-        var lifetime = App.Current.ApplicationLifetime;
+        if (dlg == null)
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        var lifetime = App.Current?.ApplicationLifetime;
 
         Window window = null;
         switch (lifetime)

--- a/src/Unlimotion/LibGit2Interop.cs
+++ b/src/Unlimotion/LibGit2Interop.cs
@@ -5,16 +5,18 @@ namespace Unlimotion;
 
 public static class LibGit2Interop
 {
+    public const string NativeLibraryName = "git2-3f4182d";
+
     private const int GitOptSetOwnerValidation = 36;
     private const int GitOptSetSslCertLocations = 12;
 
-    [DllImport("git2", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(NativeLibraryName, CallingConvention = CallingConvention.Cdecl)]
     private static extern int git_libgit2_init();
 
-    [DllImport("git2", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(NativeLibraryName, CallingConvention = CallingConvention.Cdecl)]
     private static extern int git_libgit2_opts(int option, __arglist);
 
-    [DllImport("git2", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(NativeLibraryName, CallingConvention = CallingConvention.Cdecl)]
     private static extern int git_libgit2_opts(int option, IntPtr value1, IntPtr value2);
 
     internal static void DisableOwnerValidationOnAndroid()

--- a/src/Unlimotion/Services/BackupViaGitService.cs
+++ b/src/Unlimotion/Services/BackupViaGitService.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using LibGit2Sharp;
@@ -18,7 +21,16 @@ namespace Unlimotion.Services;
 public class BackupViaGitService : IRemoteBackupService
 {
     private const string DefaultSshKeyFileName = "id_ed25519_unlimotion";
+    private const string KnownHostsFileName = "known_hosts_unlimotion";
     private const string TasksFolderName = "Tasks";
+    // SHA1 hashes of GitHub SSH host key blobs derived from GitHub-published known_hosts entries.
+    private static readonly byte[][] GitHubSshHostKeySha1Hashes =
+    {
+        Convert.FromHexString("E9619E2ED56C2F2A71729DB80BACC2CE9CCCE8D4"),
+        Convert.FromHexString("3358AB5DD3E306C461C840F7487E93B697E30600"),
+        Convert.FromHexString("6F4C60375018BAE0918E37D9162BC15BA40E6365")
+    };
+
     private static readonly string[] IgnoredMigrationReportFileNames =
     {
         "availability.migration.report",
@@ -164,21 +176,28 @@ public class BackupViaGitService : IRemoteBackupService
             throw new InvalidOperationException(L10n.Format("SshKeyAlreadyExists", keyPaths.PublicKeyPath));
         }
 
-        var processResult = RunProcess(CreateProcessStartInfo(
-            "ssh-keygen",
-            sshDirectory,
-            "-t",
-            "ed25519",
-            "-f",
-            keyPaths.PrivateKeyPath,
-            "-N",
-            string.Empty,
-            "-C",
-            "unlimotion"));
-
-        if (processResult.ExitCode != 0)
+        try
         {
-            throw new InvalidOperationException(L10n.Format("SshKeygenFailed", GetProcessError(processResult)));
+            var processResult = RunProcess(CreateProcessStartInfo(
+                "ssh-keygen",
+                sshDirectory,
+                "-t",
+                "ed25519",
+                "-f",
+                keyPaths.PrivateKeyPath,
+                "-N",
+                string.Empty,
+                "-C",
+                "unlimotion"));
+
+            if (processResult.ExitCode != 0)
+            {
+                throw new InvalidOperationException(L10n.Format("SshKeygenFailed", GetProcessError(processResult)));
+            }
+        }
+        catch (Exception ex) when (ShouldUseManagedSshKeyGenerationFallback(ex))
+        {
+            GenerateManagedRsaSshKey(keyPaths.PrivateKeyPath, keyPaths.PublicKeyPath);
         }
 
         if (!File.Exists(keyPaths.PrivateKeyPath) || !File.Exists(keyPaths.PublicKeyPath))
@@ -205,7 +224,11 @@ public class BackupViaGitService : IRemoteBackupService
         {
             if (IsSshUrl(url))
             {
-                return new DefaultCredentials();
+                var privateKeyPath = GetConfiguredSshPrivateKeyPath(gitSettings);
+                return new SshPrivateKeyCredentials(
+                    GetSshUsername(url, _user),
+                    privateKeyPath,
+                    GetConfiguredSshPublicKeyPath(gitSettings, privateKeyPath));
             }
 
             return new UsernamePasswordCredentials
@@ -214,6 +237,116 @@ public class BackupViaGitService : IRemoteBackupService
                 Password = gitSettings.Password
             };
         };
+    }
+
+    private FetchOptions CreateFetchOptions(GitSettings gitSettings)
+    {
+        return new FetchOptions
+        {
+            CredentialsProvider = GetCredentials(gitSettings),
+            CertificateCheck = CheckRemoteCertificate
+        };
+    }
+
+    private PushOptions CreatePushOptions(GitSettings gitSettings)
+    {
+        return new PushOptions
+        {
+            CredentialsProvider = GetCredentials(gitSettings),
+            CertificateCheck = CheckRemoteCertificate
+        };
+    }
+
+    private static ProxyOptions CreateProxyOptions()
+    {
+        return new ProxyOptions
+        {
+            CertificateCheck = CheckRemoteCertificate
+        };
+    }
+
+    internal static bool CheckRemoteCertificate(Certificate certificate, bool valid, string host)
+    {
+        if (valid)
+        {
+            return true;
+        }
+
+        if (certificate is not CertificateSsh sshCertificate ||
+            !sshCertificate.HasSHA1 ||
+            sshCertificate.HashSHA1 == null)
+        {
+            return false;
+        }
+
+        return IsKnownGitHubSshHostKey(host, sshCertificate.HashSHA1) ||
+               IsKnownOrTrustFirstUseSshHostKey(GetKnownHostsPath(), host, sshCertificate.HashSHA1);
+    }
+
+    internal static bool IsKnownGitHubSshHostKey(string host, byte[] sha1Hash)
+    {
+        if (!IsGitHubSshHost(host))
+        {
+            return false;
+        }
+
+        return GitHubSshHostKeySha1Hashes.Any(expectedHash => expectedHash.SequenceEqual(sha1Hash));
+    }
+
+    private static bool IsGitHubSshHost(string host)
+    {
+        var normalizedHost = NormalizeSshHost(host);
+        return string.Equals(normalizedHost, "github.com", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(normalizedHost, "ssh.github.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    internal static bool IsKnownOrTrustFirstUseSshHostKey(string knownHostsPath, string host, byte[] sha1Hash)
+    {
+        var normalizedHost = NormalizeSshHost(host);
+        if (string.IsNullOrWhiteSpace(normalizedHost))
+        {
+            return false;
+        }
+
+        var hashHex = Convert.ToHexString(sha1Hash);
+        if (File.Exists(knownHostsPath))
+        {
+            foreach (var line in File.ReadLines(knownHostsPath))
+            {
+                var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                if (parts.Length != 2 || !string.Equals(parts[0], normalizedHost, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                return string.Equals(parts[1], hashHex, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        Directory.CreateDirectory(Path.GetDirectoryName(knownHostsPath) ?? ".");
+        File.AppendAllText(knownHostsPath, $"{normalizedHost} {hashHex}{Environment.NewLine}");
+        return true;
+    }
+
+    private static string NormalizeSshHost(string host)
+    {
+        var normalizedHost = host.Trim();
+        if (normalizedHost.StartsWith("[", StringComparison.Ordinal) &&
+            normalizedHost.Contains(']', StringComparison.Ordinal))
+        {
+            normalizedHost = normalizedHost[1..normalizedHost.IndexOf(']', StringComparison.Ordinal)];
+        }
+        else
+        {
+            var portSeparatorIndex = normalizedHost.LastIndexOf(':');
+            if (portSeparatorIndex > 0 &&
+                normalizedHost[(portSeparatorIndex + 1)..].All(char.IsDigit))
+            {
+                normalizedHost = normalizedHost[..portSeparatorIndex];
+            }
+        }
+
+        return normalizedHost;
     }
 
     public BackupRepositoryConnectPreview PreviewConnectRepository()
@@ -345,19 +478,7 @@ public class BackupViaGitService : IRemoteBackupService
                 {
                     dbwatcher?.SetEnable(false);
 
-                    if (ShouldUseConfiguredSshKey(remote.Url, settings.git))
-                    {
-                        PushWithConfiguredSshKey(path, settings.git.RemoteName, settings.git.PushRefSpec, settings.git);
-                    }
-                    else
-                    {
-                        var options = new PushOptions
-                        {
-                            CredentialsProvider = GetCredentials(settings.git)
-                        };
-
-                        repo.Network.Push(remote, settings.git.PushRefSpec, options);
-                    }
+                    repo.Network.Push(remote, settings.git.PushRefSpec, CreatePushOptions(settings.git));
 
                     ShowUiMessage(L10n.Get("PushSuccessful"));
                 }
@@ -403,18 +524,8 @@ public class BackupViaGitService : IRemoteBackupService
             {
                 dbwatcher?.SetEnable(false);
 
-                if (ShouldUseConfiguredSshKey(remote.Url, settings.git))
-                {
-                    FetchWithConfiguredSshKey(path, settings.git.RemoteName, settings.git);
-                }
-                else
-                {
-                    var refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
-                    Commands.Fetch(repo, settings.git.RemoteName, refSpecs, new FetchOptions
-                    {
-                        CredentialsProvider = GetCredentials(settings.git)
-                    }, string.Empty);
-                }
+                var refSpecs = remote.FetchRefSpecs.Select(x => x.Specification);
+                Commands.Fetch(repo, settings.git.RemoteName, refSpecs, CreateFetchOptions(settings.git), string.Empty);
 
                 var localBranch = repo.Branches[settings.git.PushRefSpec];
                 if (localBranch == null)
@@ -597,18 +708,14 @@ public class BackupViaGitService : IRemoteBackupService
 
     private void FetchRemote(Repository repo, string repositoryPath, GitSettings gitSettings)
     {
-        if (ShouldUseConfiguredSshKey(gitSettings.RemoteUrl, gitSettings))
-        {
-            FetchWithConfiguredSshKey(repositoryPath, gitSettings.RemoteName, gitSettings);
-            return;
-        }
-
         var remote = repo.Network.Remotes[gitSettings.RemoteName]
                      ?? throw new InvalidOperationException(L10n.Format("RemoteNotFound", gitSettings.RemoteName));
-        Commands.Fetch(repo, gitSettings.RemoteName, remote.FetchRefSpecs.Select(x => x.Specification), new FetchOptions
-        {
-            CredentialsProvider = GetCredentials(gitSettings)
-        }, string.Empty);
+        Commands.Fetch(
+            repo,
+            gitSettings.RemoteName,
+            remote.FetchRefSpecs.Select(x => x.Specification),
+            CreateFetchOptions(gitSettings),
+            string.Empty);
     }
 
     private void CheckoutRemoteBranch(Repository repo, GitSettings gitSettings)
@@ -631,13 +738,47 @@ public class BackupViaGitService : IRemoteBackupService
         }
         catch (Exception)
         {
-            MergeRemoteBranchWithGitCli(repositoryPath, gitSettings);
+            try
+            {
+                MergeUnrelatedHistoriesWithLibGit2(repo, remoteBranch, signature);
+            }
+            catch (Exception)
+            {
+                MergeRemoteBranchWithGitCli(repositoryPath, gitSettings);
+            }
         }
 
         if (repo.Index.Conflicts.Any())
         {
             throw new InvalidOperationException(L10n.Get("GitConflicts"));
         }
+    }
+
+    private static void MergeUnrelatedHistoriesWithLibGit2(Repository repo, Branch remoteBranch, Signature signature)
+    {
+        var localBranch = repo.Head;
+        var localCommit = localBranch.Tip
+                          ?? throw new InvalidOperationException(L10n.Get("RepositoryHeadUnavailable"));
+        var remoteCommit = remoteBranch.Tip
+                           ?? throw new InvalidOperationException(
+                               L10n.Format("RemoteBranchNotFoundAfterFetch", remoteBranch.FriendlyName));
+
+        var mergeResult = repo.ObjectDatabase.MergeCommits(localCommit, remoteCommit, new MergeTreeOptions());
+        if (mergeResult.Status == MergeTreeStatus.Conflicts)
+        {
+            throw new InvalidOperationException(L10n.Get("GitConflicts"));
+        }
+
+        var mergeCommit = repo.ObjectDatabase.CreateCommit(
+            signature,
+            signature,
+            $"Merge remote-tracking branch '{remoteBranch.FriendlyName}'",
+            mergeResult.Tree,
+            new[] { localCommit, remoteCommit },
+            prettifyMessage: true);
+
+        repo.Refs.UpdateTarget(localBranch.Reference, mergeCommit.Id, "merge unrelated histories");
+        repo.Reset(ResetMode.Hard, mergeCommit);
     }
 
     private static bool CommitIgnoredMigrationReportsCleanup(
@@ -674,9 +815,7 @@ public class BackupViaGitService : IRemoteBackupService
             remoteBranchName
         };
 
-        var processResult = ShouldUseConfiguredSshKey(gitSettings.RemoteUrl, gitSettings)
-            ? RunGitCommandWithConfiguredSshKey(repositoryPath, gitSettings, "git merge", arguments.ToArray())
-            : RunGitCommand(repositoryPath, "git merge", arguments.ToArray());
+        var processResult = RunGitCommand(repositoryPath, "git merge", arguments.ToArray());
 
         if (processResult.ExitCode != 0)
         {
@@ -688,16 +827,7 @@ public class BackupViaGitService : IRemoteBackupService
     {
         var remote = repo.Network.Remotes[gitSettings.RemoteName]
                      ?? throw new InvalidOperationException(L10n.Format("RemoteNotFound", gitSettings.RemoteName));
-        if (ShouldUseConfiguredSshKey(remote.Url, gitSettings))
-        {
-            PushWithConfiguredSshKey(repo.Info.WorkingDirectory, gitSettings.RemoteName, gitSettings.PushRefSpec, gitSettings);
-            return;
-        }
-
-        repo.Network.Push(remote, gitSettings.PushRefSpec, new PushOptions
-        {
-            CredentialsProvider = GetCredentials(gitSettings)
-        });
+        repo.Network.Push(remote, gitSettings.PushRefSpec, CreatePushOptions(gitSettings));
     }
 
     private Branch EnsureLocalBranch(Repository repo, GitSettings gitSettings, Commit targetCommit)
@@ -739,31 +869,67 @@ public class BackupViaGitService : IRemoteBackupService
 
     private List<string> GetRemoteHeadRefs(string remoteUrl, GitSettings gitSettings)
     {
-        if (ShouldUseConfiguredSshKey(remoteUrl, gitSettings))
+        if (IsSshUrl(remoteUrl))
         {
-            var processResult = RunGitCommandWithConfiguredSshKey(
-                Environment.CurrentDirectory,
-                gitSettings,
-                "git ls-remote",
-                "ls-remote",
-                "--heads",
-                remoteUrl);
-            return processResult.StandardOutput
-                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(line => line.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).LastOrDefault())
-                .Where(reference => !string.IsNullOrWhiteSpace(reference) &&
-                                    reference.StartsWith("refs/heads/", StringComparison.Ordinal))
-                .Select(reference => reference!)
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
+            return GetRemoteHeadRefsViaFetch(remoteUrl, gitSettings);
         }
 
         return Repository
-            .ListRemoteReferences(remoteUrl, GetCredentials(gitSettings))
+            .ListRemoteReferences(remoteUrl, GetCredentials(gitSettings), CreateProxyOptions())
             .Select(reference => reference.CanonicalName)
             .Where(reference => reference.StartsWith("refs/heads/", StringComparison.Ordinal))
             .Distinct(StringComparer.Ordinal)
             .ToList();
+    }
+
+    private List<string> GetRemoteHeadRefsViaFetch(string remoteUrl, GitSettings gitSettings)
+    {
+        var remoteName = string.IsNullOrWhiteSpace(gitSettings.RemoteName) ? "origin" : gitSettings.RemoteName;
+        var remoteRefPrefix = $"refs/remotes/{remoteName}/";
+        var fetchRefSpec = $"+refs/heads/*:{remoteRefPrefix}*";
+        var tempRepositoryPath = Path.Combine(Path.GetTempPath(), $"unlimotion-remote-refs-{Guid.NewGuid():N}");
+
+        try
+        {
+            Repository.Init(tempRepositoryPath, isBare: true);
+            using var repo = new Repository(tempRepositoryPath);
+            repo.Network.Remotes.Add(remoteName, remoteUrl, fetchRefSpec);
+
+            Commands.Fetch(
+                repo,
+                remoteName,
+                new[] { fetchRefSpec },
+                CreateFetchOptions(gitSettings),
+                string.Empty);
+
+            return repo.Refs
+                .Select(reference => reference.CanonicalName)
+                .Where(reference => reference.StartsWith(remoteRefPrefix, StringComparison.Ordinal))
+                .Select(reference => reference[remoteRefPrefix.Length..])
+                .Where(branchName => !string.Equals(branchName, "HEAD", StringComparison.Ordinal))
+                .Select(branchName => $"refs/heads/{branchName}")
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+        }
+        finally
+        {
+            TryDeleteDirectory(tempRepositoryPath);
+        }
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to delete temporary git repository '{path}': {ex}");
+        }
     }
 
     private void EnsureGitSelectionFromLocalRepository(string repositoryPath, GitSettings gitSettings)
@@ -1158,6 +1324,82 @@ public class BackupViaGitService : IRemoteBackupService
         return $"ssh -i \"{normalizedPath}\" -o IdentitiesOnly=yes -o BatchMode=yes";
     }
 
+    internal static void GenerateManagedRsaSshKey(string privateKeyPath, string publicKeyPath)
+    {
+        using var rsa = RSA.Create(4096);
+        File.WriteAllText(privateKeyPath, rsa.ExportRSAPrivateKeyPem());
+        File.WriteAllText(publicKeyPath, BuildOpenSshRsaPublicKey(rsa, "unlimotion"));
+        TrySetPrivateKeyPermissions(privateKeyPath);
+    }
+
+    internal static string BuildOpenSshRsaPublicKey(RSA rsa, string comment)
+    {
+        var parameters = rsa.ExportParameters(includePrivateParameters: false);
+        using var stream = new MemoryStream();
+        WriteOpenSshString(stream, Encoding.ASCII.GetBytes("ssh-rsa"));
+        WriteOpenSshMpint(stream, parameters.Exponent);
+        WriteOpenSshMpint(stream, parameters.Modulus);
+
+        var key = Convert.ToBase64String(stream.ToArray());
+        return string.IsNullOrWhiteSpace(comment)
+            ? $"ssh-rsa {key}"
+            : $"ssh-rsa {key} {comment}";
+    }
+
+    private static void WriteOpenSshMpint(Stream stream, byte[]? value)
+    {
+        value ??= Array.Empty<byte>();
+        var firstNonZero = 0;
+        while (firstNonZero < value.Length && value[firstNonZero] == 0)
+        {
+            firstNonZero++;
+        }
+
+        var length = value.Length - firstNonZero;
+        var needsPositivePrefix = length > 0 && (value[firstNonZero] & 0x80) != 0;
+        Span<byte> lengthBytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(lengthBytes, (uint)(length + (needsPositivePrefix ? 1 : 0)));
+        stream.Write(lengthBytes);
+
+        if (needsPositivePrefix)
+        {
+            stream.WriteByte(0);
+        }
+
+        stream.Write(value, firstNonZero, length);
+    }
+
+    private static void WriteOpenSshString(Stream stream, byte[] value)
+    {
+        Span<byte> lengthBytes = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(lengthBytes, (uint)value.Length);
+        stream.Write(lengthBytes);
+        stream.Write(value, 0, value.Length);
+    }
+
+    private static bool ShouldUseManagedSshKeyGenerationFallback(Exception ex)
+    {
+        return ex is Win32Exception or PlatformNotSupportedException ||
+               ex.InnerException is Win32Exception or PlatformNotSupportedException;
+    }
+
+    private static void TrySetPrivateKeyPermissions(string privateKeyPath)
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        try
+        {
+            File.SetUnixFileMode(privateKeyPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch (Exception)
+        {
+            // Android app-private storage already prevents other apps from reading the key.
+        }
+    }
+
     private static string GetRepositoryPath(string? pathFromSettings)
     {
         var path = string.IsNullOrWhiteSpace(pathFromSettings) ? TasksFolderName : pathFromSettings;
@@ -1217,64 +1459,6 @@ public class BackupViaGitService : IRemoteBackupService
                && remoteUrl.IndexOf("://", StringComparison.Ordinal) < 0;
     }
 
-    private static bool ShouldUseConfiguredSshKey(string? remoteUrl, GitSettings gitSettings)
-    {
-        return IsSshUrl(remoteUrl) && !string.IsNullOrWhiteSpace(gitSettings.SshPrivateKeyPath);
-    }
-
-    private void CloneRepositoryWithConfiguredSshKey(string remoteUrl, string repositoryPath, GitSettings gitSettings)
-    {
-        var cloneRoot = Path.GetDirectoryName(repositoryPath);
-        if (string.IsNullOrWhiteSpace(cloneRoot))
-        {
-            throw new InvalidOperationException(L10n.Format("CannotResolveCloneDirectory", repositoryPath));
-        }
-
-        Directory.CreateDirectory(cloneRoot);
-
-        var arguments = new List<string> { "clone" };
-        if (!string.IsNullOrWhiteSpace(gitSettings.Branch))
-        {
-            arguments.Add("--branch");
-            arguments.Add(gitSettings.Branch);
-        }
-
-        arguments.Add(remoteUrl);
-        arguments.Add(repositoryPath);
-
-        RunGitCommandWithConfiguredSshKey(cloneRoot, gitSettings, "git clone", arguments.ToArray());
-    }
-
-    private void FetchWithConfiguredSshKey(string repositoryPath, string remoteName, GitSettings gitSettings)
-    {
-        RunGitCommandWithConfiguredSshKey(repositoryPath, gitSettings, "git fetch", "fetch", remoteName);
-    }
-
-    private void PushWithConfiguredSshKey(string repositoryPath, string remoteName, string pushRefSpec, GitSettings gitSettings)
-    {
-        RunGitCommandWithConfiguredSshKey(repositoryPath, gitSettings, "git push", "push", remoteName, pushRefSpec);
-    }
-
-    private (int ExitCode, string StandardOutput, string StandardError) RunGitCommandWithConfiguredSshKey(
-        string workingDirectory,
-        GitSettings gitSettings,
-        string operationName,
-        params string[] arguments)
-    {
-        var privateKeyPath = GetConfiguredSshPrivateKeyPath(gitSettings);
-        var startInfo = CreateProcessStartInfo("git", workingDirectory, arguments);
-        startInfo.Environment["GIT_SSH_COMMAND"] = BuildGitSshCommand(privateKeyPath);
-        startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
-
-        var processResult = RunProcess(startInfo);
-        if (processResult.ExitCode != 0)
-        {
-            throw new InvalidOperationException(L10n.Format("GitOperationFailed", operationName, GetProcessError(processResult)));
-        }
-
-        return processResult;
-    }
-
     private static (int ExitCode, string StandardOutput, string StandardError) RunGitCommand(
         string workingDirectory,
         string operationName,
@@ -1306,6 +1490,41 @@ public class BackupViaGitService : IRemoteBackupService
         }
 
         return privateKeyPath;
+    }
+
+    private static string? GetConfiguredSshPublicKeyPath(GitSettings gitSettings, string privateKeyPath)
+    {
+        if (!string.IsNullOrWhiteSpace(gitSettings.SshPublicKeyPath) &&
+            File.Exists(gitSettings.SshPublicKeyPath))
+        {
+            return gitSettings.SshPublicKeyPath;
+        }
+
+        var inferredPublicKeyPath = $"{privateKeyPath}.pub";
+        return File.Exists(inferredPublicKeyPath) ? inferredPublicKeyPath : null;
+    }
+
+    private static string GetSshUsername(string remoteUrl, string usernameFromUrl)
+    {
+        if (!string.IsNullOrWhiteSpace(usernameFromUrl))
+        {
+            return usernameFromUrl;
+        }
+
+        if (Uri.TryCreate(remoteUrl, UriKind.Absolute, out var uri) &&
+            string.Equals(uri.Scheme, "ssh", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(uri.UserInfo))
+        {
+            return uri.UserInfo.Split(':', 2)[0];
+        }
+
+        var atSignIndex = remoteUrl.IndexOf('@');
+        if (atSignIndex > 0 && remoteUrl.IndexOf("://", StringComparison.Ordinal) < 0)
+        {
+            return remoteUrl[..atSignIndex];
+        }
+
+        return "git";
     }
 
     private static ProcessStartInfo CreateProcessStartInfo(string fileName, string? workingDirectory, params string[] arguments)
@@ -1370,6 +1589,11 @@ public class BackupViaGitService : IRemoteBackupService
         }
 
         return Path.Combine(home, ".ssh");
+    }
+
+    private static string GetKnownHostsPath()
+    {
+        return Path.Combine(GetSshDirectory(), KnownHostsFileName);
     }
 
     private static bool IsPathWithinDirectory(string path, string directory)

--- a/src/Unlimotion/Services/SshPrivateKeyCredentials.cs
+++ b/src/Unlimotion/Services/SshPrivateKeyCredentials.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Runtime.InteropServices;
+using LibGit2Sharp;
+
+namespace Unlimotion.Services;
+
+internal sealed class SshPrivateKeyCredentials : Credentials
+{
+    public SshPrivateKeyCredentials(
+        string username,
+        string privateKeyPath,
+        string? publicKeyPath,
+        string? passphrase = null)
+    {
+        Username = username;
+        PrivateKeyPath = privateKeyPath;
+        PublicKeyPath = publicKeyPath;
+        Passphrase = passphrase;
+    }
+
+    public string Username { get; }
+    public string PrivateKeyPath { get; }
+    public string? PublicKeyPath { get; }
+    public string? Passphrase { get; }
+
+    protected override int GitCredentialHandler(out IntPtr credential)
+    {
+        credential = IntPtr.Zero;
+
+        using var username = NativeUtf8String.From(Username);
+        using var publicKeyPath = NativeUtf8String.From(PublicKeyPath);
+        using var privateKeyPath = NativeUtf8String.From(PrivateKeyPath);
+        using var passphrase = NativeUtf8String.From(Passphrase);
+
+        return git_credential_ssh_key_new(
+            out credential,
+            username.Pointer,
+            publicKeyPath.Pointer,
+            privateKeyPath.Pointer,
+            passphrase.Pointer);
+    }
+
+    [DllImport(LibGit2Interop.NativeLibraryName, CallingConvention = CallingConvention.Cdecl)]
+    private static extern int git_credential_ssh_key_new(
+        out IntPtr credential,
+        IntPtr username,
+        IntPtr publicKey,
+        IntPtr privateKey,
+        IntPtr passphrase);
+
+    private sealed class NativeUtf8String : IDisposable
+    {
+        private NativeUtf8String(IntPtr pointer)
+        {
+            Pointer = pointer;
+        }
+
+        public IntPtr Pointer { get; private set; }
+
+        public static NativeUtf8String From(string? value)
+        {
+            return new NativeUtf8String(string.IsNullOrEmpty(value)
+                ? IntPtr.Zero
+                : Marshal.StringToCoTaskMemUTF8(value));
+        }
+
+        public void Dispose()
+        {
+            if (Pointer == IntPtr.Zero)
+            {
+                return;
+            }
+
+            Marshal.FreeCoTaskMem(Pointer);
+            Pointer = IntPtr.Zero;
+        }
+    }
+}

--- a/src/Unlimotion/Services/TaskStorageFactory.cs
+++ b/src/Unlimotion/Services/TaskStorageFactory.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using AutoMapper;
 using Microsoft.Extensions.Configuration;
 using Unlimotion.TaskTree;
@@ -12,6 +14,7 @@ public class TaskStorageFactory : ITaskStorageFactory
     private readonly INotificationManagerWrapper? _notificationManager;
     
     public static string DefaultStoragePath { get; set; } = string.Empty;
+    public static Func<string?, Task>? PrepareFileStoragePathAsync { get; set; }
     
     public ITaskStorage? CurrentStorage { get; private set; }
     public IDatabaseWatcher? CurrentWatcher { get; private set; }

--- a/src/Unlimotion/Views/SettingsControl.axaml
+++ b/src/Unlimotion/Views/SettingsControl.axaml
@@ -184,6 +184,7 @@
                                 <TextBox Text="{Binding TaskStoragePath}"
                                          ToolTip.Tip="{Binding TaskStoragePathTooltip}" />
                                 <Button Grid.Column="1"
+                                        AutomationProperties.AutomationId="BrowseTaskStoragePathButton"
                                         Content="{DynamicResource Browse}"
                                         Command="{Binding BrowseTaskStoragePathCommand}" />
                             </Grid>


### PR DESCRIPTION
## Summary

- package Android-native libgit2/libssh2/OpenSSL binaries for arm64 and x64
- enable SSH credentials and remote host key handling for libgit2-based Git sync
- fix Android task folder picking by using the native document tree flow and requesting all-files access for public filesystem paths

## Root Cause

Android Git sync was missing a complete native dependency/auth setup for SSH, so libgit2 could not perform repository operations reliably on-device. Separately, the task-folder picker returned an Android document tree selection that the app converted into a raw `/storage/...` path; modern Android denies direct file access to that path unless the app has all-files access.

## Impact

Users can run Git sync on Android with SSH repositories and choose task folders outside app-private storage after granting the required Android storage permission. The app also avoids the previous null-window folder dialog crash on Android.

## Validation

- `scripts/test-android-build-scripts.ps1`
- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore --treenode-filter "/*/*/BackupViaGitServiceTests/*"`
- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore --treenode-filter "/*/*/MainScreenLoadingUiTests/*"`
- `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore --treenode-filter "/*/*/SettingsControlResponsiveUiTests/*"`
- `dotnet build src\Unlimotion.Android\Unlimotion.Android.csproj --no-restore -f net10.0-android -p:Configuration=Debug -p:RuntimeIdentifier=android-arm64`
- installed and launched the debug APK on device `RFCX712DL9H`