### PR TITLE
Add keyboard-aware scrolling

### DIFF
--- a/scripts/build-libgit2-android.sh
+++ b/scripts/build-libgit2-android.sh
@@ -25,6 +25,7 @@ OPENSSL_CRYPTO_LIBRARY="${OPENSSL_CRYPTO_LIBRARY:-$OPENSSL_ROOT_DIR/lib/libcrypt
 LIBSSH2_ROOT_DIR="${LIBSSH2_ROOT_DIR:-$ROOT_DIR/artifacts/android-native/libssh2-$LIBSSH2_VERSION-$ANDROID_RID/prefix}"
 LIBSSH2_INCLUDE_DIR="${LIBSSH2_INCLUDE_DIR:-$LIBSSH2_ROOT_DIR/include}"
 LIBSSH2_LIBRARY="${LIBSSH2_LIBRARY:-$LIBSSH2_ROOT_DIR/lib/libssh2.so}"
+EMPTY_PKG_CONFIG_DIR="$BUILD_DIR/pkgconfig-empty"
 
 if [ ! -d "$SRC_DIR" ] || ! git -C "$SRC_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Missing submodule at $SRC_DIR. Run: git submodule update --init --recursive"
@@ -103,7 +104,11 @@ if [ "$LIBGIT2_USE_SSH" = "ON" ]; then
   )
 fi
 
-cmake "${CMAKE_ARGS[@]}"
+mkdir -p "$EMPTY_PKG_CONFIG_DIR"
+
+PKG_CONFIG_LIBDIR="$EMPTY_PKG_CONFIG_DIR" \
+PKG_CONFIG_PATH="" \
+  cmake "${CMAKE_ARGS[@]}"
 
 cmake --build "$BUILD_DIR" --target libgit2package
 

--- a/scripts/test-android-build-scripts.ps1
+++ b/scripts/test-android-build-scripts.ps1
@@ -93,6 +93,7 @@ Assert-Match $buildLibgit2Script '-DBUILD_CLI=OFF' 'build-libgit2-android.sh mus
 Assert-Match $buildLibgit2Script '-DUSE_SSH="\$LIBGIT2_USE_SSH"' 'build-libgit2-android.sh must enable SSH through libssh2 for Android builds.'
 Assert-Match $buildLibgit2Script '-DLIBSSH2_INCLUDE_DIR="\$LIBSSH2_INCLUDE_DIR"' 'build-libgit2-android.sh must pass libssh2 headers to libgit2 CMake.'
 Assert-Match $buildLibgit2Script '-DLIBSSH2_LIBRARY="\$LIBSSH2_LIBRARY"' 'build-libgit2-android.sh must pass libssh2 library to libgit2 CMake.'
+Assert-Match $buildLibgit2Script 'PKG_CONFIG_LIBDIR="\$EMPTY_PKG_CONFIG_DIR"' 'build-libgit2-android.sh must isolate pkg-config so libgit2 uses the explicit Android libssh2 paths.'
 Assert-Match $buildLibgit2Script '--target libgit2package' 'build-libgit2-android.sh must build the shared libgit2 package target.'
 Assert-Match $buildLibssh2Script 'CRYPTO_BACKEND=OpenSSL' 'build-libssh2-android.sh must build libssh2 against OpenSSL.'
 Assert-Match $buildLibssh2Script '-DBUILD_EXAMPLES=OFF' 'build-libssh2-android.sh must disable libssh2 examples for Android packaging.'

--- a/src/Unlimotion.Test/KeyboardAwareScrollViewerUiTests.cs
+++ b/src/Unlimotion.Test/KeyboardAwareScrollViewerUiTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Unlimotion.Behavior;
+
+namespace Unlimotion.Test;
+
+[ParallelLimiter<SharedUiStateParallelLimit>]
+public class KeyboardAwareScrollViewerUiTests
+{
+    [Test]
+    public async Task FocusedTextBoxCoveredByKeyboardInset_ScrollsIntoVisibleArea()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            const double keyboardInset = 190;
+            Window? window = null;
+
+            try
+            {
+                var textBox = new TextBox
+                {
+                    Height = 36,
+                    Text = "Focused field"
+                };
+
+                var content = new StackPanel
+                {
+                    Margin = new Thickness(12),
+                    Spacing = 8,
+                    Children =
+                    {
+                        new Border { Height = 300, Background = Brushes.Transparent },
+                        textBox,
+                        new Border { Height = 450, Background = Brushes.Transparent }
+                    }
+                };
+
+                var scrollViewer = new ScrollViewer
+                {
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Disabled,
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    Content = content
+                };
+                KeyboardAwareScrollViewer.SetIsEnabled(scrollViewer, true);
+                KeyboardAwareScrollViewer.SetKeyboardInsetBottomOverride(scrollViewer, keyboardInset);
+
+                window = new Window
+                {
+                    Width = 360,
+                    Height = 420,
+                    Content = scrollViewer
+                };
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var initialOffset = scrollViewer.Offset.Y;
+                var focused = textBox.Focus();
+                Dispatcher.UIThread.RunJobs();
+
+                var scrolledAboveKeyboard = WaitFor(() =>
+                    scrollViewer.Offset.Y > initialOffset + 1 &&
+                    IsControlAboveKeyboard(scrollViewer, textBox, keyboardInset));
+
+                await Assert.That(focused).IsTrue();
+                await Assert.That(scrolledAboveKeyboard).IsTrue();
+                await Assert.That(content.Margin.Bottom).IsEqualTo(12 + keyboardInset);
+            }
+            finally
+            {
+                window?.Close();
+            }
+        }, CancellationToken.None);
+    }
+
+    private static bool IsControlAboveKeyboard(ScrollViewer scrollViewer, Control control, double keyboardInset)
+    {
+        var bottom = control.TranslatePoint(new Point(0, control.Bounds.Height), scrollViewer);
+        if (!bottom.HasValue)
+        {
+            return false;
+        }
+
+        var focusedMargin = KeyboardAwareScrollViewer.GetFocusedControlMargin(scrollViewer);
+        return bottom.Value.Y <= scrollViewer.Bounds.Height - keyboardInset - focusedMargin + 1;
+    }
+
+    private static bool WaitFor(Func<bool> predicate, int timeoutMilliseconds = 2000)
+    {
+        var start = DateTime.UtcNow;
+        while ((DateTime.UtcNow - start).TotalMilliseconds < timeoutMilliseconds)
+        {
+            Dispatcher.UIThread.RunJobs();
+            if (predicate())
+            {
+                return true;
+            }
+
+            Thread.Sleep(10);
+        }
+
+        Dispatcher.UIThread.RunJobs();
+        return predicate();
+    }
+}

--- a/src/Unlimotion/Behavior/KeyboardAwareScrollViewer.cs
+++ b/src/Unlimotion/Behavior/KeyboardAwareScrollViewer.cs
@@ -1,0 +1,429 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Platform;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+
+namespace Unlimotion.Behavior
+{
+    public sealed class KeyboardAwareScrollViewer
+    {
+        private const double DefaultFocusedControlMargin = 16;
+
+        private KeyboardAwareScrollViewer()
+        {
+        }
+
+        public static readonly AttachedProperty<bool> IsEnabledProperty =
+            AvaloniaProperty.RegisterAttached<KeyboardAwareScrollViewer, ScrollViewer, bool>("IsEnabled");
+
+        public static readonly AttachedProperty<double> KeyboardInsetBottomOverrideProperty =
+            AvaloniaProperty.RegisterAttached<KeyboardAwareScrollViewer, ScrollViewer, double>(
+                "KeyboardInsetBottomOverride",
+                double.NaN);
+
+        public static readonly AttachedProperty<double> FocusedControlMarginProperty =
+            AvaloniaProperty.RegisterAttached<KeyboardAwareScrollViewer, ScrollViewer, double>(
+                "FocusedControlMargin",
+                DefaultFocusedControlMargin);
+
+        private static readonly AttachedProperty<KeyboardAwareScrollViewerState?> StateProperty =
+            AvaloniaProperty.RegisterAttached<KeyboardAwareScrollViewer, ScrollViewer, KeyboardAwareScrollViewerState?>(
+                "State");
+
+        static KeyboardAwareScrollViewer()
+        {
+            IsEnabledProperty.Changed.Subscribe(e =>
+            {
+                if (e.Sender is ScrollViewer scrollViewer)
+                {
+                    UpdateState(scrollViewer);
+                }
+            });
+
+            KeyboardInsetBottomOverrideProperty.Changed.Subscribe(e =>
+            {
+                if (e.Sender is ScrollViewer scrollViewer)
+                {
+                    GetState(scrollViewer)?.RefreshKeyboardInsetAndFocusedControl();
+                }
+            });
+
+            FocusedControlMarginProperty.Changed.Subscribe(e =>
+            {
+                if (e.Sender is ScrollViewer scrollViewer)
+                {
+                    GetState(scrollViewer)?.ScrollFocusedControlIntoView();
+                }
+            });
+        }
+
+        public static bool GetIsEnabled(ScrollViewer scrollViewer)
+        {
+            return scrollViewer.GetValue(IsEnabledProperty);
+        }
+
+        public static void SetIsEnabled(ScrollViewer scrollViewer, bool value)
+        {
+            scrollViewer.SetValue(IsEnabledProperty, value);
+        }
+
+        public static double GetKeyboardInsetBottomOverride(ScrollViewer scrollViewer)
+        {
+            return scrollViewer.GetValue(KeyboardInsetBottomOverrideProperty);
+        }
+
+        public static void SetKeyboardInsetBottomOverride(ScrollViewer scrollViewer, double value)
+        {
+            scrollViewer.SetValue(KeyboardInsetBottomOverrideProperty, value);
+        }
+
+        public static double GetFocusedControlMargin(ScrollViewer scrollViewer)
+        {
+            return scrollViewer.GetValue(FocusedControlMarginProperty);
+        }
+
+        public static void SetFocusedControlMargin(ScrollViewer scrollViewer, double value)
+        {
+            scrollViewer.SetValue(FocusedControlMarginProperty, value);
+        }
+
+        private static KeyboardAwareScrollViewerState? GetState(ScrollViewer scrollViewer)
+        {
+            return scrollViewer.GetValue(StateProperty);
+        }
+
+        private static void UpdateState(ScrollViewer scrollViewer)
+        {
+            var state = GetState(scrollViewer);
+            if (GetIsEnabled(scrollViewer))
+            {
+                if (state == null)
+                {
+                    state = new KeyboardAwareScrollViewerState(scrollViewer);
+                    scrollViewer.SetValue(StateProperty, state);
+                    state.Attach();
+                }
+            }
+            else if (state != null)
+            {
+                state.Detach();
+                scrollViewer.ClearValue(StateProperty);
+            }
+        }
+
+        private sealed class KeyboardAwareScrollViewerState
+        {
+            private readonly ScrollViewer scrollViewer;
+            private TopLevel? topLevel;
+            private IInputPane? inputPane;
+            private Control? contentControl;
+            private Thickness contentBaseMargin;
+            private double keyboardInsetBottom;
+            private bool isApplyingContentMargin;
+            private int scrollRequestVersion;
+
+            public KeyboardAwareScrollViewerState(ScrollViewer scrollViewer)
+            {
+                this.scrollViewer = scrollViewer;
+            }
+
+            public void Attach()
+            {
+                scrollViewer.AttachedToVisualTree += OnAttachedToVisualTree;
+                scrollViewer.DetachedFromVisualTree += OnDetachedFromVisualTree;
+                scrollViewer.PropertyChanged += OnScrollViewerPropertyChanged;
+                scrollViewer.AddHandler(InputElement.GotFocusEvent, OnGotFocus, RoutingStrategies.Bubble);
+
+                RefreshContentControl();
+                RefreshInputPaneSubscription();
+                RefreshKeyboardInsetAndFocusedControl();
+            }
+
+            public void Detach()
+            {
+                scrollViewer.AttachedToVisualTree -= OnAttachedToVisualTree;
+                scrollViewer.DetachedFromVisualTree -= OnDetachedFromVisualTree;
+                scrollViewer.PropertyChanged -= OnScrollViewerPropertyChanged;
+                scrollViewer.RemoveHandler(InputElement.GotFocusEvent, OnGotFocus);
+
+                if (inputPane != null)
+                {
+                    inputPane.StateChanged -= OnInputPaneStateChanged;
+                    inputPane = null;
+                }
+
+                topLevel = null;
+                RestoreContentMargin();
+                contentControl = null;
+            }
+
+            public void RefreshKeyboardInsetAndFocusedControl()
+            {
+                RefreshInputPaneSubscription();
+                keyboardInsetBottom = ResolveKeyboardInsetBottom();
+                ApplyContentMargin();
+                ScrollFocusedControlIntoView();
+            }
+
+            public void ScrollFocusedControlIntoView()
+            {
+                var focusedControl = GetFocusedKeyboardInputControl();
+                if (focusedControl != null)
+                {
+                    QueueScrollIntoView(focusedControl);
+                }
+            }
+
+            private void OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+            {
+                RefreshInputPaneSubscription();
+                RefreshKeyboardInsetAndFocusedControl();
+            }
+
+            private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+            {
+                if (inputPane != null)
+                {
+                    inputPane.StateChanged -= OnInputPaneStateChanged;
+                    inputPane = null;
+                }
+
+                topLevel = null;
+            }
+
+            private void OnScrollViewerPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+            {
+                if (e.Property == ContentControl.ContentProperty)
+                {
+                    RefreshContentControl();
+                    ApplyContentMargin();
+                    ScrollFocusedControlIntoView();
+                }
+            }
+
+            private void OnInputPaneStateChanged(object? sender, InputPaneStateEventArgs e)
+            {
+                RefreshKeyboardInsetAndFocusedControl();
+            }
+
+            private void OnGotFocus(object? sender, RoutedEventArgs e)
+            {
+                if (e.Source is Control control && IsKeyboardInputControlOrDescendant(control))
+                {
+                    QueueScrollIntoView(control);
+                }
+            }
+
+            private void RefreshInputPaneSubscription()
+            {
+                var currentTopLevel = TopLevel.GetTopLevel(scrollViewer);
+                var currentInputPane = currentTopLevel?.InputPane;
+                if (ReferenceEquals(currentInputPane, inputPane))
+                {
+                    topLevel = currentTopLevel;
+                    return;
+                }
+
+                if (inputPane != null)
+                {
+                    inputPane.StateChanged -= OnInputPaneStateChanged;
+                }
+
+                topLevel = currentTopLevel;
+                inputPane = currentInputPane;
+
+                if (inputPane != null)
+                {
+                    inputPane.StateChanged += OnInputPaneStateChanged;
+                }
+            }
+
+            private void RefreshContentControl()
+            {
+                var currentContentControl = scrollViewer.Content as Control;
+                if (ReferenceEquals(currentContentControl, contentControl))
+                {
+                    return;
+                }
+
+                RestoreContentMargin();
+                contentControl = currentContentControl;
+                contentBaseMargin = contentControl?.Margin ?? default;
+            }
+
+            private void ApplyContentMargin()
+            {
+                RefreshContentControl();
+                if (contentControl == null)
+                {
+                    return;
+                }
+
+                isApplyingContentMargin = true;
+                try
+                {
+                    contentControl.Margin = new Thickness(
+                        contentBaseMargin.Left,
+                        contentBaseMargin.Top,
+                        contentBaseMargin.Right,
+                        contentBaseMargin.Bottom + keyboardInsetBottom);
+                }
+                finally
+                {
+                    isApplyingContentMargin = false;
+                }
+            }
+
+            private void RestoreContentMargin()
+            {
+                if (contentControl == null || isApplyingContentMargin)
+                {
+                    return;
+                }
+
+                contentControl.Margin = contentBaseMargin;
+            }
+
+            private double ResolveKeyboardInsetBottom()
+            {
+                var overrideInset = GetKeyboardInsetBottomOverride(scrollViewer);
+                if (!double.IsNaN(overrideInset))
+                {
+                    return Math.Max(0, overrideInset);
+                }
+
+                if (topLevel == null ||
+                    inputPane == null ||
+                    inputPane.State != InputPaneState.Open ||
+                    inputPane.OccludedRect.Height <= 0)
+                {
+                    return 0;
+                }
+
+                var scrollViewerTop = scrollViewer.TranslatePoint(default, topLevel)?.Y ?? 0;
+                var scrollViewerBottom = scrollViewer.TranslatePoint(
+                    new Point(0, scrollViewer.Bounds.Height),
+                    topLevel)?.Y ?? scrollViewer.Bounds.Height;
+                var overlapTop = Math.Max(scrollViewerTop, inputPane.OccludedRect.Top);
+                var overlapBottom = Math.Min(scrollViewerBottom, inputPane.OccludedRect.Bottom);
+
+                return Math.Max(0, overlapBottom - overlapTop);
+            }
+
+            private Control? GetFocusedKeyboardInputControl()
+            {
+                var focused = topLevel?.FocusManager?.GetFocusedElement() as Control;
+                if (focused == null ||
+                    !IsInsideScrollViewer(focused) ||
+                    !IsKeyboardInputControlOrDescendant(focused))
+                {
+                    return null;
+                }
+
+                return focused;
+            }
+
+            private bool IsInsideScrollViewer(Control control)
+            {
+                for (Visual? current = control; current != null; current = current.GetVisualParent())
+                {
+                    if (ReferenceEquals(current, scrollViewer))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            private bool IsKeyboardInputControlOrDescendant(Control control)
+            {
+                if (IsKeyboardInputControl(control))
+                {
+                    return true;
+                }
+
+                for (Visual? current = control.GetVisualParent(); current != null; current = current.GetVisualParent())
+                {
+                    if (ReferenceEquals(current, scrollViewer))
+                    {
+                        return false;
+                    }
+
+                    if (current is Control ancestor && IsKeyboardInputControl(ancestor))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            private static bool IsKeyboardInputControl(Control control)
+            {
+                return control is TextBox or NumericUpDown or AutoCompleteBox;
+            }
+
+            private void QueueScrollIntoView(Control control)
+            {
+                var requestVersion = ++scrollRequestVersion;
+                Dispatcher.UIThread.Post(
+                    () =>
+                    {
+                        if (requestVersion == scrollRequestVersion)
+                        {
+                            ScrollIntoVisibleArea(control);
+                        }
+                    },
+                    DispatcherPriority.Loaded);
+            }
+
+            private void ScrollIntoVisibleArea(Control control)
+            {
+                if (!control.IsAttachedToVisualTree() || !IsInsideScrollViewer(control))
+                {
+                    return;
+                }
+
+                RefreshInputPaneSubscription();
+                keyboardInsetBottom = ResolveKeyboardInsetBottom();
+                ApplyContentMargin();
+                scrollViewer.UpdateLayout();
+
+                var topLeft = control.TranslatePoint(default, scrollViewer);
+                if (!topLeft.HasValue)
+                {
+                    return;
+                }
+
+                var margin = Math.Max(0, GetFocusedControlMargin(scrollViewer));
+                var visibleTop = margin;
+                var visibleBottom = Math.Max(visibleTop, scrollViewer.Bounds.Height - keyboardInsetBottom - margin);
+                var controlTop = topLeft.Value.Y;
+                var controlBottom = controlTop + control.Bounds.Height;
+                var desiredOffsetY = scrollViewer.Offset.Y;
+
+                if (controlBottom > visibleBottom)
+                {
+                    desiredOffsetY += controlBottom - visibleBottom;
+                }
+                else if (controlTop < visibleTop)
+                {
+                    desiredOffsetY -= visibleTop - controlTop;
+                }
+
+                var maxOffsetY = Math.Max(0, scrollViewer.Extent.Height - scrollViewer.Viewport.Height);
+                desiredOffsetY = Math.Clamp(desiredOffsetY, 0, maxOffsetY);
+
+                if (Math.Abs(desiredOffsetY - scrollViewer.Offset.Y) > 0.5)
+                {
+                    scrollViewer.Offset = new Vector(scrollViewer.Offset.X, desiredOffsetY);
+                }
+            }
+        }
+    }
+}

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -642,7 +642,13 @@
                 <Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch" ColumnDefinitions="*,Auto">
                     <ToggleButton Width="20" Padding="0" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Content="↔️" VerticalAlignment="Stretch" Grid.Column="1" IsChecked="{Binding !DetailsAreOpen}"
                                   AutomationProperties.AutomationId="DetailsPaneToggleButton"></ToggleButton>
-                    <ScrollViewer IsVisible="{Binding DetailsAreOpen}" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto" VerticalContentAlignment="Top">
+                    <ScrollViewer x:Name="CurrentTaskDetailsScrollViewer"
+                                  AutomationProperties.AutomationId="CurrentTaskDetailsScrollViewer"
+                                  IsVisible="{Binding DetailsAreOpen}"
+                                  HorizontalScrollBarVisibility="Disabled"
+                                  VerticalScrollBarVisibility="Auto"
+                                  VerticalContentAlignment="Top"
+                                  behavior:KeyboardAwareScrollViewer.IsEnabled="True">
                         <StackPanel Margin="10">
                             <WrapPanel>
                                 <Button Command="{Binding Create}" Content="{DynamicResource NewTask}" />

--- a/src/Unlimotion/Views/SettingsControl.axaml
+++ b/src/Unlimotion/Views/SettingsControl.axaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:viewModel="clr-namespace:Unlimotion.ViewModel;assembly=Unlimotion.ViewModel"
              xmlns:localization="clr-namespace:Unlimotion.ViewModel.Localization;assembly=Unlimotion.ViewModel"
+             xmlns:behavior="clr-namespace:Unlimotion.Behavior"
              mc:Ignorable="d"
              d:DesignWidth="900"
              d:DesignHeight="700"
@@ -64,7 +65,8 @@
         </Style>
     </UserControl.Styles>
 
-    <ScrollViewer HorizontalScrollBarVisibility="Disabled">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                  behavior:KeyboardAwareScrollViewer.IsEnabled="True">
         <StackPanel Margin="16">
             <TextBlock Classes="SectionTitle" Text="{DynamicResource SettingsTitle}" />
             <TextBlock Classes="SectionHint"


### PR DESCRIPTION
## What changed

- Added a reusable `KeyboardAwareScrollViewer` attached behavior for Avalonia scroll containers.
- The behavior listens to `TopLevel.InputPane`, adds bottom scrollable space for the software keyboard, and scrolls focused text input controls into the visible area.
- Enabled the behavior for the task details panel and settings screen.
- Added a headless UI test that simulates a keyboard inset and verifies the focused input is scrolled above it.

## Why

On phones, the software keyboard could cover inputs inside long forms. Avalonia does not automatically resize/reflow every layout for the input pane, so the app needs to account for the occluded area and bring focused controls into view.

## Validation

- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -- --treenode-filter "/Unlimotion.Test/Unlimotion.Test/KeyboardAwareScrollViewerUiTests/*" --no-progress --no-ansi --output Detailed`
- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-build -- --treenode-filter "/Unlimotion.Test/Unlimotion.Test/SettingsControlResponsiveUiTests/*" --no-progress --no-ansi --output Detailed`
- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-build -- --treenode-filter "/Unlimotion.Test/Unlimotion.Test/MainControlRelationPickerUiTests/*" --no-progress --no-ansi --output Detailed`