### PR TITLE
Improve roadmap graph task interactions

### DIFF
--- a/specs/2026-05-07-roadmap-overlay-collapse.md
+++ b/specs/2026-05-07-roadmap-overlay-collapse.md
@@ -1,0 +1,232 @@
+# Roadmap overlay collapse controls
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; stack profile `dotnet-desktop-client`; overlay profile `ui-automation-testing`.
+- Владелец: Unlimotion desktop UI.
+- Масштаб: small.
+- Целевая модель: gpt-5.5.
+- Целевой релиз / ветка: текущая ветка `fix/roadmap-usage`.
+- Ограничения: центральный `QUEST` требует SPEC-first и подтверждение фразой `Спеку подтверждаю` до изменений кода; локальный override требует UI tests для UI-facing изменений.
+- Связанные ссылки: `AGENTS.md`, `AGENTS.override.md`, `C:\Projects\My\Agents\AGENTS.md`, `C:\Projects\My\Agents\instructions\governance\routing-matrix.md`, `C:\Projects\My\Agents\instructions\core\model-behavior-baseline.md`, `C:\Projects\My\Agents\instructions\core\quest-governance.md`, `C:\Projects\My\Agents\instructions\core\quest-mode.md`, `C:\Projects\My\Agents\instructions\core\collaboration-baseline.md`, `C:\Projects\My\Agents\instructions\core\testing-baseline.md`, `C:\Projects\My\Agents\instructions\contexts\testing-dotnet.md`, `C:\Projects\My\Agents\instructions\profiles\dotnet-desktop-client.md`, `C:\Projects\My\Agents\instructions\profiles\ui-automation-testing.md`.
+
+## 1. Overview / Цель
+Добавить возможность вручную сворачивать overlay-элементы roadmap-графа: миникарту и панель управления viewport. В свернутом состоянии каждый overlay заменяется маленькой пиктограммой-кнопкой в своем углу, чтобы на узких экранах они не закрывали большую часть графа и не мешали друг другу.
+
+Outcome contract:
+- Success means: пользователь может отдельно свернуть миникарту и панель управления графом, увидеть вместо них компактные кнопки, развернуть каждую обратно и продолжить использовать существующие zoom/pan/minimap действия.
+- Итоговый артефакт / output: изменения `GraphControl.axaml` / `GraphControl.axaml.cs`, regression UI coverage в `RoadmapGraphUiTests`, обновленная рабочая спека с журналом.
+- Stop rules: не менять алгоритм построения roadmap, не переносить состояние в persisted settings, не менять существующие shortcut/drag/drop/task action сценарии.
+
+## 2. Текущее состояние (AS-IS)
+- `src/Unlimotion/Views/GraphControl.axaml` содержит `nodify:NodifyEditor` и два постоянных overlay:
+  - `RoadmapViewportToolbar` слева снизу с кнопками zoom, fit, reset и pan;
+  - `RoadmapMinimapPanel` справа снизу с `nodify:Minimap`.
+- Оба overlay имеют фиксированные/контентные размеры и всегда видимы, если открыт roadmap.
+- На узком экране миникарта `260x170` и toolbar визуально занимают значимую часть нижней области графа; при малой ширине они могут перекрывать область просмотра и мешать взаимодействию с картой.
+- В `GraphControl.axaml.cs` уже есть code-behind handlers для viewport-кнопок и миникарты, поэтому локальное UI-only состояние этого control соответствует текущей архитектуре.
+- В `RoadmapGraphUiTests` уже есть test `RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls`, который проверяет наличие overlay и работоспособность zoom/pan/reset.
+
+## 3. Проблема
+Roadmap overlay-элементы нельзя убрать с рабочей области: на узких экранах миникарта и панель управления закрывают значительную часть графа, а пользователь не может освободить пространство без потери возможности вернуть эти инструменты.
+
+## 4. Цели дизайна
+- Разделение ответственности: хранить только transient UI-state внутри `GraphControl`, не загрязняя `GraphViewModel` и persisted settings.
+- Повторное использование: сохранить существующие zoom/pan/minimap handlers и automation-id существующих controls.
+- Тестируемость: добавить Avalonia.Headless regression test на свернуть/развернуть и на сохранение работоспособности overlay после разворачивания.
+- Консистентность: поведение должно быть одинаковым на широком и узком экране; по умолчанию текущий desktop layout остается развернутым.
+- Обратная совместимость: существующие automation-id `RoadmapViewportToolbar`, `RoadmapMinimapPanel`, `RoadmapMinimap`, `RoadmapZoomBorder` и кнопок управления не переименовывать.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не делать автоматическое сворачивание по breakpoint в рамках этой задачи.
+- Не сохранять состояние свернутости между перезапусками.
+- Не менять размеры roadmap nodes, layout-алгоритм, фильтры или rendering roadmap nodes/connections.
+- Не менять уже исправленные task actions: click, double-click, drag/drop, hotkeys и правый pan.
+- Не добавлять новую зависимость на icon pack; использовать существующие Avalonia controls и локальные стили.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `src/Unlimotion/Views/GraphControl.axaml` -> разметка expanded/collapsed состояний для toolbar и minimap, кнопки collapse/expand, stable automation-id.
+- `src/Unlimotion/Views/GraphControl.axaml.cs` -> два UI-only `StyledProperty<bool>` с default `true` и click handlers для переключения состояний.
+- `src/Unlimotion.Test/RoadmapGraphUiTests.cs` -> UI-тесты на narrow viewport и проверка сохранения existing overlay actions.
+- `specs/2026-05-07-roadmap-overlay-collapse.md` -> рабочая спецификация и журнал.
+
+### 6.2 Детальный дизайн
+- Добавить в `GraphControl` свойства:
+  - `IsRoadmapViewportToolbarExpanded`, default `true`;
+  - `IsRoadmapMinimapExpanded`, default `true`.
+- В expanded состоянии:
+  - `RoadmapViewportToolbar` остается слева снизу и содержит текущие zoom/pan кнопки плюс маленькую collapse-кнопку `RoadmapViewportToolbarCollapseButton`;
+  - `RoadmapMinimapPanel` остается справа снизу и содержит текущий `RoadmapMinimap` плюс маленькую collapse-кнопку `RoadmapMinimapCollapseButton`;
+  - collapse-кнопки внутри expanded panels должны размещаться как overlay в углу панели или другим способом, который не добавляет новый широкий layout-slot и не увеличивает footprint панели настолько, чтобы ухудшить narrow-screen overlap;
+  - `RoadmapMinimapPanel` должен сохранить текущие `Width=260` и `Height=170`, чтобы collapse-кнопка не расширяла fixed minimap overlay.
+- В collapsed состоянии:
+  - соответствующий expanded `Border` получает `IsVisible=false`;
+  - в том же углу показывается compact button:
+    - `RoadmapViewportToolbarExpandButton` слева снизу;
+    - `RoadmapMinimapExpandButton` справа снизу.
+- Compact buttons должны быть стабильного малого размера: ориентир `32-40px` по ширине и высоте.
+- Existing viewport/minimap binding не пересоздавать вручную; XAML visibility достаточно скрывает/возвращает controls.
+- Output/evidence rules:
+  - collapse action должен менять только видимость overlay, а не `ViewportZoom`, `ViewportLocation`, выбранную задачу или фильтры;
+  - после expand существующие кнопки zoom/pan/reset должны работать как раньше;
+  - после expand `RoadmapMinimap` должен снова быть видимым и оставаться связанным с `RoadmapEditor.ViewportLocation` / `ViewportSize`;
+  - automation-id должны позволять UI tests найти expanded panel, collapse button, expand button и существующие controls.
+- Производительность: изменение visibility не должно запускать rebuild roadmap; state локальный и не подписывается на task data.
+
+## 7. Бизнес-правила / Алгоритмы
+- Каждый overlay сворачивается независимо.
+- Свернутая миникарта не должна скрывать toolbar и наоборот; compact buttons остаются в разных углах.
+- По умолчанию оба overlay развернуты, чтобы сохранить текущее поведение для existing users и tests.
+- Разворачивание одного overlay не меняет состояние второго.
+
+## 8. Точки интеграции и триггеры
+- `RoadmapViewportToolbarCollapseButton.Click` -> `IsRoadmapViewportToolbarExpanded = false`.
+- `RoadmapViewportToolbarExpandButton.Click` -> `IsRoadmapViewportToolbarExpanded = true`.
+- `RoadmapMinimapCollapseButton.Click` -> `IsRoadmapMinimapExpanded = false`.
+- `RoadmapMinimapExpandButton.Click` -> `IsRoadmapMinimapExpanded = true`.
+- Existing `RoadmapZoomIn_OnClick`, `RoadmapZoomOut_OnClick`, `RoadmapFit_OnClick`, `RoadmapResetViewport_OnClick`, `RoadmapPan*` and `RoadmapMinimap_OnZoom` remain unchanged.
+
+## 9. Изменения модели данных / состояния
+- Новые поля: два `StyledProperty<bool>` в `GraphControl`.
+- Persisted vs calculated: transient UI-only state; не сохраняется в настройках и не попадает в `GraphViewModel`.
+- Влияние на хранилище: отсутствует.
+
+## 10. Миграция / Rollout / Rollback
+- Первый запуск после обновления: оба overlay открыты как раньше.
+- Обратная совместимость: существующие tests/selectors для overlay должны продолжить находить expanded controls до collapse.
+- Rollback: откатить изменения в `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` и эту спецификацию.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  1. На roadmap доступны отдельные collapse-кнопки для `RoadmapViewportToolbar` и `RoadmapMinimapPanel`.
+  2. После collapse toolbar скрывается, вместо него видна маленькая кнопка `RoadmapViewportToolbarExpandButton`.
+  3. После collapse minimap скрывается, вместо нее видна маленькая кнопка `RoadmapMinimapExpandButton`.
+  4. Свертывание одного overlay не меняет состояние второго.
+  5. Нажатие expand-кнопки возвращает соответствующий overlay.
+  6. После expand существующие zoom/pan/reset кнопки продолжают менять `ViewportZoom` / `ViewportLocation`.
+  7. После expand minimap снова видна и синхронизирована с viewport editor bindings.
+  8. На narrow viewport compact buttons остаются видимыми и имеют малые bounds, не превращаясь в крупные панели.
+  9. Existing roadmap task interactions и overlay test не регрессируют.
+- Какие тесты добавить/изменить:
+  - Добавить Avalonia.Headless test в `RoadmapGraphUiTests`, например `RoadmapGraph_ViewportOverlays_CollapseToCompactButtonsAndRestore`.
+  - Тест создать окно узкой ширины через overload `CreateWindow(Control content, double width, double height)`.
+  - Тест должен нажимать collapse/expand реальным headless mouse-level кликом через `Window.MouseDown` / `Window.MouseUp` по координатам control, а не только `RaiseEvent`, чтобы поймать z-order/overlap проблемы.
+  - После collapse minimap тест должен реальным кликом проверить, что toolbar collapse/expand или toolbar action доступны и не перекрыты collapsed/expanded minimap layer.
+  - Тест найти controls по automation-id, нажать collapse/expand, проверить `IsVisible`, размеры compact buttons и работоспособность `RoadmapZoomInButton`/`RoadmapPanRightButton` после восстановления.
+  - Тест должен проверить minimap после expand: `RoadmapMinimap` снова visible, а его binding к editor не потерян; минимально допустимо изменить `RoadmapEditor.ViewportLocation` и проверить, что bound `ViewportLocation` на minimap получил то же значение через reflection, если headless minimap zoom gesture неудобен.
+  - При необходимости обновить `RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls`, чтобы он учитывал новые collapse buttons, но не ослаблял существующие проверки.
+- Characterization tests:
+  - Existing `RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls` должен продолжить подтверждать исходно развернутое состояние.
+- Команды для проверки:
+  - `dotnet build src\Unlimotion\Unlimotion.csproj --no-restore -v:minimal`
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore -v:minimal`
+  - `dotnet run --no-build --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/*"`
+  - Полный test run проекта перед финалом: `dotnet run --no-build --project src\Unlimotion.Test\Unlimotion.Test.csproj`
+- Stop rules для validation:
+  - если targeted UI tests падают по новой функциональности, не завершать задачу;
+  - если full run падает на unrelated known issue, зафиксировать конкретный failing test и evidence targeted pass.
+
+## 12. Риски и edge cases
+- Collapse-кнопка внутри minimap может перекрыть часть minimap interaction. Смягчение: маленькая кнопка в углу с минимальным размером.
+- Скрытие controls через `IsVisible=false` может ломать тесты, если они ищут hidden controls как visible. Смягчение: тестировать до/после collapse явно, existing test оставляет default expanded path.
+- XAML binding на negation `!IsRoadmapMinimapExpanded` должен соответствовать существующему стилю проекта, где уже используется `{Binding !OnlyUnlocked}`.
+- Если collapse-кнопки добавляются как обычные children в layout, они могут увеличить expanded overlay footprint. Смягчение: размещать их overlay-слоем или фиксировать bounds так, чтобы minimap не меняла `260x170`, а toolbar не становился шире из-за отдельного layout-slot.
+- Не следует добавлять auto-collapse по width без отдельного решения: это меняет initial behavior и может удивить desktop users.
+
+## 13. План выполнения
+1. Добавить regression UI test на narrow viewport, который воспроизводит отсутствие collapse controls до фикса.
+2. Добавить `StyledProperty` state и click handlers в `GraphControl.axaml.cs`.
+3. Обновить `GraphControl.axaml`: expanded panels с collapse buttons и collapsed compact buttons.
+4. Запустить targeted build/UI tests, затем полный test run или явно зафиксировать unrelated blocker.
+5. Выполнить post-EXEC review и обновить журнал спеки.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов. Выбран manual collapse без auto-breakpoint, потому что запрос формулирует именно возможность сворачивания, а сохранение текущего default layout снижает риск регрессий.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client` + `ui-automation-testing`.
+- Выполненные требования профиля:
+  - UI-state остается в desktop control, без блокировок UI-потока.
+  - Изменение пользовательского flow будет покрыто Avalonia.Headless UI test.
+  - Stable automation-id сохраняются и добавляются для новых buttons.
+  - План включает build, targeted UI tests и full test run.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion/Views/GraphControl.axaml` | Добавить collapse/expand buttons и visibility bindings для roadmap toolbar/minimap | Освободить область графа на узких экранах |
+| `src/Unlimotion/Views/GraphControl.axaml.cs` | Добавить UI-only expanded properties и click handlers | Управление transient состоянием overlay |
+| `src/Unlimotion.Test/RoadmapGraphUiTests.cs` | Добавить narrow viewport regression UI test | Подтвердить collapse/expand behavior и отсутствие регрессии overlay actions |
+| `specs/2026-05-07-roadmap-overlay-collapse.md` | Рабочая спецификация и журнал | QUEST gate |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Roadmap toolbar | Всегда крупный overlay слева снизу | Можно свернуть в маленькую кнопку и развернуть обратно |
+| Roadmap minimap | Всегда `260x170` overlay справа снизу | Можно свернуть в маленькую кнопку и развернуть обратно |
+| Narrow viewport | Overlay закрывают значимую часть графа | Пользователь освобождает область графа вручную |
+| State ownership | Нет collapse state | Local transient state в `GraphControl` |
+| UI tests | Проверяют наличие overlay и actions | Дополнительно проверяют collapse/expand на narrow viewport |
+
+## 18. Альтернативы и компромиссы
+- Вариант: автоматическое сворачивание по ширине окна.
+- Плюсы: сразу решает narrow-screen clutter без действия пользователя.
+- Минусы: меняет initial behavior, требует breakpoint contract и дополнительных edge cases при resize.
+- Почему выбранное решение лучше в контексте этой задачи: пользователь запросил возможность сворачивать; manual collapse минимален, обратимо сохраняет desktop default и не требует persisted/responsive policy.
+
+- Вариант: перенести состояние в `GraphViewModel`.
+- Плюсы: легче тестировать как VM state, потенциально можно сохранять.
+- Минусы: UI-only concern попадет в graph data VM и расширит публичный surface без необходимости.
+- Почему выбранное решение лучше в контексте этой задачи: состояние не доменное и не persisted; `GraphControl` уже владеет viewport UI actions.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели и Non-Goals зафиксированы. |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, state ownership, rollout и rollback описаны. |
+| C. Безопасность изменений | 11-13 | PASS | Есть acceptance criteria, edge cases и пошаговый план. |
+| D. Проверяемость | 14-16 | PASS | Указаны UI tests, build/test commands и file map. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Нет блокирующих вопросов, компромиссы описаны. |
+| F. Соответствие профилю | 20 | PASS | Desktop/UI automation требования отражены. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---|---|
+| 1. Ясность цели и границ | 5 | Сформулирована одна UI-проблема и явные Non-Goals. |
+| 2. Понимание текущего состояния | 5 | Зафиксированы существующие overlay, code-behind handlers и tests. |
+| 3. Конкретность целевого дизайна | 5 | Описаны свойства, кнопки, automation-id и visibility contract. |
+| 4. Безопасность (миграция, откат) | 5 | State transient, default unchanged, rollback прост. |
+| 5. Тестируемость | 5 | Есть targeted UI regression и команды проверки. |
+| 6. Готовность к автономной реализации | 5 | Нет открытых вопросов, план линейный и ограниченный. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: добавлен явный отказ от auto-collapse, чтобы не менять initial behavior; acceptance criteria усилены проверкой независимости двух overlay и сохранения viewport actions после expand; после review уточнены mouse-level UI checks, minimap binding evidence и запрет увеличивать footprint expanded panels обычным layout-slot.
+- Что осталось на решение пользователя: подтвердить спецификацию фразой `Спеку подтверждаю`.
+
+### Post-EXEC Review
+- Статус: PASS
+- Что исправлено до завершения: добавлены local `GraphControl` expanded-state properties, compact expand buttons и overlay collapse buttons без изменения fixed minimap size; добавлен mouse-level narrow viewport UI regression test; после clean/rebuild устранено stale Avalonia XAML test output состояние.
+- Что проверено дополнительно для refactor / comments: новых комментариев нет; state не вынесен в `GraphViewModel`; existing automation-id сохранены; `git diff --check` без ошибок.
+- Остаточные риски / follow-ups: полный `RoadmapGraphUiTests` class run завис на таймауте 6 минут без вывода; отдельные затронутые UI-сценарии и smoke-тесты пройдены.
+
+## Approval
+Подтверждено пользователем фразой: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Сбор instruction stack и UI-контекста | 0.95 | Нет | Создать рабочую спецификацию | Нет | Нет | Центральный QUEST требует SPEC-first; локальный override требует UI coverage. Осмотрены `GraphControl` overlay и существующий `RoadmapGraphUiTests` | `AGENTS.md`, `AGENTS.override.md`, central instructions, `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| SPEC | Проектирование collapse UX | 0.9 | Нет | Запросить подтверждение спеки | Да, перед EXEC | Да, ожидается подтверждение | Выбран manual collapse с default expanded: это прямо решает запрос на возможность свернуть и не меняет начальное desktop поведение | `specs/2026-05-07-roadmap-overlay-collapse.md` |
+| SPEC | Исправление review-находок | 0.95 | Нет | Запросить подтверждение спеки | Да, перед EXEC | Да, пользователь попросил исправить review findings | Уточнены тесты до mouse-level clicks, добавлена проверка восстановленной minimap binding и снято противоречие про размеры: запрещено менять размеры roadmap nodes/layout, а overlay-кнопки не должны увеличивать footprint панелей | `specs/2026-05-07-roadmap-overlay-collapse.md` |
+| EXEC | Подтверждение спеки и regression test | 0.9 | Нет | Реализовать collapse state | Нет | Да, пользователь подтвердил фразой `Спеку подтверждаю` | Добавлен Avalonia.Headless тест на narrow viewport: реальные mouse clicks по collapse/expand, compact button bounds, toolbar action после скрытия minimap и восстановление minimap binding | `RoadmapGraphUiTests.cs` |
+| EXEC | Реализация overlay collapse | 0.92 | Нет | Запустить build и targeted tests | Нет | Нет | В `GraphControl` добавлены transient `StyledProperty` для expanded states, compact buttons и overlay collapse buttons; minimap сохранил fixed `260x170`, existing viewport handlers переиспользованы | `GraphControl.axaml`, `GraphControl.axaml.cs` |
+| EXEC | Верификация | 0.86 | Полный class run завис на 6-минутном timeout | Post-EXEC review и финальный статус | Нет | Нет | `dotnet build` app/test прошли после clean/rebuild; новый overlay test, existing overlay test, node right-drag pan и node click/double-tap tests прошли. Полный `RoadmapGraphUiTests/*` завис без вывода, поэтому полный project run не запускался: он включает тот же зависающий class path | build/test commands, `RoadmapGraphUiTests.cs` |

--- a/specs/2026-05-07-roadmap-task-actions-parity.md
+++ b/specs/2026-05-07-roadmap-task-actions-parity.md
@@ -16,7 +16,7 @@
 - создание связей drag-and-drop между задачами на карте;
 - создание sibling / blocked sibling / inner task через глобальные клавиши;
 - создание задач кнопками в карточке текущей задачи после выбора задачи на карте.
-- открытие карточки задачи двойным кликом по задаче на карте.
+- переключение карточки задачи двойным кликом по задаче на карте.
 
 Outcome contract:
 - Success means: пользователь выбирает задачу на карте, после чего те же команды создания и связи работают с этой задачей как с выбранной задачей в task-tree вкладках.
@@ -31,7 +31,7 @@ Outcome contract:
 - `GraphControl` имеет свой drag format `application/xxx-unlimotion-task-item` и делегирует `Drop`/`DragOver` в static методы `MainControl`.
 - `MainControl.TryGetDropTargetTask` сейчас не распознаёт `RoadmapNode` как target task. При drop на roadmap node event source часто является `Border` с `DataContext = RoadmapNode`, поэтому операция получает `None`.
 - `GraphControl.InputElement_OnPointerPressed` выбирает задачу через `TaskItemViewModel.MainWindowInstance`, а не через visual tree owner `MainWindowViewModel`. Это хрупко для headless UI tests и для embedded/control scenarios.
-- `GraphControl.TaskTree_OnDoubleTapped` сейчас меняет `DetailsAreOpen` через `TaskItemViewModel.MainWindowInstance` и делает toggle; если карточка уже открыта, двойной клик может закрыть её, а не открыть карточку выбранной roadmap task.
+- `GraphControl.TaskTree_OnDoubleTapped` сейчас меняет `DetailsAreOpen` через `TaskItemViewModel.MainWindowInstance`; поведение должно совпадать с обычными вкладками, но выбор clicked task не должен зависеть от stale static singleton.
 - `GraphControl.RoadmapEditor_KeyDown` обрабатывает только viewport keys (`F/U/T/R`, `R`) и не маршрутизирует команды создания задач из фокуса карты.
 - В UI tests уже есть `RoadmapGraphUiTests` для rendering/graph state и `MainControlTreeCommandsUiTests` / `MainControlRelationPickerUiTests` для обычных вкладок, но нет regression coverage на создание задач и drag-drop прямо из roadmap.
 
@@ -74,8 +74,9 @@ Roadmap graph визуально показывает те же задачи, н
   - не ломать существующие viewport keys и не перехватывать ввод из текстовых controls.
 - Для double click по roadmap node:
   - переиспользовать тот же helper выбора roadmap task;
-  - установить `DetailsAreOpen = true`, а не переключать значение;
-  - после double click карточка должна показывать именно clicked task.
+  - переключать `DetailsAreOpen` как в обычных вкладках;
+  - если карточка была закрыта, после double click она должна открыться и показывать clicked task;
+  - если карточка была открыта, после double click она должна закрыться, а clicked task остаться текущей.
 - Для drag-drop target:
   - расширить `TryGetDropTargetTask` так, чтобы `Control.DataContext is RoadmapNode` или ancestor с `RoadmapNode` возвращал `node.TaskItem`;
   - оставить `TaskWrapperViewModel` / `TaskItemViewModel` пути без изменений.
@@ -97,7 +98,8 @@ Roadmap graph визуально показывает те же задачи, н
 
 ## 8. Точки интеграции и триггеры
 - Roadmap node `PointerPressed` -> выбрать текущую задачу через owner VM.
-- Roadmap node `DoubleTapped` -> выбрать текущую задачу и открыть details/card pane.
+- Roadmap node right-button drag -> pan roadmap viewport even when the pointer starts over a task node.
+- Roadmap node `DoubleTapped` -> выбрать текущую задачу и переключить details/card pane.
 - Roadmap node drag source -> existing `GraphControl.CustomFormat`.
 - Roadmap node drop target -> `MainControl.Drop` / `DragOver` через `RoadmapNode` DataContext.
 - Roadmap editor `KeyDown` -> existing create commands.
@@ -120,14 +122,15 @@ Roadmap graph визуально показывает те же задачи, н
   3. На Roadmap `Shift+Enter` создаёт ровно один blocked sibling с blocking relation как на других вкладках.
   4. На Roadmap `Ctrl+Tab` создаёт ровно один inner task под выбранной roadmap task.
   5. Кнопки `NewTask`, `NewSibling`, `NewBlockedSibling`, `NewInner` в карточке задачи после выбора roadmap task создают задачи через существующие commands; relative-кнопки создают задачи относительно выбранной roadmap task, `NewTask` создаёт root task.
-  6. Двойной клик по roadmap node выбирает clicked task и открывает карточку задачи; если карточка уже открыта, она остаётся открытой и переключается на clicked task.
+  6. Двойной клик по roadmap node выбирает clicked task и переключает карточку задачи: закрытая карточка открывается, открытая карточка закрывается как в обычных вкладках.
   7. Drag-drop roadmap node -> roadmap node с `Ctrl` создаёт blocking relation source blocks target.
-  8. Существующие tree command и roadmap rendering tests не регрессируют.
+  8. Правая кнопка мыши двигает карту задач, даже если drag начинается поверх задачи, и не выбирает задачу.
+  9. Существующие tree command и roadmap rendering tests не регрессируют.
 - Какие тесты добавить/изменить:
   - Добавить Avalonia.Headless tests в `RoadmapGraphUiTests` или новый `RoadmapTaskActionsUiTests`.
-  - Reproducing tests должны сначала падать до фикса: selection without static singleton, double click opens card without closing, create hotkey/button и drag-drop target на `RoadmapNode`.
+  - Reproducing tests должны сначала падать до фикса: selection without static singleton, double click toggles card like other tabs, create hotkey/button и drag-drop target на `RoadmapNode`.
   - Selection regression test должен временно сбросить или подменить `TaskItemViewModel.MainWindowInstance`, чтобы старый static path не мог замаскировать баг.
-  - Double-click regression test должен проверить два состояния: `DetailsAreOpen = false` перед double click открывается; `DetailsAreOpen = true` перед double click не закрывается и current task становится clicked task.
+  - Double-click regression test должен проверить два состояния: `DetailsAreOpen = false` перед double click открывается; `DetailsAreOpen = true` перед double click закрывается и current task становится clicked task.
   - Hotkey regression tests должны проверять прирост числа задач строго на `+1` для каждого нажатия.
   - При необходимости использовать reflection только для private static drop helpers нельзя; предпочтительно UI-level event/controls. Если headless drag API не позволяет полный `DoDragDrop`, допустим targeted handler-level test через реальные `MainControl.Drop`/`MainControl.DragOver`, `DataObject` с `GraphControl.CustomFormat` и assert по `Blocks`/`BlockedBy` в VM/storage. Такой fallback не считается достаточным, если он не проходит через existing drop pipeline и не проверяет mutation результата.
 - Characterization tests:
@@ -146,7 +149,7 @@ Roadmap graph визуально показывает те же задачи, н
 ## 12. Риски и edge cases
 - `Ctrl+Tab` может конфликтовать с tab navigation. Нужно подтверждать headless test и при необходимости обрабатывать на `GraphControl` до стандартной навигации.
 - Roadmap hotkeys могут выполниться дважды из-за bubbling/handler duplication. EXEC должен выставлять `e.Handled` и проверять `+1` mutation tests.
-- Double click сейчас похож на toggle. EXEC должен заменить его на idempotent open, чтобы пользователь не закрывал карточку случайно.
+- Double click должен оставаться toggle как в обычных вкладках; EXEC должен только исправить выбор clicked task и routing, не превращая его в idempotent open.
 - `GraphControl.RoadmapEditor_KeyDown` сейчас реагирует на `F/U/T/R` без проверки modifiers; при правке нельзя сломать viewport shortcuts.
 - Static `TaskItemViewModel.MainWindowInstance` может быть stale в tests; новый resolver должен предпочитать owner/visual context.
 - Drop на child text внутри node может уже работать через `TaskItemViewModel`; drop на border с `RoadmapNode` должен работать одинаково.
@@ -183,7 +186,7 @@ Roadmap graph визуально показывает те же задачи, н
 | Область | Было | Стало |
 | --- | --- | --- |
 | Выбор roadmap task | Через static `TaskItemViewModel.MainWindowInstance` | Через visual owner VM resolver с static fallback |
-| Double click roadmap task | Toggle details pane через static singleton | Выбирает clicked task и открывает карточку idempotently |
+| Double click roadmap task | Toggle details pane через static singleton | Выбирает clicked task через owner resolver и переключает карточку как обычные вкладки |
 | Roadmap create hotkeys | Нет явного routing из `GraphControl` | `Ctrl+Enter`, `Shift+Enter`, `Ctrl+Tab` вызывают существующие commands ровно один раз |
 | Roadmap drag-drop target | `RoadmapNode` не распознаётся как target task | `RoadmapNode.TaskItem` используется как target |
 | Card create buttons после выбора roadmap node | Зависят от хрупкого selection path | Работают после надёжного выбора текущей задачи |
@@ -248,3 +251,5 @@ Roadmap graph визуально показывает те же задачи, н
 | EXEC | Исправление double-click и drag source | 0.94 | Нет | Финальный статус пользователю | Нет | Да, пользователь сообщил о регрессии | Double click теперь дополнительно обрабатывается через `PointerPressed.ClickCount`, если routed `DoubleTapped` не приходит до шаблона node; drag source захватывает pointer до threshold и освобождает его перед `DoDragDrop`, чтобы move events не терялись при выходе курсора за границы node | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
 | EXEC | Верификация follow-up исправления | 0.95 | Нет | Финальный статус пользователю | Нет | Нет | Добавлен source-side UI test для pointer drag на roadmap node; `RoadmapGraphUiTests` прошли 32/32 после пересборки, ранее после production-code изменений прошли `MainControlTreeCommandsUiTests` 34/34 | `RoadmapGraphUiTests.cs`, build/test commands |
 | EXEC | Повторное исправление roadmap drag source | 0.93 | Нет | Финальный статус пользователю | Нет | Да, пользователь сообщил, что drag всё ещё не стартует | `GraphControl` теперь слушает `PointerMoved/Released` на своём уровне с `handledEventsToo`, чтобы `NodifyEditor`/контейнеры не теряли pending drag; pointer capture больше не сбрасывается перед `DoDragDrop`, а освобождается после завершения операции. UI test теперь проверяет инкремент `RoadmapDragStartCount` после движения за threshold | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| EXEC | Возврат double-click toggle | 0.95 | Нет | Проверить targeted UI tests | Нет | Да, пользователь уточнил parity с обычными вкладками | Double click на roadmap node снова переключает `DetailsAreOpen`: закрытая карточка открывается, открытая закрывается; выбор clicked task остаётся через owner resolver, а `ClickCount` fallback защищён от duplicate `DoubleTapped` toggle | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `specs/2026-05-07-roadmap-task-actions-parity.md` |
+| EXEC | Правый drag поверх roadmap task | 0.93 | Нет | Проверить targeted UI tests | Нет | Да, пользователь сообщил о пропавшем pan gesture | Правый drag, начатый на задаче, теперь обрабатывается в `GraphControl`: pointer захватывается, `ViewportLocation` меняется вручную с учётом zoom, задача не выбирается. Добавлен UI test на pan поверх node | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `specs/2026-05-07-roadmap-task-actions-parity.md` |

--- a/specs/2026-05-07-roadmap-task-actions-parity.md
+++ b/specs/2026-05-07-roadmap-task-actions-parity.md
@@ -1,0 +1,250 @@
+# Roadmap task actions parity
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; stack profile `dotnet-desktop-client`; overlay profile `ui-automation-testing`.
+- Владелец: Codex / Unlimotion desktop UI.
+- Масштаб: medium.
+- Целевая модель: gpt-5.5.
+- Целевой релиз / ветка: текущая рабочая ветка.
+- Ограничения: центральный `QUEST` требует SPEC-first и подтверждение фразой `Спеку подтверждаю` до изменений кода; локальный override требует UI tests для UI-facing исправлений.
+- Связанные ссылки: `AGENTS.md`, `AGENTS.override.md`, `C:\Projects\My\Agents\AGENTS.md`, `C:\Projects\My\Agents\instructions\governance\routing-matrix.md`, `C:\Projects\My\Agents\instructions\core\model-behavior-baseline.md`, `C:\Projects\My\Agents\instructions\core\quest-governance.md`, `C:\Projects\My\Agents\instructions\core\quest-mode.md`, `C:\Projects\My\Agents\instructions\core\collaboration-baseline.md`, `C:\Projects\My\Agents\instructions\core\testing-baseline.md`, `C:\Projects\My\Agents\instructions\contexts\testing-dotnet.md`, `C:\Projects\My\Agents\instructions\profiles\dotnet-desktop-client.md`, `C:\Projects\My\Agents\instructions\profiles\ui-automation-testing.md`.
+
+Если секция не применима, явно указано `Не применимо`.
+
+## 1. Overview / Цель
+Сделать карту задач поведенчески совместимой с обычными вкладками задач для базовых действий над выбранной задачей:
+- создание связей drag-and-drop между задачами на карте;
+- создание sibling / blocked sibling / inner task через глобальные клавиши;
+- создание задач кнопками в карточке текущей задачи после выбора задачи на карте.
+- открытие карточки задачи двойным кликом по задаче на карте.
+
+Outcome contract:
+- Success means: пользователь выбирает задачу на карте, после чего те же команды создания и связи работают с этой задачей как с выбранной задачей в task-tree вкладках.
+- Итоговый артефакт / output: минимальный кодовый фикс в `GraphControl`/`MainControl` плюс regression UI tests.
+- Stop rules: остановиться после прохождения targeted UI tests и full build/test либо явно зафиксировать невыполнимую проверку и next-best evidence.
+
+## 2. Текущее состояние (AS-IS)
+- Вкладка Roadmap в `src/Unlimotion/Views/MainControl.axaml` рендерит `<views:GraphControl DataContext="{Binding Graph}"/>`, то есть сам control работает с `GraphViewModel`, а не напрямую с `MainWindowViewModel`.
+- `MainControl` содержит глобальные `UserControl.KeyBindings`: `Ctrl+Enter -> CreateSibling`, `Shift+Enter -> CreateBlockedSibling`, `Ctrl+Tab -> CreateInner`.
+- Кнопки в карточке задачи находятся в pane `MainControl` и вызывают команды `Create`, `CreateSibling`, `CreateBlockedSibling`, `CreateInner` из `MainWindowViewModel`.
+- Обычный tree drag-and-drop реализован в `MainControl.axaml.cs`: данные имеют форматы `application/xxx-unlimotion-task` / batch, drop-target извлекается из `TaskWrapperViewModel` или `TaskItemViewModel`.
+- `GraphControl` имеет свой drag format `application/xxx-unlimotion-task-item` и делегирует `Drop`/`DragOver` в static методы `MainControl`.
+- `MainControl.TryGetDropTargetTask` сейчас не распознаёт `RoadmapNode` как target task. При drop на roadmap node event source часто является `Border` с `DataContext = RoadmapNode`, поэтому операция получает `None`.
+- `GraphControl.InputElement_OnPointerPressed` выбирает задачу через `TaskItemViewModel.MainWindowInstance`, а не через visual tree owner `MainWindowViewModel`. Это хрупко для headless UI tests и для embedded/control scenarios.
+- `GraphControl.TaskTree_OnDoubleTapped` сейчас меняет `DetailsAreOpen` через `TaskItemViewModel.MainWindowInstance` и делает toggle; если карточка уже открыта, двойной клик может закрыть её, а не открыть карточку выбранной roadmap task.
+- `GraphControl.RoadmapEditor_KeyDown` обрабатывает только viewport keys (`F/U/T/R`, `R`) и не маршрутизирует команды создания задач из фокуса карты.
+- В UI tests уже есть `RoadmapGraphUiTests` для rendering/graph state и `MainControlTreeCommandsUiTests` / `MainControlRelationPickerUiTests` для обычных вкладок, но нет regression coverage на создание задач и drag-drop прямо из roadmap.
+
+## 3. Проблема
+Roadmap graph визуально показывает те же задачи, но не участвует в общем контракте task actions как task-tree вкладки: выбор задачи, drop-target resolution и hotkey routing на карте неполны.
+
+## 4. Цели дизайна
+- Разделение ответственности: roadmap остаётся graph-view, а task mutations продолжают выполняться через существующие `MainWindowViewModel` commands и `TaskItemViewModel` relation methods.
+- Повторное использование: переиспользовать `MainControl` drag-drop pipeline и существующие VM commands вместо нового relation/action API.
+- Тестируемость: добавить Avalonia.Headless regression tests, которые воспроизводят действия через UI controls/events.
+- Консистентность: modifiers drag-drop на карте должны соответствовать вкладкам: default copy/contains, `Shift` move, `Ctrl` source blocks target, `Alt` target blocks source, `Ctrl+Shift` clone.
+- Обратная совместимость: не менять persisted model, storage format, public command names и automation ids.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не менять алгоритм layout/rendering карты и `RoadmapGraphBuilder`.
+- Не добавлять новый тип связей или новый persisted state.
+- Не перерабатывать весь drag threshold UX roadmap node dragging, если regression закрывается target resolution и selection routing.
+- Не менять тексты локализации и visual design карточки задачи.
+- Не расширять public storage API.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `src/Unlimotion/Views/GraphControl.axaml.cs` -> надёжно резолвит `MainWindowViewModel`, выбирает roadmap task без зависимости только от static singleton, маршрутизирует create hotkeys из фокуса карты.
+- `src/Unlimotion/Views/MainControl.axaml.cs` -> распознаёт `RoadmapNode` как валидный drop target и сохраняет существующий drag-drop pipeline.
+- `src/Unlimotion.Test/RoadmapGraphUiTests.cs` или отдельный UI test class -> regression tests для roadmap selection/create/hotkeys/drop.
+
+### 6.2 Детальный дизайн
+- Добавить helper для выбора roadmap task:
+  - получить `MainWindowViewModel` через `FindParentDataContext<MainWindowViewModel>()`;
+  - использовать `TaskItemViewModel.MainWindowInstance` только как fallback для production compatibility, если visual owner недоступен;
+  - установить `CurrentTaskItem`;
+  - вызвать `SelectCurrentTask()` при `GraphMode`, чтобы `CurrentGraphItem` синхронизировался с тем же source wrapper, где это возможно.
+  - не добавлять новый public owner API в `GraphViewModel`, если реализация возможна через visual owner resolver.
+- Для hotkeys в `GraphControl.RoadmapEditor_KeyDown`:
+  - при `Ctrl+Enter` выполнить `vm.CreateSibling`;
+  - при `Shift+Enter` выполнить `vm.CreateBlockedSibling`;
+  - при `Ctrl+Tab` выполнить `vm.CreateInner`;
+  - перед выполнением проверять `e.Handled`, после выполнения выставлять `e.Handled = true`;
+  - команда должна выполняться ровно один раз на одно нажатие, несмотря на подписки `GraphControl` и `RoadmapEditor`, а также существующие `MainControl.UserControl.KeyBindings`;
+  - не ломать существующие viewport keys и не перехватывать ввод из текстовых controls.
+- Для double click по roadmap node:
+  - переиспользовать тот же helper выбора roadmap task;
+  - установить `DetailsAreOpen = true`, а не переключать значение;
+  - после double click карточка должна показывать именно clicked task.
+- Для drag-drop target:
+  - расширить `TryGetDropTargetTask` так, чтобы `Control.DataContext is RoadmapNode` или ancestor с `RoadmapNode` возвращал `node.TaskItem`;
+  - оставить `TaskWrapperViewModel` / `TaskItemViewModel` пути без изменений.
+- Output contract / evidence rules:
+  - тест должен проверять именно изменение storage/model после UI action, а не только вызов обработчика;
+  - для drag-drop проверить хотя бы `Ctrl` roadmap node -> roadmap node создаёт blocking relation и вызывает rebuild/update evidence.
+- Обработка ошибок: использовать существующие validation guards `CanApplyDrop`, `CanMoveInto`, `CanCreateBlockingRelation`, toast errors.
+- Производительность: изменения выполняются на пользовательских events, без дополнительных subscriptions и без влияния на background roadmap build.
+
+## 7. Бизнес-правила / Алгоритмы
+- Roadmap node represents `RoadmapNode.TaskItem`; для UI actions он равен task entity в tree вкладках.
+- Create commands не должны создавать задачу, если `CurrentTaskItem` отсутствует или title текущей задачи пустой, как сейчас в `MainWindowViewModel`.
+- Drag modifiers сохраняют текущую таблицу `MainControl.GetBatchDropOperationKind`:
+  - no modifiers: source copied/contained into target;
+  - `Shift`: move into target;
+  - `Ctrl`: source blocks target;
+  - `Alt`: target blocks source;
+  - `Ctrl+Shift`: clone into target.
+
+## 8. Точки интеграции и триггеры
+- Roadmap node `PointerPressed` -> выбрать текущую задачу через owner VM.
+- Roadmap node `DoubleTapped` -> выбрать текущую задачу и открыть details/card pane.
+- Roadmap node drag source -> existing `GraphControl.CustomFormat`.
+- Roadmap node drop target -> `MainControl.Drop` / `DragOver` через `RoadmapNode` DataContext.
+- Roadmap editor `KeyDown` -> existing create commands.
+- Storage/relation mutation -> existing roadmap subscriptions trigger rebuild.
+
+## 9. Изменения модели данных / состояния
+- Новых persisted fields нет.
+- Новых public/runtime fields в `GraphViewModel` не планируется; если EXEC докажет техническую необходимость, нужен локальный private/internal helper без расширения публичного command surface.
+- `CurrentTaskItem` и `CurrentGraphItem` остаются существующими runtime state.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция данных: не применимо, storage schema не меняется.
+- Rollout: обычный desktop build.
+- Rollback: откатить кодовые изменения в `GraphControl`/`MainControl`/tests; данные пользователей не затрагиваются.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  1. Клик по roadmap node выбирает задачу в `MainWindowViewModel.CurrentTaskItem` без зависимости от актуального `TaskItemViewModel.MainWindowInstance`.
+  2. На Roadmap `Ctrl+Enter` создаёт ровно один sibling для выбранной roadmap task, и новая задача появляется в storage / VM.
+  3. На Roadmap `Shift+Enter` создаёт ровно один blocked sibling с blocking relation как на других вкладках.
+  4. На Roadmap `Ctrl+Tab` создаёт ровно один inner task под выбранной roadmap task.
+  5. Кнопки `NewTask`, `NewSibling`, `NewBlockedSibling`, `NewInner` в карточке задачи после выбора roadmap task создают задачи через существующие commands; relative-кнопки создают задачи относительно выбранной roadmap task, `NewTask` создаёт root task.
+  6. Двойной клик по roadmap node выбирает clicked task и открывает карточку задачи; если карточка уже открыта, она остаётся открытой и переключается на clicked task.
+  7. Drag-drop roadmap node -> roadmap node с `Ctrl` создаёт blocking relation source blocks target.
+  8. Существующие tree command и roadmap rendering tests не регрессируют.
+- Какие тесты добавить/изменить:
+  - Добавить Avalonia.Headless tests в `RoadmapGraphUiTests` или новый `RoadmapTaskActionsUiTests`.
+  - Reproducing tests должны сначала падать до фикса: selection without static singleton, double click opens card without closing, create hotkey/button и drag-drop target на `RoadmapNode`.
+  - Selection regression test должен временно сбросить или подменить `TaskItemViewModel.MainWindowInstance`, чтобы старый static path не мог замаскировать баг.
+  - Double-click regression test должен проверить два состояния: `DetailsAreOpen = false` перед double click открывается; `DetailsAreOpen = true` перед double click не закрывается и current task становится clicked task.
+  - Hotkey regression tests должны проверять прирост числа задач строго на `+1` для каждого нажатия.
+  - При необходимости использовать reflection только для private static drop helpers нельзя; предпочтительно UI-level event/controls. Если headless drag API не позволяет полный `DoDragDrop`, допустим targeted handler-level test через реальные `MainControl.Drop`/`MainControl.DragOver`, `DataObject` с `GraphControl.CustomFormat` и assert по `Blocks`/`BlockedBy` в VM/storage. Такой fallback не считается достаточным, если он не проходит через existing drop pipeline и не проверяет mutation результата.
+- Characterization tests:
+  - Существующие `MainControlTreeCommandsUiTests` должны продолжить подтверждать обычные вкладки.
+- Базовые замеры performance: не применимо, изменение event routing, не layout/perf.
+- Команды для проверки:
+  - `dotnet build src\Unlimotion\Unlimotion.csproj`
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj`
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/*"`
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*"`
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj`
+- Stop rules для test/retrieval/tool/validation loops:
+  - Если targeted roadmap tests падают, не завершать EXEC.
+  - Если full test run не запускается из-за внешней known repo issue, выполнить targeted UI tests + relevant project builds и зафиксировать точную ошибку.
+
+## 12. Риски и edge cases
+- `Ctrl+Tab` может конфликтовать с tab navigation. Нужно подтверждать headless test и при необходимости обрабатывать на `GraphControl` до стандартной навигации.
+- Roadmap hotkeys могут выполниться дважды из-за bubbling/handler duplication. EXEC должен выставлять `e.Handled` и проверять `+1` mutation tests.
+- Double click сейчас похож на toggle. EXEC должен заменить его на idempotent open, чтобы пользователь не закрывал карточку случайно.
+- `GraphControl.RoadmapEditor_KeyDown` сейчас реагирует на `F/U/T/R` без проверки modifiers; при правке нельзя сломать viewport shortcuts.
+- Static `TaskItemViewModel.MainWindowInstance` может быть stale в tests; новый resolver должен предпочитать owner/visual context.
+- Drop на child text внутри node может уже работать через `TaskItemViewModel`; drop на border с `RoadmapNode` должен работать одинаково.
+- После mutation roadmap rebuild asynchronous; UI tests должны ждать через existing `WaitFor`/throttle helpers.
+
+## 13. План выполнения
+1. Добавить failing Avalonia.Headless roadmap UI tests для selection, double click opens card, create hotkeys/buttons и drag-drop relation.
+2. Реализовать owner VM resolution / selection helper в `GraphControl`.
+3. Реализовать roadmap create hotkey routing в `GraphControl` с сохранением viewport shortcuts.
+4. Расширить `MainControl.TryGetDropTargetTask` для `RoadmapNode`.
+5. Прогнать targeted UI tests, затем build/full test согласно командам.
+6. Выполнить post-EXEC review: отклонения от спеки, regressions, selector stability, stale comments, validation evidence.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов. Если headless API не позволит достоверно симулировать полный OS drag-drop, в EXEC будет использован next-best event-level regression test для drop target plus UI-level create/selection tests.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client` + `ui-automation-testing`; context `testing-dotnet`; local UI testing override.
+- Выполненные требования профиля:
+  - План не блокирует UI thread длительными операциями.
+  - Изменения пользовательского потока покрываются Avalonia.Headless UI tests.
+  - Automation ids сохраняются; новые selectors добавляются только если тестам нужен стабильный roadmap node selector и без переименования существующих ids.
+  - Проверки используют TUnit/Microsoft.Testing.Platform style через `dotnet run --project ... -- --treenode-filter`.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion/Views/GraphControl.axaml.cs` | Owner VM resolution, task selection sync, double-click open-card behavior, create hotkey routing | Roadmap должен участвовать в общем task action contract |
+| `src/Unlimotion/Views/MainControl.axaml.cs` | Drop target resolution для `RoadmapNode` | Drag-drop на graph node должен создавать связи как в trees |
+| `src/Unlimotion.Test/RoadmapGraphUiTests.cs` или новый test file | Regression UI tests | Локальный override и центральный profile требуют UI coverage |
+| `specs/2026-05-07-roadmap-task-actions-parity.md` | Рабочая спецификация и журнал | Центральный QUEST contract |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Выбор roadmap task | Через static `TaskItemViewModel.MainWindowInstance` | Через visual owner VM resolver с static fallback |
+| Double click roadmap task | Toggle details pane через static singleton | Выбирает clicked task и открывает карточку idempotently |
+| Roadmap create hotkeys | Нет явного routing из `GraphControl` | `Ctrl+Enter`, `Shift+Enter`, `Ctrl+Tab` вызывают существующие commands ровно один раз |
+| Roadmap drag-drop target | `RoadmapNode` не распознаётся как target task | `RoadmapNode.TaskItem` используется как target |
+| Card create buttons после выбора roadmap node | Зависят от хрупкого selection path | Работают после надёжного выбора текущей задачи |
+
+## 18. Альтернативы и компромиссы
+- Вариант: перенести все команды в `GraphViewModel`.
+- Плюсы: bindings внутри `GraphControl` стали бы прямыми.
+- Минусы: дублирование command surface, риск рассинхронизации с `MainWindowViewModel`, расширение VM API.
+- Почему выбранное решение лучше в контексте этой задачи: существующий source of truth для mutations уже в `MainWindowViewModel`/`TaskItemViewModel`; достаточно исправить routing и target resolution.
+
+- Вариант: заставить `GraphControl` DataContext быть `MainWindowViewModel`.
+- Плюсы: общие bindings стали бы проще.
+- Минусы: ломает текущий graph-specific binding contract (`GraphViewModel.Tasks`, filters, search, reset command), большой blast radius.
+- Почему выбранное решение лучше в контексте этой задачи: сохраняет текущий graph binding surface.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+| Блок | Пункты | Статус | Комментарий |
+| --- | --- | --- | --- |
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, goals и Non-Goals описаны. |
+| B. Качество дизайна | 6-10 | PASS | Распределение ответственности, интеграции, state, rollout и perf границы описаны. |
+| C. Безопасность изменений | 11-13 | PASS | Persisted data не меняется, rollback простой, план ограничен event routing. |
+| D. Проверяемость | 14-16 | PASS | Acceptance Criteria, UI tests и команды TUnit/MTP указаны. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Этапы и риски определены, блокирующих вопросов нет. |
+| F. Соответствие профилю | 20 | PASS | Выбран .NET desktop + UI automation stack, local UI tests requirement учтён. |
+
+Итог: ГОТОВО.
+
+### SPEC Rubric Result
+| Критерий | Балл (0/2/5) | Обоснование |
+| --- | --- | --- |
+| 1. Ясность цели и границ | 5 | Одна корневая проблема и явные Non-Goals. |
+| 2. Понимание текущего состояния | 5 | Зафиксированы `GraphControl`, `MainControl`, VM commands и drag/drop formats. |
+| 3. Конкретность целевого дизайна | 5 | Описаны helper, hotkey routing и drop target resolution. |
+| 4. Безопасность (миграция, откат) | 5 | Нет persisted изменений; rollback code-only. |
+| 5. Тестируемость | 5 | Есть AC и конкретные Avalonia.Headless/TUnit команды. |
+| 6. Готовность к автономной реализации | 5 | План действий и риски достаточны, пользовательского выбора не требуется. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению.
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: в дизайн добавлены отдельные checks для card buttons и `Ctrl+Tab`, потому что только drop-target fix не покрывал бы всю пользовательскую проблему; добавлен owner/visual VM resolver вместо зависимости от static singleton; после review-находок убрано плановое расширение `GraphViewModel`, добавлен guard против двойного выполнения hotkeys, усилены evidence rules для drag-drop fallback, selection test обязан нейтрализовать `TaskItemViewModel.MainWindowInstance`, кнопка `NewTask` явно включена в card-button contract; double click по roadmap task добавлен как idempotent open-card scenario.
+- Что осталось на решение пользователя: требуется только утверждение спеки фразой `Спеку подтверждаю`.
+
+## Approval
+Получено подтверждение пользователя: "Спеку подтверждаю".
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Сбор central instruction stack | 0.95 | Нет | Сформировать рабочую спецификацию | Да, перед EXEC | Нет | Локальный `AGENTS.md` требует центральный каталог; задача UI bugfix проходит через QUEST и UI tests | `AGENTS.md`, `AGENTS.override.md`, central instructions |
+| SPEC | Анализ AS-IS roadmap actions | 0.86 | Нужен EXEC test-first для точного воспроизведения | Зафиксировать TO-BE и tests | Да, перед EXEC | Нет | Обнаружены хрупкий static selection path, отсутствие `RoadmapNode` drop-target resolution и отсутствие явного create hotkey routing в GraphControl | `GraphControl.axaml.cs`, `MainControl.axaml.cs`, `MainWindowViewModel.cs`, UI tests |
+| SPEC | SPEC quality gate и post-SPEC review | 0.92 | Нет | Дождаться утверждения спеки | Да | Да, ожидается фраза `Спеку подтверждаю` | Spec прошёл linter/rubric; центральный QUEST запрещает кодовые изменения до утверждения | `specs/2026-05-07-roadmap-task-actions-parity.md` |
+| SPEC | Исправление review-находок спеки | 0.94 | Нет | Дождаться утверждения спеки | Да | Да, пользователь попросил исправить spec review findings | Убрана неоднозначность с `GraphViewModel` API, добавлены guards против double hotkey execution, усилены UI evidence requirements и покрытие `NewTask` | `specs/2026-05-07-roadmap-task-actions-parity.md` |
+| SPEC | Расширение scope double-click open card | 0.94 | Нет | Дождаться утверждения спеки | Да | Да, пользователь попросил добавить сценарий | Double click на graph task относится к тому же roadmap task action parity и должен открывать карточку clicked task без toggle-close поведения | `specs/2026-05-07-roadmap-task-actions-parity.md` |
+| EXEC | Реализация roadmap action routing | 0.91 | Нет | Проверить build и UI tests | Нет | Да, пользователь подтвердил spec | `GraphControl` теперь резолвит owner VM через visual tree, выбирает roadmap task, открывает карточку idempotently и маршрутизирует create hotkeys; `MainControl` распознаёт `RoadmapNode` как drop target | `src/Unlimotion/Views/GraphControl.axaml.cs`, `src/Unlimotion/Views/MainControl.axaml.cs` |
+| EXEC | Regression UI coverage | 0.90 | Нет | Запустить targeted suites | Нет | Нет | Добавлены Avalonia.Headless tests для double click, roadmap hotkeys, card buttons и roadmap node drop с `Ctrl` relation | `src/Unlimotion.Test/RoadmapGraphUiTests.cs` |
+| EXEC | Верификация targeted checks | 0.94 | Full run упал на существующем storage concurrency exception | Выполнить post-EXEC review | Нет | Нет | `dotnet build` для app/test projects прошёл; `RoadmapGraphUiTests` 31/31 и `MainControlTreeCommandsUiTests` 34/34 прошли; full `Unlimotion.Test` без rebuild упал с `Collection was modified` в `UnifiedTaskStorage.RefreshRelations/Delete` | build/test commands |
+| EXEC | Уточнение click/rebuild поведения | 0.93 | Нет | Финальный статус пользователю | Нет | Да, пользователь уточнил требования | Изменение текста задачи больше не запускает rebuild карты; binding обновляет текст сам, а `SizeChanged` обновляет только локальную ширину node/anchors. Roadmap drag теперь стартует только после pointer-move threshold, поэтому первый клик сразу выбирает задачу, а double click открывает карточку | `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| EXEC | Исправление double-click и drag source | 0.94 | Нет | Финальный статус пользователю | Нет | Да, пользователь сообщил о регрессии | Double click теперь дополнительно обрабатывается через `PointerPressed.ClickCount`, если routed `DoubleTapped` не приходит до шаблона node; drag source захватывает pointer до threshold и освобождает его перед `DoDragDrop`, чтобы move events не терялись при выходе курсора за границы node | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| EXEC | Верификация follow-up исправления | 0.95 | Нет | Финальный статус пользователю | Нет | Нет | Добавлен source-side UI test для pointer drag на roadmap node; `RoadmapGraphUiTests` прошли 32/32 после пересборки, ранее после production-code изменений прошли `MainControlTreeCommandsUiTests` 34/34 | `RoadmapGraphUiTests.cs`, build/test commands |
+| EXEC | Повторное исправление roadmap drag source | 0.93 | Нет | Финальный статус пользователю | Нет | Да, пользователь сообщил, что drag всё ещё не стартует | `GraphControl` теперь слушает `PointerMoved/Released` на своём уровне с `handledEventsToo`, чтобы `NodifyEditor`/контейнеры не теряли pending drag; pointer capture больше не сбрасывается перед `DoDragDrop`, а освобождается после завершения операции. UI test теперь проверяет инкремент `RoadmapDragStartCount` после движения за threshold | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -1288,7 +1288,7 @@ public class RoadmapGraphUiTests
     }
 
     [Test]
-    public async Task RoadmapGraph_NodeClickSelectsTaskAndDoubleTapOpensDetailsWithoutStaticSingleton()
+    public async Task RoadmapGraph_NodeClickSelectsTaskAndDoubleTapTogglesDetailsWithoutStaticSingleton()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
@@ -1332,10 +1332,11 @@ public class RoadmapGraphUiTests
                 vm.DetailsAreOpen = true;
                 var otherTask = TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask1Id);
                 await Assert.That(otherTask).IsNotNull();
+                await Task.Delay(550);
 
                 taskNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
 
-                await Assert.That(vm.DetailsAreOpen).IsTrue();
+                await Assert.That(vm.DetailsAreOpen).IsFalse();
                 await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
             }
             finally
@@ -1408,6 +1409,82 @@ public class RoadmapGraphUiTests
                     topLevel.MouseUp(
                         GetControlCenterPoint(topLevel, taskNode),
                         MouseButton.Left,
+                        RawInputModifiers.None);
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_NodeRightDrag_PansViewportWithoutSelectingTask()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+            Control? taskNode = null;
+            var mouseIsDown = false;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+                vm.DetailsAreOpen = false;
+                vm.CurrentTaskItem = null;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = WaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                taskNode = WaitForTaskNode(
+                    graphControl!,
+                    MainWindowViewModelFixture.RootTask2Id);
+
+                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                var locationProperty = editor.GetType().GetProperty("ViewportLocation")!;
+                var startLocation = (Point)locationProperty.GetValue(editor)!;
+                var startPoint = GetControlCenterPoint(window, taskNode);
+                var movePoint = new Point(startPoint.X + 80, startPoint.Y + 36);
+
+                window.MouseDown(startPoint, MouseButton.Right, RawInputModifiers.None);
+                mouseIsDown = true;
+                Dispatcher.UIThread.RunJobs();
+
+                window.MouseMove(movePoint, RawInputModifiers.RightMouseButton);
+                Dispatcher.UIThread.RunJobs();
+
+                var panned = WaitFor(() =>
+                {
+                    var currentLocation = (Point)locationProperty.GetValue(editor)!;
+                    return Math.Abs(currentLocation.X - startLocation.X) > 1 ||
+                           Math.Abs(currentLocation.Y - startLocation.Y) > 1;
+                });
+                await Assert.That(panned).IsTrue();
+
+                window.MouseUp(movePoint, MouseButton.Right, RawInputModifiers.RightMouseButton);
+                mouseIsDown = false;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(vm.CurrentTaskItem).IsNull();
+                await Assert.That(vm.DetailsAreOpen).IsFalse();
+            }
+            finally
+            {
+                if (mouseIsDown && window is { } topLevel && taskNode != null)
+                {
+                    topLevel.MouseUp(
+                        GetControlCenterPoint(topLevel, taskNode),
+                        MouseButton.Right,
                         RawInputModifiers.None);
                     Dispatcher.UIThread.RunJobs();
                 }
@@ -1516,8 +1593,9 @@ public class RoadmapGraphUiTests
                 await Assert.That(selectedTask).IsNotNull();
 
                 var selectedNode = WaitForTaskNode(graphControl!, selectedTask!.Id);
-                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                await ClickControlAsync(window, selectedNode);
                 await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTask.Id);
+                await Assert.That(vm.DetailsAreOpen).IsTrue();
 
                 var countBefore = vm.taskRepository!.Tasks.Count;
                 var createRootButton = FindButtonForCommand(view, vm.Create);
@@ -1527,20 +1605,23 @@ public class RoadmapGraphUiTests
                 await Assert.That(rootCreated).IsNotNull();
                 await Assert.That(rootCreated!.Parents).IsEmpty();
 
-                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                await ClickControlAsync(window, selectedNode);
+                await Assert.That(vm.DetailsAreOpen).IsTrue();
                 countBefore = vm.taskRepository.Tasks.Count;
                 var createSiblingButton = FindButtonForCommand(view, vm.CreateSibling);
                 await ClickControlAsync(window, createSiblingButton);
                 await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
 
-                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                await ClickControlAsync(window, selectedNode);
+                await Assert.That(vm.DetailsAreOpen).IsTrue();
                 countBefore = vm.taskRepository.Tasks.Count;
                 var createBlockedSiblingButton = FindButtonForCommand(view, vm.CreateBlockedSibling);
                 await ClickControlAsync(window, createBlockedSiblingButton);
                 await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
                 await Assert.That(selectedTask.Blocks).Contains(vm.CurrentTaskItem!.Id);
 
-                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                await ClickControlAsync(window, selectedNode);
+                await Assert.That(vm.DetailsAreOpen).IsTrue();
                 countBefore = vm.taskRepository.Tasks.Count;
                 var createInnerButton = FindButtonForCommand(view, vm.CreateInner);
                 await ClickControlAsync(window, createInnerButton);

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -918,6 +918,110 @@ public class RoadmapGraphUiTests
     }
 
     [Test]
+    public async Task RoadmapGraph_ViewportOverlays_CollapseToCompactButtonsAndRestore()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view, 420, 520);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = WaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var nodesReady = WaitFor(() => graphControl!.RoadmapNodes.Count > 0);
+                await Assert.That(nodesReady).IsTrue();
+
+                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                var toolbar = WaitForAutomationControl<Control>(view, "RoadmapViewportToolbar");
+                var minimapPanel = WaitForAutomationControl<Control>(view, "RoadmapMinimapPanel");
+                var minimap = WaitForAutomationControl<Control>(view, "RoadmapMinimap");
+                var toolbarCollapseButton = WaitForAutomationControl<Button>(view, "RoadmapViewportToolbarCollapseButton");
+                var minimapCollapseButton = WaitForAutomationControl<Button>(view, "RoadmapMinimapCollapseButton");
+
+                await Assert.That(IsVisibleAndArranged(toolbar)).IsTrue();
+                await Assert.That(IsVisibleAndArranged(minimapPanel)).IsTrue();
+                await Assert.That(IsVisibleAndArranged(minimap)).IsTrue();
+
+                await ClickControlAsync(window, minimapCollapseButton);
+                var minimapCollapsed = WaitFor(() => !minimapPanel.IsVisible);
+                await Assert.That(minimapCollapsed).IsTrue();
+
+                var minimapExpandButton = WaitForAutomationControl<Button>(view, "RoadmapMinimapExpandButton");
+                await Assert.That(IsVisibleAndArranged(minimapExpandButton)).IsTrue();
+                await Assert.That(minimapExpandButton.Bounds.Width).IsLessThanOrEqualTo(40);
+                await Assert.That(minimapExpandButton.Bounds.Height).IsLessThanOrEqualTo(40);
+                await Assert.That(IsVisibleAndArranged(toolbar)).IsTrue();
+
+                var locationProperty = editor.GetType().GetProperty("ViewportLocation")!;
+                var panRightButton = WaitForAutomationControl<Button>(view, "RoadmapPanRightButton");
+                var locationBeforePan = (Avalonia.Point)locationProperty.GetValue(editor)!;
+
+                await ClickControlAsync(window, panRightButton);
+                var toolbarClickable = WaitFor(() =>
+                    ((Avalonia.Point)locationProperty.GetValue(editor)!).X > locationBeforePan.X);
+                await Assert.That(toolbarClickable).IsTrue();
+
+                await ClickControlAsync(window, toolbarCollapseButton);
+                var toolbarCollapsed = WaitFor(() => !toolbar.IsVisible);
+                await Assert.That(toolbarCollapsed).IsTrue();
+
+                var toolbarExpandButton = WaitForAutomationControl<Button>(view, "RoadmapViewportToolbarExpandButton");
+                await Assert.That(IsVisibleAndArranged(toolbarExpandButton)).IsTrue();
+                await Assert.That(toolbarExpandButton.Bounds.Width).IsLessThanOrEqualTo(40);
+                await Assert.That(toolbarExpandButton.Bounds.Height).IsLessThanOrEqualTo(40);
+
+                await ClickControlAsync(window, toolbarExpandButton);
+                var toolbarExpanded = WaitFor(() => IsVisibleAndArranged(toolbar));
+                await Assert.That(toolbarExpanded).IsTrue();
+
+                await ClickControlAsync(window, minimapExpandButton);
+                var minimapExpanded = WaitFor(() =>
+                    IsVisibleAndArranged(minimapPanel) &&
+                    IsVisibleAndArranged(minimap));
+                await Assert.That(minimapExpanded).IsTrue();
+
+                var zoomProperty = editor.GetType().GetProperty("ViewportZoom")!;
+                var initialZoom = (double)zoomProperty.GetValue(editor)!;
+                var zoomInButton = WaitForAutomationControl<Button>(view, "RoadmapZoomInButton");
+                await ClickControlAsync(window, zoomInButton);
+                var zoomed = WaitFor(() => (double)zoomProperty.GetValue(editor)! > initialZoom);
+                await Assert.That(zoomed).IsTrue();
+
+                var expectedLocation = new Avalonia.Point(123, 45);
+                locationProperty.SetValue(editor, expectedLocation);
+                Dispatcher.UIThread.RunJobs();
+
+                var minimapLocationProperty = minimap.GetType().GetProperty("ViewportLocation")!;
+                var minimapBound = WaitFor(() =>
+                {
+                    var actual = (Avalonia.Point)minimapLocationProperty.GetValue(minimap)!;
+                    return Math.Abs(actual.X - expectedLocation.X) < 0.001 &&
+                           Math.Abs(actual.Y - expectedLocation.Y) < 0.001;
+                });
+                await Assert.That(minimapBound).IsTrue();
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
     public async Task RoadmapGraph_UpdateGraphPulse_CoalescesQueuedBackgroundRebuilds()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
@@ -1759,6 +1863,16 @@ public class RoadmapGraphUiTests
         };
     }
 
+    private static Window CreateWindow(Control content, double width, double height)
+    {
+        return new Window
+        {
+            Width = width,
+            Height = height,
+            Content = content
+        };
+    }
+
     private static async Task ClickControlAsync(
         Window window,
         Control control,
@@ -1956,6 +2070,13 @@ public class RoadmapGraphUiTests
             Dispatcher.UIThread.RunJobs();
             return predicate();
         }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
+    }
+
+    private static bool IsVisibleAndArranged(Control control)
+    {
+        return control.IsVisible &&
+               control.Bounds.Width > 0 &&
+               control.Bounds.Height > 0;
     }
 
     private static int WaitForStableRoadmapUpdates(

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -4,10 +4,13 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Input;
+using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
+using Avalonia.Input.Raw;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
@@ -1113,7 +1116,7 @@ public class RoadmapGraphUiTests
     }
 
     [Test]
-    public async Task RoadmapGraph_NodeWidthFollowsRenderedTitleAfterRename()
+    public async Task RoadmapGraph_TitleRename_UpdatesTextWithoutRebuildingMap()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
@@ -1142,43 +1145,29 @@ public class RoadmapGraphUiTests
                 var rootTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
                 await Assert.That(rootTask).IsNotNull();
 
-                rootTask!.Title = "1231233445345343534534534534534535345";
-                var wideReady = WaitFor(() =>
+                WaitForStableRoadmapUpdates(graphControl!);
+                var updateCountBeforeRename = graphControl.RoadmapGraphUpdateCount;
+                var locationBeforeRename = originalNode!.Location;
+                var connectionCountBeforeRename = graphControl.RoadmapConnections.Count;
+
+                rootTask!.Title = "Renamed roadmap task without rebuild";
+                var textUpdated = WaitFor(() =>
                 {
                     var text = FindTaskTitleTextBlock(graphControl!, MainWindowViewModelFixture.RootTask2Id);
                     var node = FindRoadmapNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
                     return text?.Text == rootTask.TitleWithoutEmoji &&
-                           node?.Width > 300 &&
-                           Math.Abs(taskNodeWidth(text) - node.Width) < 0.5;
+                           ReferenceEquals(originalNode, node);
                 });
-                await Assert.That(wideReady).IsTrue();
-                await Assert.That(ReferenceEquals(
-                    originalNode,
-                    FindRoadmapNode(graphControl!, MainWindowViewModelFixture.RootTask2Id))).IsTrue();
+                await Assert.That(textUpdated).IsTrue();
 
-                var wideWidth = FindRoadmapNode(graphControl!, MainWindowViewModelFixture.RootTask2Id)!.Width;
+                var rebuildHappened = WaitFor(
+                    () => graphControl.RoadmapGraphUpdateCount > updateCountBeforeRename,
+                    1200);
 
-                rootTask.Title = "A";
-                var narrowReady = WaitFor(() =>
-                {
-                    var text = FindTaskTitleTextBlock(graphControl!, MainWindowViewModelFixture.RootTask2Id);
-                    var node = FindRoadmapNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
-                    var outgoingConnection = graphControl!.RoadmapConnections
-                        .FirstOrDefault(connection => connection.Tail.Id == MainWindowViewModelFixture.RootTask2Id);
-                    return text?.Text == rootTask.TitleWithoutEmoji &&
-                           node != null &&
-                           outgoingConnection != null &&
-                           node.Width < wideWidth - 150 &&
-                           node.Width <= RoadmapNode.MinWidth + 1 &&
-                           Math.Abs(taskNodeWidth(text) - node.Width) < 0.5 &&
-                           Math.Abs(node.RightAnchor.X - (node.Location.X + node.Width)) < 0.5 &&
-                           Math.Abs(outgoingConnection.Source.X - node.RightAnchor.X) < 0.5 &&
-                           outgoingConnection.HasSourceExtension &&
-                           Math.Abs(
-                               outgoingConnection.RoutedSource.X -
-                               (node.Location.X + RoadmapNode.MaxWidth)) < 0.5;
-                });
-                await Assert.That(narrowReady).IsTrue();
+                await Assert.That(rebuildHappened).IsFalse();
+                await Assert.That(graphControl.RoadmapGraphUpdateCount).IsEqualTo(updateCountBeforeRename);
+                await Assert.That(graphControl.RoadmapConnections.Count).IsEqualTo(connectionCountBeforeRename);
+                await Assert.That(originalNode.Location).IsEqualTo(locationBeforeRename);
                 await Assert.That(ReferenceEquals(
                     originalNode,
                     FindRoadmapNode(graphControl!, MainWindowViewModelFixture.RootTask2Id))).IsTrue();
@@ -1299,12 +1288,13 @@ public class RoadmapGraphUiTests
     }
 
     [Test]
-    public async Task RoadmapGraph_NodeDoubleTap_TogglesDetailsPanel()
+    public async Task RoadmapGraph_NodeClickSelectsTaskAndDoubleTapOpensDetailsWithoutStaticSingleton()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
+            var previousMainWindow = TaskItemViewModel.MainWindowInstance;
             Window? window = null;
 
             try
@@ -1314,6 +1304,8 @@ public class RoadmapGraphUiTests
                 vm.AllTasksMode = false;
                 vm.GraphMode = true;
                 vm.DetailsAreOpen = false;
+                vm.CurrentTaskItem = null;
+                TaskItemViewModel.MainWindowInstance = null;
 
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
@@ -1327,9 +1319,293 @@ public class RoadmapGraphUiTests
                     graphControl!,
                     MainWindowViewModelFixture.RootTask2Id);
 
+                await ClickControlAsync(window!, taskNode);
+
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
+                await Assert.That(vm.DetailsAreOpen).IsFalse();
+
+                await ClickControlAsync(window!, taskNode);
+
+                await Assert.That(vm.DetailsAreOpen).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
+
+                vm.DetailsAreOpen = true;
+                var otherTask = TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask1Id);
+                await Assert.That(otherTask).IsNotNull();
+
                 taskNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
 
                 await Assert.That(vm.DetailsAreOpen).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
+            }
+            finally
+            {
+                TaskItemViewModel.MainWindowInstance = previousMainWindow;
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_NodePointerDrag_StartsAfterMoveThresholdAndKeepsSelection()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+            Control? taskNode = null;
+            var mouseIsDown = false;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+                vm.DetailsAreOpen = false;
+                vm.CurrentTaskItem = null;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = WaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                taskNode = WaitForTaskNode(
+                    graphControl!,
+                    MainWindowViewModelFixture.RootTask2Id);
+
+                var startPoint = GetControlCenterPoint(window, taskNode);
+                var movePoint = new Point(startPoint.X + 24, startPoint.Y + 16);
+                var dragStartCountBefore = graphControl!.RoadmapDragStartCount;
+
+                window.MouseDown(startPoint, MouseButton.Left, RawInputModifiers.None);
+                mouseIsDown = true;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
+                await Assert.That(vm.DetailsAreOpen).IsFalse();
+
+                window.MouseMove(movePoint, RawInputModifiers.LeftMouseButton);
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(WaitFor(() =>
+                    graphControl.RoadmapDragStartCount == dragStartCountBefore + 1)).IsTrue();
+
+                window.MouseUp(movePoint, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+                mouseIsDown = false;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
+                await Assert.That(vm.DetailsAreOpen).IsFalse();
+            }
+            finally
+            {
+                if (mouseIsDown && window is { } topLevel && taskNode != null)
+                {
+                    topLevel.MouseUp(
+                        GetControlCenterPoint(topLevel, taskNode),
+                        MouseButton.Left,
+                        RawInputModifiers.None);
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    [Arguments("CtrlEnter", MainWindowViewModelFixture.RootTask2Id)]
+    [Arguments("ShiftEnter", MainWindowViewModelFixture.RootTask2Id)]
+    [Arguments("CtrlTab", MainWindowViewModelFixture.RootTask2Id)]
+    public async Task RoadmapGraph_CreateHotkeys_UseSelectedRoadmapTaskExactlyOnce(
+        string hotkey,
+        string selectedTaskId)
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = WaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var selectedTask = TestHelpers.GetTask(vm, selectedTaskId);
+                await Assert.That(selectedTask).IsNotNull();
+                var selectedNode = WaitForTaskNode(graphControl!, selectedTaskId);
+                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTaskId);
+
+                var taskCountBefore = vm.taskRepository!.Tasks.Count;
+                var roadmapEditor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                roadmapEditor.Focus();
+                PressRoadmapHotkey(window, hotkey);
+                Dispatcher.UIThread.RunJobs();
+
+                var created = WaitFor(() =>
+                    vm.taskRepository.Tasks.Count == taskCountBefore + 1 &&
+                    vm.CurrentTaskItem != null &&
+                    vm.CurrentTaskItem.Id != selectedTaskId);
+                await Assert.That(created).IsTrue();
+
+                var createdTask = vm.CurrentTaskItem!;
+                await Assert.That(vm.taskRepository.Tasks.Count).IsEqualTo(taskCountBefore + 1);
+
+                switch (hotkey)
+                {
+                    case "ShiftEnter":
+                        await Assert.That(selectedTask!.Blocks).Contains(createdTask.Id);
+                        await Assert.That(createdTask.BlockedBy).Contains(selectedTask.Id);
+                        break;
+                    case "CtrlTab":
+                        await Assert.That(selectedTask!.Contains).Contains(createdTask.Id);
+                        await Assert.That(createdTask.Parents).Contains(selectedTask.Id);
+                        break;
+                }
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_TaskCardButtons_AfterRoadmapSelection_CreateExpectedTasks()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+                vm.DetailsAreOpen = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = WaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                var selectedTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
+                await Assert.That(selectedTask).IsNotNull();
+
+                var selectedNode = WaitForTaskNode(graphControl!, selectedTask!.Id);
+                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTask.Id);
+
+                var countBefore = vm.taskRepository!.Tasks.Count;
+                var createRootButton = FindButtonForCommand(view, vm.Create);
+                await ClickControlAsync(window, createRootButton);
+                await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
+                var rootCreated = vm.CurrentTaskItem;
+                await Assert.That(rootCreated).IsNotNull();
+                await Assert.That(rootCreated!.Parents).IsEmpty();
+
+                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                countBefore = vm.taskRepository.Tasks.Count;
+                var createSiblingButton = FindButtonForCommand(view, vm.CreateSibling);
+                await ClickControlAsync(window, createSiblingButton);
+                await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
+
+                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                countBefore = vm.taskRepository.Tasks.Count;
+                var createBlockedSiblingButton = FindButtonForCommand(view, vm.CreateBlockedSibling);
+                await ClickControlAsync(window, createBlockedSiblingButton);
+                await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
+                await Assert.That(selectedTask.Blocks).Contains(vm.CurrentTaskItem!.Id);
+
+                selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                countBefore = vm.taskRepository.Tasks.Count;
+                var createInnerButton = FindButtonForCommand(view, vm.CreateInner);
+                await ClickControlAsync(window, createInnerButton);
+                await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
+                await Assert.That(selectedTask.Contains).Contains(vm.CurrentTaskItem!.Id);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_DropWithControl_CreatesBlockingRelationBetweenRoadmapNodes()
+    {
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var sourceTask = await vm.taskRepository!.Add();
+                sourceTask.Title = "Roadmap DnD source";
+                var targetTask = await vm.taskRepository.Add();
+                targetTask.Title = "Roadmap DnD target";
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = WaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var sourceReady = WaitFor(() => FindRoadmapNode(graphControl!, sourceTask.Id) != null);
+                var targetReady = WaitFor(() => FindRoadmapNode(graphControl!, targetTask.Id) != null);
+                await Assert.That(sourceReady).IsTrue();
+                await Assert.That(targetReady).IsTrue();
+
+                var targetNode = WaitForTaskNode(graphControl!, targetTask.Id);
+                var dragData = new DataObject();
+                dragData.Set(GraphControl.CustomFormat, sourceTask);
+                var dropArgs = new DragEventArgs(
+                    DragDrop.DropEvent,
+                    dragData,
+                    targetNode,
+                    new Avalonia.Point(targetNode.Bounds.Width / 2, targetNode.Bounds.Height / 2),
+                    KeyModifiers.Control);
+
+                await MainControl.Drop(view, dropArgs);
+                await TestHelpers.WaitThrottleTime();
+
+                await Assert.That(dropArgs.Handled).IsTrue();
+                await Assert.That(dropArgs.DragEffects).IsEqualTo(DragDropEffects.Link);
+                await Assert.That(sourceTask.Blocks).Contains(targetTask.Id);
+                await Assert.That(targetTask.BlockedBy).Contains(sourceTask.Id);
             }
             finally
             {
@@ -1400,6 +1676,68 @@ public class RoadmapGraphUiTests
             Height = 900,
             Content = content
         };
+    }
+
+    private static async Task ClickControlAsync(
+        Window window,
+        Control control,
+        MouseButton button = MouseButton.Left,
+        RawInputModifiers modifiers = RawInputModifiers.None)
+    {
+        var point = GetControlCenterPoint(window, control);
+        window.MouseDown(point, button, modifiers);
+        window.MouseUp(point, button, modifiers);
+        Dispatcher.UIThread.RunJobs();
+        await Task.CompletedTask;
+    }
+
+    private static Point GetControlCenterPoint(Visual relativeTo, Control control)
+    {
+        var point = control.TranslatePoint(
+            new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
+            relativeTo);
+
+        if (!point.HasValue)
+        {
+            throw new InvalidOperationException($"Cannot translate point for control {control.GetType().Name}.");
+        }
+
+        return point.Value;
+    }
+
+    private static void PressRoadmapHotkey(Window window, string hotkey)
+    {
+        switch (hotkey)
+        {
+            case "CtrlEnter":
+                PressHotkey(window, Key.Enter, PhysicalKey.Enter, RawInputModifiers.Control);
+                break;
+            case "ShiftEnter":
+                PressHotkey(window, Key.Enter, PhysicalKey.Enter, RawInputModifiers.Shift);
+                break;
+            case "CtrlTab":
+                PressHotkey(window, Key.Tab, PhysicalKey.Tab, RawInputModifiers.Control);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(hotkey), hotkey, "Unknown roadmap hotkey.");
+        }
+    }
+
+    private static void PressHotkey(
+        Window window,
+        Key key,
+        PhysicalKey physicalKey,
+        RawInputModifiers modifiers)
+    {
+        window.KeyPress(key, modifiers, physicalKey, null);
+        window.KeyRelease(key, modifiers, physicalKey, null);
+    }
+
+    private static Button FindButtonForCommand(Control root, ICommand command)
+    {
+        return root.GetVisualDescendants()
+            .OfType<Button>()
+            .First(button => ReferenceEquals(button.Command, command));
     }
 
     private static GraphControl? WaitForGraphControl(Control root, int timeoutMilliseconds = 3000)

--- a/src/Unlimotion/Views/GraphControl.axaml
+++ b/src/Unlimotion/Views/GraphControl.axaml
@@ -30,6 +30,18 @@
             <Setter Property="BorderBrush" Value="#707070" />
             <Setter Property="Foreground" Value="White" />
         </Style>
+        <Style Selector="Button.roadmapOverlayButton">
+            <Setter Property="Width" Value="28" />
+            <Setter Property="Height" Value="28" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+            <Setter Property="Background" Value="#3A3A3A" />
+            <Setter Property="BorderBrush" Value="#707070" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="Auto,*">
         <WrapPanel Orientation="Horizontal" x:DataType="viewModel:GraphViewModel">
@@ -189,112 +201,153 @@
 
             <Border HorizontalAlignment="Left"
                     VerticalAlignment="Bottom"
-                    Margin="10"
-                    Padding="6"
+                    Margin="0"
+                    Padding="0"
                     CornerRadius="4"
                     Background="#CC1E1E1E"
                     BorderBrush="#666666"
                     BorderThickness="1"
+                    IsVisible="{Binding IsRoadmapViewportToolbarExpanded, ElementName=Root}"
                     AutomationProperties.AutomationId="RoadmapViewportToolbar">
-                <Grid ColumnDefinitions="Auto,8,Auto" RowDefinitions="Auto">
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                        <Button Classes="roadmapViewportButton"
-                                Content="+"
-                                Click="RoadmapZoomIn_OnClick"
-                                ToolTip.Tip="Zoom in"
-                                AutomationProperties.AutomationId="RoadmapZoomInButton" />
-                        <Button Classes="roadmapViewportButton"
-                                Content="-"
-                                Click="RoadmapZoomOut_OnClick"
-                                ToolTip.Tip="Zoom out"
-                                AutomationProperties.AutomationId="RoadmapZoomOutButton" />
-                        <Button Classes="roadmapViewportButton"
-                                Content="[]"
-                                Click="RoadmapFit_OnClick"
-                                ToolTip.Tip="Fit"
-                                AutomationProperties.AutomationId="RoadmapFitButton" />
-                        <Button Classes="roadmapViewportButton"
-                                Content="0"
-                                Click="RoadmapResetViewport_OnClick"
-                                ToolTip.Tip="Reset"
-                                AutomationProperties.AutomationId="RoadmapResetViewportButton" />
-                    </StackPanel>
+                <Grid>
+                    <Grid ColumnDefinitions="Auto,8,Auto" RowDefinitions="Auto">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <Button Classes="roadmapViewportButton"
+                                    Content="+"
+                                    Click="RoadmapZoomIn_OnClick"
+                                    ToolTip.Tip="Zoom in"
+                                    AutomationProperties.AutomationId="RoadmapZoomInButton" />
+                            <Button Classes="roadmapViewportButton"
+                                    Content="-"
+                                    Click="RoadmapZoomOut_OnClick"
+                                    ToolTip.Tip="Zoom out"
+                                    AutomationProperties.AutomationId="RoadmapZoomOutButton" />
+                            <Button Classes="roadmapViewportButton"
+                                    Content="[]"
+                                    Click="RoadmapFit_OnClick"
+                                    ToolTip.Tip="Fit"
+                                    AutomationProperties.AutomationId="RoadmapFitButton" />
+                            <Button Classes="roadmapViewportButton"
+                                    Content="0"
+                                    Click="RoadmapResetViewport_OnClick"
+                                    ToolTip.Tip="Reset"
+                                    AutomationProperties.AutomationId="RoadmapResetViewportButton" />
+                        </StackPanel>
 
-                    <Grid Grid.Column="2"
-                          Width="86"
-                          Height="86"
-                          RowDefinitions="*,*,*"
-                          ColumnDefinitions="*,*,*">
-                        <Button Grid.Row="0"
-                                Grid.Column="1"
-                                Classes="roadmapViewportButton"
-                                Content="^"
-                                Click="RoadmapPanUp_OnClick"
-                                ToolTip.Tip="Pan up"
-                                AutomationProperties.AutomationId="RoadmapPanUpButton" />
-                        <Button Grid.Row="1"
-                                Grid.Column="0"
-                                Classes="roadmapViewportButton"
-                                Content="&lt;"
-                                Click="RoadmapPanLeft_OnClick"
-                                ToolTip.Tip="Pan left"
-                                AutomationProperties.AutomationId="RoadmapPanLeftButton" />
-                        <Button Grid.Row="1"
-                                Grid.Column="2"
-                                Classes="roadmapViewportButton"
-                                Content="&gt;"
-                                Click="RoadmapPanRight_OnClick"
-                                ToolTip.Tip="Pan right"
-                                AutomationProperties.AutomationId="RoadmapPanRightButton" />
-                        <Button Grid.Row="2"
-                                Grid.Column="1"
-                                Classes="roadmapViewportButton"
-                                Content="v"
-                                Click="RoadmapPanDown_OnClick"
-                                ToolTip.Tip="Pan down"
-                                AutomationProperties.AutomationId="RoadmapPanDownButton" />
+                        <Grid Grid.Column="2"
+                              Width="86"
+                              Height="86"
+                              RowDefinitions="*,*,*"
+                              ColumnDefinitions="*,*,*">
+                            <Button Grid.Row="0"
+                                    Grid.Column="1"
+                                    Classes="roadmapViewportButton"
+                                    Content="^"
+                                    Click="RoadmapPanUp_OnClick"
+                                    ToolTip.Tip="Pan up"
+                                    AutomationProperties.AutomationId="RoadmapPanUpButton" />
+                            <Button Grid.Row="1"
+                                    Grid.Column="0"
+                                    Classes="roadmapViewportButton"
+                                    Content="&lt;"
+                                    Click="RoadmapPanLeft_OnClick"
+                                    ToolTip.Tip="Pan left"
+                                    AutomationProperties.AutomationId="RoadmapPanLeftButton" />
+                            <Button Grid.Row="1"
+                                    Grid.Column="2"
+                                    Classes="roadmapViewportButton"
+                                    Content="&gt;"
+                                    Click="RoadmapPanRight_OnClick"
+                                    ToolTip.Tip="Pan right"
+                                    AutomationProperties.AutomationId="RoadmapPanRightButton" />
+                            <Button Grid.Row="2"
+                                    Grid.Column="1"
+                                    Classes="roadmapViewportButton"
+                                    Content="v"
+                                    Click="RoadmapPanDown_OnClick"
+                                    ToolTip.Tip="Pan down"
+                                    AutomationProperties.AutomationId="RoadmapPanDownButton" />
+                        </Grid>
                     </Grid>
+
+                    <Button Classes="roadmapOverlayButton"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Bottom"
+                            Content="x"
+                            Click="RoadmapViewportToolbarCollapse_OnClick"
+                            ToolTip.Tip="Hide graph controls"
+                            AutomationProperties.AutomationId="RoadmapViewportToolbarCollapseButton" />
                 </Grid>
             </Border>
+
+            <Button HorizontalAlignment="Left"
+                    VerticalAlignment="Bottom"
+                    Margin="0"
+                    Classes="roadmapOverlayButton"
+                    Content="T"
+                    Click="RoadmapViewportToolbarExpand_OnClick"
+                    IsVisible="{Binding !IsRoadmapViewportToolbarExpanded, ElementName=Root}"
+                    ToolTip.Tip="Show graph controls"
+                    AutomationProperties.AutomationId="RoadmapViewportToolbarExpandButton" />
 
             <Border HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
                     Width="260"
                     Height="170"
-                    Margin="10"
-                    Padding="5"
+                    Margin="0"
+                    Padding="0"
                     CornerRadius="4"
                     Background="#CC1E1E1E"
                     BorderBrush="#666666"
                     BorderThickness="1"
+                    IsVisible="{Binding IsRoadmapMinimapExpanded, ElementName=Root}"
                     AutomationProperties.AutomationId="RoadmapMinimapPanel">
-                <nodify:Minimap x:Name="RoadmapMinimap"
-                                AutomationProperties.AutomationId="RoadmapMinimap"
-                                ItemsSource="{Binding RoadmapNodes, ElementName=Root}"
-                                ViewportLocation="{Binding ViewportLocation, ElementName=RoadmapEditor, Mode=TwoWay}"
-                                ViewportSize="{Binding ViewportSize, ElementName=RoadmapEditor}"
-                                ResizeToViewport="True"
-                                Zoom="RoadmapMinimap_OnZoom"
-                                Background="#202020">
-                    <nodify:Minimap.ItemTemplate>
-                        <DataTemplate DataType="{x:Type local:RoadmapNode}">
-                            <Border Background="#808080"
-                                    BorderBrush="#B0B0B0"
-                                    BorderThickness="1"
-                                    CornerRadius="1" />
-                        </DataTemplate>
-                    </nodify:Minimap.ItemTemplate>
+                <Grid>
+                    <nodify:Minimap x:Name="RoadmapMinimap"
+                                    AutomationProperties.AutomationId="RoadmapMinimap"
+                                    ItemsSource="{Binding RoadmapNodes, ElementName=Root}"
+                                    ViewportLocation="{Binding ViewportLocation, ElementName=RoadmapEditor, Mode=TwoWay}"
+                                    ViewportSize="{Binding ViewportSize, ElementName=RoadmapEditor}"
+                                    ResizeToViewport="True"
+                                    Zoom="RoadmapMinimap_OnZoom"
+                                    Background="#202020">
+                        <nodify:Minimap.ItemTemplate>
+                            <DataTemplate DataType="{x:Type local:RoadmapNode}">
+                                <Border Background="#808080"
+                                        BorderBrush="#B0B0B0"
+                                        BorderThickness="1"
+                                        CornerRadius="1" />
+                            </DataTemplate>
+                        </nodify:Minimap.ItemTemplate>
 
-                    <nodify:Minimap.ItemContainerTheme>
-                        <ControlTheme TargetType="{x:Type nodify:MinimapItem}"
-                                      BasedOn="{StaticResource {x:Type nodify:MinimapItem}}">
-                            <Setter Property="Location" Value="{Binding Location}" />
-                            <Setter Property="Width" Value="{Binding Width}" />
-                            <Setter Property="Height" Value="{x:Static local:RoadmapNode.Height}" />
-                        </ControlTheme>
-                    </nodify:Minimap.ItemContainerTheme>
-                </nodify:Minimap>
+                        <nodify:Minimap.ItemContainerTheme>
+                            <ControlTheme TargetType="{x:Type nodify:MinimapItem}"
+                                          BasedOn="{StaticResource {x:Type nodify:MinimapItem}}">
+                                <Setter Property="Location" Value="{Binding Location}" />
+                                <Setter Property="Width" Value="{Binding Width}" />
+                                <Setter Property="Height" Value="{x:Static local:RoadmapNode.Height}" />
+                            </ControlTheme>
+                        </nodify:Minimap.ItemContainerTheme>
+                    </nodify:Minimap>
+
+                    <Button Classes="roadmapOverlayButton"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            Content="x"
+                            Click="RoadmapMinimapCollapse_OnClick"
+                            ToolTip.Tip="Hide minimap"
+                            AutomationProperties.AutomationId="RoadmapMinimapCollapseButton" />
+                </Grid>
             </Border>
+
+            <Button HorizontalAlignment="Right"
+                    VerticalAlignment="Bottom"
+                    Classes="roadmapOverlayButton"
+                    Content="M"
+                    Click="RoadmapMinimapExpand_OnClick"
+                    IsVisible="{Binding !IsRoadmapMinimapExpanded, ElementName=Root}"
+                    ToolTip.Tip="Show minimap"
+                    AutomationProperties.AutomationId="RoadmapMinimapExpandButton" />
         </Grid>
     </Grid>
 </UserControl>

--- a/src/Unlimotion/Views/GraphControl.axaml
+++ b/src/Unlimotion/Views/GraphControl.axaml
@@ -104,6 +104,8 @@
                                 DragDrop.AllowDrop="True"
                                 SizeChanged="RoadmapNode_OnSizeChanged"
                                 PointerPressed="InputElement_OnPointerPressed"
+                                PointerMoved="InputElement_OnPointerMoved"
+                                PointerReleased="InputElement_OnPointerReleased"
                                 DoubleTapped="TaskTree_OnDoubleTapped">
                             <Grid ColumnDefinitions="Auto,Auto,Auto,*">
                                 <CheckBox DataContext="{Binding TaskItem}"

--- a/src/Unlimotion/Views/GraphControl.axaml.cs
+++ b/src/Unlimotion/Views/GraphControl.axaml.cs
@@ -33,12 +33,15 @@ namespace Unlimotion.Views
         private readonly SerialDisposable roadmapScopeSubscriptions = new();
         private readonly SerialDisposable roadmapFilterSubscriptions = new();
         private readonly DispatcherTimer graphUpdateTimer;
+        private DateTime lastRoadmapPointerDoubleTapAt = DateTime.MinValue;
+        private string? lastRoadmapPointerDoubleTapTaskId;
         private ReadOnlyObservableCollection<TaskWrapperViewModel>? roadmapScopeSubscriptionRoots;
         private string? roadmapScopeSubscriptionSignature;
         private bool roadmapScopeSubscriptionsDirty = true;
         private bool graphUpdateQueued;
         private bool highlightUpdateQueued;
         private PendingRoadmapDragContext? pendingRoadmapDrag;
+        private PendingRoadmapPanContext? pendingRoadmapPan;
         private bool roadmapDragInProgress;
         private int roadmapBuildRequestVersion;
         private int roadmapActiveBuildCount;
@@ -72,6 +75,8 @@ namespace Unlimotion.Views
             {
                 CancelScheduledGraphUpdate();
                 CancelPendingRoadmapBuilds();
+                ClearPendingRoadmapDrag();
+                ClearPendingRoadmapPan();
             };
             InitializeComponent();
             AddHandler(DragDrop.DropEvent, MainControl.Drop);
@@ -1063,39 +1068,63 @@ namespace Unlimotion.Views
         private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
             var pointer = e.GetCurrentPoint(this);
+            var control = sender as Control;
+            var gestureControl = control ?? (e.Source as Control);
+
+            if (pointer.Properties.IsRightButtonPressed &&
+                TryGetRoadmapTaskItem(gestureControl, out _))
+            {
+                ClearPendingRoadmapDrag();
+                e.Pointer.Capture(gestureControl ?? this);
+                pendingRoadmapPan = new PendingRoadmapPanContext(
+                    gestureControl ?? this,
+                    e.Pointer,
+                    e.GetPosition(RoadmapEditor),
+                    RoadmapEditor.ViewportLocation);
+                e.Handled = true;
+                return;
+            }
+
             if (!pointer.Properties.IsLeftButtonPressed)
             {
                 ClearPendingRoadmapDrag();
+                ClearPendingRoadmapPan();
                 return;
             }
 
-            var control = sender as Control;
-            var dragControl = control ?? (e.Source as Control);
-            if (!TryGetRoadmapTaskItem(dragControl, out var taskItem))
+            ClearPendingRoadmapPan();
+            if (!TryGetRoadmapTaskItem(gestureControl, out var taskItem))
             {
                 ClearPendingRoadmapDrag();
                 return;
             }
 
-            SelectRoadmapTask(dragControl, taskItem);
+            SelectRoadmapTask(gestureControl, taskItem);
             if (e.ClickCount > 1)
             {
-                OpenRoadmapTaskDetails(dragControl, taskItem);
+                ToggleRoadmapTaskDetails(gestureControl, taskItem);
+                lastRoadmapPointerDoubleTapAt = DateTime.UtcNow;
+                lastRoadmapPointerDoubleTapTaskId = taskItem.Id;
                 ClearPendingRoadmapDrag();
                 e.Handled = true;
                 return;
             }
 
-            e.Pointer.Capture(dragControl);
+            e.Pointer.Capture(gestureControl ?? this);
             pendingRoadmapDrag = new PendingRoadmapDragContext(
-                dragControl ?? this,
+                gestureControl ?? this,
                 e.Pointer,
                 taskItem,
-                e.GetPosition(dragControl ?? this));
+                e.GetPosition(gestureControl ?? this));
         }
 
         private async void InputElement_OnPointerMoved(object? sender, PointerEventArgs e)
         {
+            if (TryHandlePendingRoadmapPan(e))
+            {
+                return;
+            }
+
             var pending = pendingRoadmapDrag;
             if (pending == null ||
                 roadmapDragInProgress ||
@@ -1134,6 +1163,14 @@ namespace Unlimotion.Views
 
         private void InputElement_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
         {
+            if (pendingRoadmapPan != null &&
+                ReferenceEquals(e.Pointer, pendingRoadmapPan.Pointer))
+            {
+                ClearPendingRoadmapPan();
+                e.Handled = true;
+                return;
+            }
+
             if (pendingRoadmapDrag != null &&
                 !ReferenceEquals(e.Pointer, pendingRoadmapDrag.Pointer))
             {
@@ -1141,6 +1178,31 @@ namespace Unlimotion.Views
             }
 
             ClearPendingRoadmapDrag();
+        }
+
+        private bool TryHandlePendingRoadmapPan(PointerEventArgs e)
+        {
+            var pending = pendingRoadmapPan;
+            if (pending == null || !ReferenceEquals(e.Pointer, pending.Pointer))
+            {
+                return false;
+            }
+
+            if (!e.GetCurrentPoint(pending.Control).Properties.IsRightButtonPressed)
+            {
+                ClearPendingRoadmapPan();
+                return true;
+            }
+
+            var zoom = RoadmapEditor.ViewportZoom;
+            var scale = Math.Abs(zoom) < 0.001 ? 1 : zoom;
+            var currentPoint = e.GetPosition(RoadmapEditor);
+            var delta = currentPoint - pending.StartPoint;
+            RoadmapEditor.ViewportLocation = new Point(
+                pending.StartViewportLocation.X - delta.X / scale,
+                pending.StartViewportLocation.Y - delta.Y / scale);
+            e.Handled = true;
+            return true;
         }
 
         private static bool HasExceededRoadmapDragThreshold(Point startPoint, Point currentPoint)
@@ -1179,6 +1241,12 @@ namespace Unlimotion.Views
             pendingRoadmapDrag = null;
         }
 
+        private void ClearPendingRoadmapPan()
+        {
+            pendingRoadmapPan?.Pointer.Capture(null);
+            pendingRoadmapPan = null;
+        }
+
         private void TaskTree_OnDoubleTapped(object? sender, TappedEventArgs e)
         {
             var control = sender as Control;
@@ -1187,16 +1255,28 @@ namespace Unlimotion.Views
                 return;
             }
 
-            OpenRoadmapTaskDetails(control, taskItem);
+            if (ShouldIgnoreDuplicateRoadmapDoubleTap(taskItem))
+            {
+                e.Handled = true;
+                return;
+            }
+
+            ToggleRoadmapTaskDetails(control, taskItem);
             e.Handled = true;
         }
 
-        private MainWindowViewModel? OpenRoadmapTaskDetails(Control? context, TaskItemViewModel taskItem)
+        private bool ShouldIgnoreDuplicateRoadmapDoubleTap(TaskItemViewModel taskItem)
+        {
+            return lastRoadmapPointerDoubleTapTaskId == taskItem.Id &&
+                   DateTime.UtcNow - lastRoadmapPointerDoubleTapAt < TimeSpan.FromMilliseconds(500);
+        }
+
+        private MainWindowViewModel? ToggleRoadmapTaskDetails(Control? context, TaskItemViewModel taskItem)
         {
             var owner = SelectRoadmapTask(context, taskItem);
             if (owner != null)
             {
-                owner.DetailsAreOpen = true;
+                owner.DetailsAreOpen = !owner.DetailsAreOpen;
             }
 
             return owner;
@@ -1258,6 +1338,21 @@ namespace Unlimotion.Views
             public TaskItemViewModel TaskItem { get; } = taskItem;
 
             public Point StartPoint { get; } = startPoint;
+        }
+
+        private sealed class PendingRoadmapPanContext(
+            Control control,
+            IPointer pointer,
+            Point startPoint,
+            Point startViewportLocation)
+        {
+            public Control Control { get; } = control;
+
+            public IPointer Pointer { get; } = pointer;
+
+            public Point StartPoint { get; } = startPoint;
+
+            public Point StartViewportLocation { get; } = startViewportLocation;
         }
 
         private bool Matches(TaskItemViewModel task, string normalizedQuery, bool isFuzzy)

--- a/src/Unlimotion/Views/GraphControl.axaml.cs
+++ b/src/Unlimotion/Views/GraphControl.axaml.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
@@ -37,11 +38,14 @@ namespace Unlimotion.Views
         private bool roadmapScopeSubscriptionsDirty = true;
         private bool graphUpdateQueued;
         private bool highlightUpdateQueued;
+        private PendingRoadmapDragContext? pendingRoadmapDrag;
+        private bool roadmapDragInProgress;
         private int roadmapBuildRequestVersion;
         private int roadmapActiveBuildCount;
         private CancellationTokenSource? currentRoadmapBuildCancellation;
         private RoadmapBuildRequest? pendingRoadmapBuildRequest;
         private const double RoadmapPanStep = 240;
+        private const double RoadmapDragThreshold = 4;
         private static readonly TimeSpan RoadmapGraphUpdateDelay = TimeSpan.FromMilliseconds(100);
 
         public static readonly StyledProperty<bool> RoadmapGraphBuildInProgressProperty =
@@ -72,6 +76,16 @@ namespace Unlimotion.Views
             InitializeComponent();
             AddHandler(DragDrop.DropEvent, MainControl.Drop);
             AddHandler(DragDrop.DragOverEvent, MainControl.DragOver);
+            AddHandler(
+                PointerMovedEvent,
+                InputElement_OnPointerMoved,
+                RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+                true);
+            AddHandler(
+                PointerReleasedEvent,
+                InputElement_OnPointerReleased,
+                RoutingStrategies.Tunnel | RoutingStrategies.Bubble,
+                true);
             KeyDown += RoadmapEditor_KeyDown;
             RoadmapEditor.KeyDown += RoadmapEditor_KeyDown;
         }
@@ -113,6 +127,8 @@ namespace Unlimotion.Views
         public int RoadmapGraphBackgroundBuildCancelRequestCount { get; private set; }
 
         public int RoadmapGraphBackgroundBuildCanceledCount { get; private set; }
+
+        internal int RoadmapDragStartCount { get; private set; }
 
         internal Func<RoadmapGraphBuildInput, IProgress<double>?, CancellationToken, RoadmapGraphProjection>? RoadmapGraphBuildOverride { get; set; }
 
@@ -756,8 +772,12 @@ namespace Unlimotion.Views
 
             if (propertyName is nameof(TaskItemViewModel.Title)
                 or nameof(TaskItemViewModel.TitleWithoutEmoji)
-                or nameof(TaskItemViewModel.OnlyTextTitle)
-                or nameof(TaskItemViewModel.Emoji)
+                or nameof(TaskItemViewModel.OnlyTextTitle))
+            {
+                return false;
+            }
+
+            if (propertyName is nameof(TaskItemViewModel.Emoji)
                 or nameof(TaskItemViewModel.GetAllEmoji))
             {
                 return HasActiveEmojiFilter();
@@ -848,6 +868,16 @@ namespace Unlimotion.Views
 
         private void RoadmapEditor_KeyDown(object? sender, KeyEventArgs e)
         {
+            if (e.Handled || IsTextInputEventSource(e.Source))
+            {
+                return;
+            }
+
+            if (TryExecuteRoadmapCreateHotkey(sender, e))
+            {
+                return;
+            }
+
             switch (e.Key)
             {
                 case Key.F:
@@ -861,6 +891,77 @@ namespace Unlimotion.Views
                     e.Handled = true;
                     break;
             }
+        }
+
+        private bool TryExecuteRoadmapCreateHotkey(object? sender, KeyEventArgs e)
+        {
+            var owner = ResolveMainWindowViewModel(sender as Control ?? e.Source as Control);
+            if (owner == null || !TryGetRoadmapCreateCommand(owner, e, out var command))
+            {
+                return false;
+            }
+
+            if (!command.CanExecute(null))
+            {
+                return false;
+            }
+
+            command.Execute(null);
+            e.Handled = true;
+            return true;
+        }
+
+        private static bool TryGetRoadmapCreateCommand(
+            MainWindowViewModel owner,
+            KeyEventArgs e,
+            out ICommand command)
+        {
+            command = null!;
+
+            if (e.KeyModifiers == KeyModifiers.Control && e.Key == Key.Enter)
+            {
+                command = owner.CreateSibling;
+                return true;
+            }
+
+            if (e.KeyModifiers == KeyModifiers.Shift && e.Key == Key.Enter)
+            {
+                command = owner.CreateBlockedSibling;
+                return true;
+            }
+
+            if (e.KeyModifiers == KeyModifiers.Control && e.Key == Key.Tab)
+            {
+                command = owner.CreateInner;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsTextInputEventSource(object? source)
+        {
+            return source is Control control &&
+                   (IsControlOrAncestor<TextBox>(control) ||
+                    IsControlOrAncestor<AutoCompleteBox>(control) ||
+                    IsControlOrAncestor<NumericUpDown>(control));
+        }
+
+        private static bool IsControlOrAncestor<TControl>(Control control)
+            where TControl : Control
+        {
+            Control? current = control;
+            while (current != null)
+            {
+                if (current is TControl)
+                {
+                    return true;
+                }
+
+                current = current.FindParent<Control>();
+            }
+
+            return false;
         }
 
         private void FitRoadmapToScreen()
@@ -948,10 +1049,7 @@ namespace Unlimotion.Views
         {
             if (sender is Control { DataContext: RoadmapNode node })
             {
-                if (node.SetMeasuredWidth(e.NewSize.Width))
-                {
-                    ScheduleUpdateGraph();
-                }
+                node.SetMeasuredWidth(e.NewSize.Width);
             }
         }
 
@@ -962,46 +1060,204 @@ namespace Unlimotion.Views
                 .ToDictionary(group => group.Key, group => group.First().Width);
         }
 
-        private async void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+        private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
             var pointer = e.GetCurrentPoint(this);
             if (!pointer.Properties.IsLeftButtonPressed)
             {
+                ClearPendingRoadmapDrag();
                 return;
             }
 
             var control = sender as Control;
-            var taskItem = control?.DataContext switch
+            var dragControl = control ?? (e.Source as Control);
+            if (!TryGetRoadmapTaskItem(dragControl, out var taskItem))
             {
-                TaskItemViewModel item => item,
-                RoadmapNode node => node.TaskItem,
-                _ => null
-            };
+                ClearPendingRoadmapDrag();
+                return;
+            }
 
-            if (taskItem == null)
+            SelectRoadmapTask(dragControl, taskItem);
+            if (e.ClickCount > 1)
+            {
+                OpenRoadmapTaskDetails(dragControl, taskItem);
+                ClearPendingRoadmapDrag();
+                e.Handled = true;
+                return;
+            }
+
+            e.Pointer.Capture(dragControl);
+            pendingRoadmapDrag = new PendingRoadmapDragContext(
+                dragControl ?? this,
+                e.Pointer,
+                taskItem,
+                e.GetPosition(dragControl ?? this));
+        }
+
+        private async void InputElement_OnPointerMoved(object? sender, PointerEventArgs e)
+        {
+            var pending = pendingRoadmapDrag;
+            if (pending == null ||
+                roadmapDragInProgress ||
+                !ReferenceEquals(e.Pointer, pending.Pointer))
             {
                 return;
             }
 
-            var mwm = TaskItemViewModel.MainWindowInstance;
-            if (mwm != null)
+            if (!e.GetCurrentPoint(pending.Control).Properties.IsLeftButtonPressed)
             {
-                mwm.CurrentTaskItem = taskItem;
+                ClearPendingRoadmapDrag();
+                return;
             }
 
-            var dragData = new DataObject();
-            dragData.Set(CustomFormat, taskItem);
+            if (!HasExceededRoadmapDragThreshold(
+                    pending.StartPoint,
+                    e.GetPosition(pending.Control)))
+            {
+                return;
+            }
 
-            await DragDrop.DoDragDrop(e, dragData, DragDropEffects.Copy | DragDropEffects.Move | DragDropEffects.Link);
+            pendingRoadmapDrag = null;
+            roadmapDragInProgress = true;
+            e.Handled = true;
+
+            try
+            {
+                await StartRoadmapDragAsync(pending, e);
+            }
+            finally
+            {
+                roadmapDragInProgress = false;
+                ClearPendingRoadmapDrag();
+            }
+        }
+
+        private void InputElement_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (pendingRoadmapDrag != null &&
+                !ReferenceEquals(e.Pointer, pendingRoadmapDrag.Pointer))
+            {
+                return;
+            }
+
+            ClearPendingRoadmapDrag();
+        }
+
+        private static bool HasExceededRoadmapDragThreshold(Point startPoint, Point currentPoint)
+        {
+            return Math.Abs(currentPoint.X - startPoint.X) >= RoadmapDragThreshold ||
+                   Math.Abs(currentPoint.Y - startPoint.Y) >= RoadmapDragThreshold;
+        }
+
+        private static async Task StartRoadmapDragAsync(PendingRoadmapDragContext pending, PointerEventArgs e)
+        {
+            var dragData = new DataObject();
+            dragData.Set(CustomFormat, pending.TaskItem);
+
+            var graphControl = pending.Control.FindParent<GraphControl>();
+            if (graphControl != null)
+            {
+                graphControl.RoadmapDragStartCount++;
+            }
+
+            try
+            {
+                await DragDrop.DoDragDrop(
+                    e,
+                    dragData,
+                    DragDropEffects.Copy | DragDropEffects.Move | DragDropEffects.Link);
+            }
+            finally
+            {
+                pending.Pointer.Capture(null);
+            }
+        }
+
+        private void ClearPendingRoadmapDrag()
+        {
+            pendingRoadmapDrag?.Pointer.Capture(null);
+            pendingRoadmapDrag = null;
         }
 
         private void TaskTree_OnDoubleTapped(object? sender, TappedEventArgs e)
         {
-            var mwm = TaskItemViewModel.MainWindowInstance;
-            if (mwm != null)
+            var control = sender as Control;
+            if (!TryGetRoadmapTaskItem(control ?? (e.Source as Control), out var taskItem))
             {
-                mwm.DetailsAreOpen = !mwm.DetailsAreOpen;
+                return;
             }
+
+            OpenRoadmapTaskDetails(control, taskItem);
+            e.Handled = true;
+        }
+
+        private MainWindowViewModel? OpenRoadmapTaskDetails(Control? context, TaskItemViewModel taskItem)
+        {
+            var owner = SelectRoadmapTask(context, taskItem);
+            if (owner != null)
+            {
+                owner.DetailsAreOpen = true;
+            }
+
+            return owner;
+        }
+
+        private MainWindowViewModel? SelectRoadmapTask(Control? context, TaskItemViewModel taskItem)
+        {
+            var owner = ResolveMainWindowViewModel(context);
+            if (owner == null)
+            {
+                return null;
+            }
+
+            owner.CurrentTaskItem = taskItem;
+            if (owner.GraphMode)
+            {
+                owner.SelectCurrentTask();
+            }
+
+            return owner;
+        }
+
+        private MainWindowViewModel? ResolveMainWindowViewModel(Control? context)
+        {
+            return context?.FindParentDataContext<MainWindowViewModel>() ??
+                   this.FindParentDataContext<MainWindowViewModel>() ??
+                   TaskItemViewModel.MainWindowInstance;
+        }
+
+        private static bool TryGetRoadmapTaskItem(Control? control, out TaskItemViewModel taskItem)
+        {
+            taskItem = null!;
+            if (control == null)
+            {
+                return false;
+            }
+
+            taskItem = (control.DataContext switch
+            {
+                TaskItemViewModel item => item,
+                RoadmapNode node => node.TaskItem,
+                _ => control.FindParentDataContext<RoadmapNode>()?.TaskItem ??
+                     control.FindParentDataContext<TaskItemViewModel>(),
+            })!;
+
+            return taskItem != null;
+        }
+
+        private sealed class PendingRoadmapDragContext(
+            Control control,
+            IPointer pointer,
+            TaskItemViewModel taskItem,
+            Point startPoint)
+        {
+            public Control Control { get; } = control;
+
+            public IPointer Pointer { get; } = pointer;
+
+            public TaskItemViewModel TaskItem { get; } = taskItem;
+
+            public Point StartPoint { get; } = startPoint;
         }
 
         private bool Matches(TaskItemViewModel task, string normalizedQuery, bool isFuzzy)

--- a/src/Unlimotion/Views/GraphControl.axaml.cs
+++ b/src/Unlimotion/Views/GraphControl.axaml.cs
@@ -62,6 +62,16 @@ namespace Unlimotion.Views
                 nameof(RoadmapGraphBuildProgressText),
                 "0%");
 
+        public static readonly StyledProperty<bool> IsRoadmapViewportToolbarExpandedProperty =
+            AvaloniaProperty.Register<GraphControl, bool>(
+                nameof(IsRoadmapViewportToolbarExpanded),
+                true);
+
+        public static readonly StyledProperty<bool> IsRoadmapMinimapExpandedProperty =
+            AvaloniaProperty.Register<GraphControl, bool>(
+                nameof(IsRoadmapMinimapExpanded),
+                true);
+
         public GraphControl()
         {
             graphUpdateTimer = new DispatcherTimer
@@ -123,6 +133,18 @@ namespace Unlimotion.Views
         {
             get => GetValue(RoadmapGraphBuildProgressTextProperty);
             private set => SetValue(RoadmapGraphBuildProgressTextProperty, value);
+        }
+
+        public bool IsRoadmapViewportToolbarExpanded
+        {
+            get => GetValue(IsRoadmapViewportToolbarExpandedProperty);
+            set => SetValue(IsRoadmapViewportToolbarExpandedProperty, value);
+        }
+
+        public bool IsRoadmapMinimapExpanded
+        {
+            get => GetValue(IsRoadmapMinimapExpandedProperty);
+            set => SetValue(IsRoadmapMinimapExpandedProperty, value);
         }
 
         public bool RoadmapLastBuildRanOnUiThread { get; private set; }
@@ -1028,6 +1050,30 @@ namespace Unlimotion.Views
         private void RoadmapPanDown_OnClick(object? sender, RoutedEventArgs e)
         {
             PanRoadmapViewport(0, RoadmapPanStep);
+            e.Handled = true;
+        }
+
+        private void RoadmapViewportToolbarCollapse_OnClick(object? sender, RoutedEventArgs e)
+        {
+            IsRoadmapViewportToolbarExpanded = false;
+            e.Handled = true;
+        }
+
+        private void RoadmapViewportToolbarExpand_OnClick(object? sender, RoutedEventArgs e)
+        {
+            IsRoadmapViewportToolbarExpanded = true;
+            e.Handled = true;
+        }
+
+        private void RoadmapMinimapCollapse_OnClick(object? sender, RoutedEventArgs e)
+        {
+            IsRoadmapMinimapExpanded = false;
+            e.Handled = true;
+        }
+
+        private void RoadmapMinimapExpand_OnClick(object? sender, RoutedEventArgs e)
+        {
+            IsRoadmapMinimapExpanded = true;
             e.Handled = true;
         }
 

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -17,6 +17,7 @@ using Avalonia.VisualTree;
 using ReactiveUI;
 using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
+using Unlimotion.Views.Graph;
 using SearchBarView = Unlimotion.Views.SearchControl.SearchBar;
 using SearchControlView = Unlimotion.Views.SearchControl.SearchControl;
 using L10n = Unlimotion.ViewModel.Localization.Localization;
@@ -773,9 +774,26 @@ namespace Unlimotion.Views
         private static bool TryGetDropTargetTask(DragEventArgs e, out TaskItemViewModel targetTask)
         {
             var control = e.Source as Control;
-            targetTask = control?.FindParentDataContext<TaskWrapperViewModel>()?.TaskItem ??
-                         control?.FindParentDataContext<TaskItemViewModel>()!;
+            targetTask = TryGetDropTargetTask(control)!;
             return targetTask != null;
+        }
+
+        private static TaskItemViewModel? TryGetDropTargetTask(Control? control)
+        {
+            if (control == null)
+            {
+                return null;
+            }
+
+            return control.DataContext switch
+            {
+                TaskWrapperViewModel wrapper => wrapper.TaskItem,
+                TaskItemViewModel task => task,
+                RoadmapNode node => node.TaskItem,
+                _ => control.FindParentDataContext<TaskWrapperViewModel>()?.TaskItem ??
+                     control.FindParentDataContext<TaskItemViewModel>() ??
+                     control.FindParentDataContext<RoadmapNode>()?.TaskItem
+            };
         }
 
         private bool TryBuildOperationItems(


### PR DESCRIPTION
## Summary

- Added a spec and implementation for roadmap task-action parity: task links by drag/drop, global task creation shortcuts, task-card action buttons, and double-click details toggling now work on the roadmap graph path.
- Refined roadmap node pointer handling so single click selection, double-click details toggling, task drag, drop, and right-button panning do not block each other.
- Added manual collapse/expand controls for the roadmap minimap and viewport toolbar so narrow screens can recover graph workspace.
- Added Avalonia.Headless UI coverage for roadmap task gestures and overlay collapse behavior.

## Why

Roadmap graph nodes used a different interaction path from other task views, so common task actions were either unavailable or interfered with graph-level gestures. The minimap and viewport controls were also always expanded, which covered too much graph area on narrow windows.

## Validation

- `dotnet build src\Unlimotion\Unlimotion.csproj --no-restore -v:minimal /nr:false /m:1 /p:UseSharedCompilation=false`
- `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore -m:1 /nr:false /p:UseSharedCompilation=false -v:minimal`
- Targeted `RoadmapGraphUiTests` for overlay collapse, existing overlay controls, node right-drag panning, and node click/double-tap details toggling passed.

## Notes

A full `RoadmapGraphUiTests/*` class run timed out after 6 minutes without output in the local environment, so the PR relies on targeted UI coverage for the affected flows plus successful builds.