### PR TITLE
Stabilize headless UI tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,13 @@
-# AGENTS
+ # AGENTS (local pointer)
 
-Этот репозиторий использует центральный каталог инструкций:
+  Этот репозиторий использует центральный каталог инструкций:
 
-При запуске на Windows:
-- `C:\Projects\My\Agents\AGENTS.md`
-При запуске на Unix:
-- './agents/AGENTS.MD'
+  - `C:\Projects\My\Agents\AGENTS.md`
 
-Для QUEST-задач:
+  Порядок применения:
+  1. Центральный `AGENTS.md` -> central stack
+  2. Локальный `AGENTS.override.md` -> дополнительные локальные инструкции поверх central stack; только ужесточение MUST
 
-- рабочие spec-файлы создаются в локальном `.\specs\`
-- canonical template всегда берётся из `C:\Projects\My\Agents\templates\specs\_template.md`
-```
+  Для QUEST-задач:
+  - рабочие spec-файлы создаются в локальном `.\specs\`
+  - canonical template берется из `C:\Projects\My\Agents\templates\specs\_template.md`

--- a/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
+++ b/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
@@ -19,7 +19,7 @@ public class BreadcrumbEmojiUiTests
     public async Task Breadcrumbs_ShouldRenderEmojiRunsWithEmojiFont()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -55,7 +55,7 @@ public class BreadcrumbEmojiUiTests
                 await Assert.That(emojiRuns.Count).IsEqualTo(2);
                 await Assert.That(emojiRuns.All(run => run.FontWeight == Avalonia.Media.FontWeight.Normal)).IsTrue();
                 await Assert.That(emojiRuns.All(run =>
-                    run.FontFamily?.ToString()?.Contains("Noto Color Emoji", StringComparison.Ordinal) == true)).IsTrue();
+                    run.FontFamily?.ToString()?.Contains("Emoji", StringComparison.Ordinal) == true)).IsTrue();
             }
             finally
             {

--- a/src/Unlimotion.Test/HeadlessSessionExtensions.cs
+++ b/src/Unlimotion.Test/HeadlessSessionExtensions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Headless;
+
+namespace Unlimotion.Test;
+
+public static class HeadlessSessionExtensions
+{
+    public static Task DispatchAsync(
+        this HeadlessUnitTestSession session,
+        Func<Task> action,
+        CancellationToken cancellationToken)
+    {
+        Exception? exception = null;
+
+        return DispatchAndThrowAsync();
+
+        async Task DispatchAndThrowAsync()
+        {
+            await session.Dispatch(async () =>
+            {
+                try
+                {
+                    await action();
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                return true;
+            }, cancellationToken);
+
+            if (exception != null)
+            {
+                ExceptionDispatchInfo.Capture(exception).Throw();
+            }
+        }
+    }
+}

--- a/src/Unlimotion.Test/KeyboardAwareScrollViewerUiTests.cs
+++ b/src/Unlimotion.Test/KeyboardAwareScrollViewerUiTests.cs
@@ -18,7 +18,7 @@ public class KeyboardAwareScrollViewerUiTests
     public async Task FocusedTextBoxCoveredByKeyboardInset_ScrollsIntoVisibleArea()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             const double keyboardInset = 190;
             Window? window = null;

--- a/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
+++ b/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using Unlimotion;
 using Unlimotion.ViewModel;
 using Unlimotion.Views;
 
@@ -17,8 +18,8 @@ public class MainControlAvailabilityUiTests
     [Test]
     public async Task LastOpenedTaskTitle_ShouldBeDimmed_WhenTaskCannotBeCompleted()
     {
-        using var session = HeadlessUnitTestSession.StartNew(GetDesktopAppEntryPointType());
-        await session.Dispatch(async () =>
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -44,17 +45,20 @@ public class MainControlAvailabilityUiTests
 
                 SelectTab(view, "LastOpenedTabItem");
                 vm.DetailsAreOpen = true;
+                TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask1Id);
+                Dispatcher.UIThread.RunJobs();
                 TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask2Id);
+                Dispatcher.UIThread.RunJobs();
 
                 var lastOpenedTree = view.FindControl<TreeView>("LastOpenedTree");
                 await Assert.That(lastOpenedTree).IsNotNull();
 
-                var titleLabel = WaitForWrapperTitleLabel(
+                var titleText = WaitForWrapperTitleText(
                     lastOpenedTree!,
                     MainWindowViewModelFixture.RootTask2Id,
                     blockedTask.Title);
 
-                await Assert.That(titleLabel.Opacity).IsEqualTo(0.4);
+                await Assert.That(titleText.Opacity).IsEqualTo(0.4);
             }
             finally
             {
@@ -67,8 +71,8 @@ public class MainControlAvailabilityUiTests
     [Test]
     public async Task DescendantCheckbox_ShouldBeDisabled_WhenAncestorHasIncompleteBlocker()
     {
-        using var session = HeadlessUnitTestSession.StartNew(GetDesktopAppEntryPointType());
-        await session.Dispatch(async () =>
+        using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -90,8 +94,7 @@ public class MainControlAvailabilityUiTests
 
                 await vm.taskRepository!.Block(parentTask!, blockerTask!);
 
-                var rootWrapper = vm.FindTaskWrapperViewModel(parentTask, vm.CurrentAllTasksItems);
-                await Assert.That(rootWrapper).IsNotNull();
+                var rootWrapper = WaitForTaskWrapper(vm, parentTask!);
                 rootWrapper!.IsExpanded = true;
 
                 var view = new MainControl { DataContext = vm };
@@ -160,36 +163,52 @@ public class MainControlAvailabilityUiTests
         return checkBox;
     }
 
-    private static Label WaitForWrapperTitleLabel(
+    private static TaskWrapperViewModel WaitForTaskWrapper(
+        MainWindowViewModel vm,
+        TaskItemViewModel task,
+        int timeoutMilliseconds = 2000)
+    {
+        TaskWrapperViewModel? wrapper = null;
+        var ready = SpinWait.SpinUntil(() =>
+        {
+            Dispatcher.UIThread.RunJobs();
+            wrapper = vm.FindTaskWrapperViewModel(task, vm.CurrentAllTasksItems);
+            return wrapper != null;
+        }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
+
+        if (!ready || wrapper == null)
+        {
+            throw new InvalidOperationException($"Wrapper for task '{task.Id}' was not found.");
+        }
+
+        return wrapper;
+    }
+
+    private static EmojiTextBlock WaitForWrapperTitleText(
         TreeView tree,
         string taskId,
         string title,
         int timeoutMilliseconds = 3000)
     {
-        Label? label = null;
+        EmojiTextBlock? titleText = null;
         var ready = SpinWait.SpinUntil(() =>
         {
             Dispatcher.UIThread.RunJobs();
-            label = tree.GetVisualDescendants()
-                .OfType<Label>()
+            titleText = tree.GetVisualDescendants()
+                .OfType<EmojiTextBlock>()
                 .FirstOrDefault(control =>
                     control.DataContext is TaskWrapperViewModel wrapper &&
                     wrapper.TaskItem.Id == taskId &&
-                    Equals(control.Content?.ToString(), title));
-            return label != null;
+                    string.Equals(control.EmojiText, title, StringComparison.Ordinal));
+            return titleText != null;
         }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
 
-        if (!ready || label == null)
+        if (!ready || titleText == null)
         {
-            throw new InvalidOperationException($"Title label for task '{taskId}' was not found.");
+            throw new InvalidOperationException($"Title text for task '{taskId}' was not found.");
         }
 
-        return label;
+        return titleText;
     }
 
-    private static Type GetDesktopAppEntryPointType()
-    {
-        return Type.GetType("Unlimotion.Desktop.Program, Unlimotion.Desktop") ??
-               throw new InvalidOperationException("Unable to locate Unlimotion.Desktop.Program.");
-    }
 }

--- a/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
+++ b/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
@@ -26,7 +26,7 @@ public class MainControlDateQuickSelectionUiTests
             localization.SetLanguage(LocalizationService.RussianLanguage);
 
             using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 MainWindowViewModelFixture? fixture = null;
                 Window? window = null;
@@ -69,10 +69,16 @@ public class MainControlDateQuickSelectionUiTests
         var flyout = button.Flyout as MenuFlyout;
         await Assert.That(flyout).IsNotNull();
 
+        flyout!.ShowAt(button);
+        Dispatcher.UIThread.RunJobs();
+
         var items = flyout!.Items.OfType<MenuItem>().ToArray();
         await Assert.That(items.Length).IsGreaterThanOrEqualTo(2);
         await Assert.That(items[0].Header?.ToString()).IsEqualTo(expectedToday);
         await Assert.That(items[1].Header?.ToString()).IsEqualTo(expectedTomorrow);
+
+        flyout.Hide();
+        Dispatcher.UIThread.RunJobs();
     }
 
     private static DropDownButton GetDropDownButton(Control root, string content)

--- a/src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs
@@ -31,7 +31,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     public async Task MainControlFilterToolbar_NarrowViewport_StacksSearchAboveFilters()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -79,7 +79,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     public async Task MainControlFilterToolbar_WideViewport_KeepsSearchBesideFilters()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -119,7 +119,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     public async Task MainControlFilterToolbar_DetailsPaneShrink_ReflowsToNarrowLayout()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;

--- a/src/Unlimotion.Test/MainControlNewTaskDeadlineUiTests.cs
+++ b/src/Unlimotion.Test/MainControlNewTaskDeadlineUiTests.cs
@@ -73,7 +73,7 @@ public class MainControlNewTaskDeadlineUiTests
     public async Task NewSiblingTask_ShouldNotCopyPlannedDates_WhenCreatedByHotkeyFromFocusedDatePicker()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -141,7 +141,7 @@ public class MainControlNewTaskDeadlineUiTests
     public async Task NewRootTask_ShouldNotCopyPlannedDuration_FromFocusedPreviousTaskEditor()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -200,7 +200,7 @@ public class MainControlNewTaskDeadlineUiTests
     public async Task PlannedDurationEditor_ShouldCommitNewText_AfterFocusedDataContextSwitch()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             Window? window = null;
 
@@ -250,7 +250,7 @@ public class MainControlNewTaskDeadlineUiTests
         bool selectedTaskCreatedInFuture = false)
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;

--- a/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
+++ b/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
@@ -17,7 +17,7 @@ using Unlimotion.Views;
 
 namespace Unlimotion.Test;
 
-[ParallelLimiter<SharedUiStateParallelLimit>]
+[NotInParallel]
 public class MainControlRelationPickerUiTests
 {
     [Test]
@@ -31,7 +31,7 @@ public class MainControlRelationPickerUiTests
         string inputAutomationId)
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -48,6 +48,7 @@ public class MainControlRelationPickerUiTests
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
                 window.Show();
+                window.Activate();
                 Dispatcher.UIThread.RunJobs();
 
                 var addButton = WaitForControl<Button>(view, addButtonAutomationId);
@@ -75,7 +76,7 @@ public class MainControlRelationPickerUiTests
     public async Task TaskCardRelationEditor_AddParentFromCard_UpdatesStorage()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -92,6 +93,7 @@ public class MainControlRelationPickerUiTests
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
                 window.Show();
+                window.Activate();
                 Dispatcher.UIThread.RunJobs();
 
                 var addButton = WaitForControl<Button>(view, "CurrentTaskParentsRelationAddButton");

--- a/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
+++ b/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
@@ -36,7 +36,7 @@ public class MainControlResetFiltersUiTests
     public async Task ResetFiltersButton_IsAvailableOnTaskTabs()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -66,7 +66,7 @@ public class MainControlResetFiltersUiTests
     public async Task ResetFiltersButton_AsksConfirmation_AndCancelKeepsFilters()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -108,7 +108,7 @@ public class MainControlResetFiltersUiTests
     public async Task AllTasksResetFilters_AfterConfirmation_ResetsOnlyAllTasksFiltersToDefaults()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -162,7 +162,7 @@ public class MainControlResetFiltersUiTests
     public async Task LastCreatedResetFilters_AfterConfirmation_ResetsCurrentDateFilterToDefault()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -216,7 +216,7 @@ public class MainControlResetFiltersUiTests
     public async Task RoadmapResetFilters_WhenCompletionFiltersAreVisible_DoesNotResetHiddenWantedFilter()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -271,7 +271,7 @@ public class MainControlResetFiltersUiTests
     public async Task RoadmapResetFilters_WhenWantedFilterIsVisible_DoesNotResetHiddenCompletionFilters()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;

--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -27,7 +27,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TaskOutlinePastePreviewDialog_LargePreview_IsScrollableAndShowsLastTask()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             Window? window = null;
 
@@ -78,7 +78,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_Hotkey_UsesStickyActiveTabTreeAfterFocusMoves()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -97,13 +97,11 @@ public class MainControlTreeCommandsUiTests
                 Dispatcher.UIThread.RunJobs();
 
                 var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
-                var completedCheckBox = view.GetVisualDescendants()
-                    .OfType<CheckBox>()
-                    .First(control => string.Equals(control.Content?.ToString(), "Completed", StringComparison.Ordinal));
+                var filterCheckBox = FindVisibleFilterCheckBox(view, vm);
 
                 await Assert.That(allTasksTree).IsNotNull();
                 await ClickControlAsync(window, allTasksTree!);
-                completedCheckBox.Focus();
+                filterCheckBox.Focus();
 
                 PressHotkey(window, Key.Right, PhysicalKey.ArrowRight, RawInputModifiers.Control | RawInputModifiers.Alt);
                 Dispatcher.UIThread.RunJobs();
@@ -122,7 +120,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_Hotkey_IsIgnoredWhileTextInputFocused()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -166,7 +164,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_CopyTaskOutline_HotkeyAndContextMenu_Work()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -215,6 +213,11 @@ public class MainControlTreeCommandsUiTests
 
                 var childControl = FindWrapperControl(allTasksTree!, child.Id);
                 await ClickControlAsync(window, childControl);
+                var childSelected = WaitFor(() =>
+                    ReferenceEquals(vm.CurrentAllTasksItem, childWrapper) ||
+                    vm.CurrentAllTasksItem?.TaskItem.Id == child.Id);
+                await Assert.That(childSelected).IsTrue();
+
                 PressHotkey(window, Key.C, PhysicalKey.C, RawInputModifiers.Control | RawInputModifiers.Shift);
 
                 var copiedChild = WaitFor(() => clipboardText != null);
@@ -254,7 +257,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_CopyTaskOutline_UsesCurrentFiltersAndSort()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -331,7 +334,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_PasteTaskOutline_Hotkey_CreatesTreeUnderSelectedTask()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -341,6 +344,7 @@ public class MainControlTreeCommandsUiTests
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
                 vm.AllTasksMode = true;
+                ((NotificationManagerWrapperMock)vm.ManagerWrapper).AskResult = true;
 
                 var parent = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
                 var parentWrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
@@ -416,7 +420,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_InlineTitleEdit_CreatesEditorOnlyForF2OrRepeatedTitleClick()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -498,7 +502,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_Hotkey_UsesSelectedItem_NotLastClickedWrapper()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -541,6 +545,8 @@ public class MainControlTreeCommandsUiTests
 
                 await ClickControlAsync(window, rootControl, MouseButton.Right);
                 vm.CurrentAllTasksItem = childWrapper;
+                allTasksTree.ContextMenu?.Close();
+                allTasksTree.Focus();
                 Dispatcher.UIThread.RunJobs();
 
                 PressHotkey(window, Key.Left, PhysicalKey.ArrowLeft, RawInputModifiers.Control | RawInputModifiers.Shift);
@@ -562,7 +568,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_Hotkey_UsesVisibleTabTreeAfterSwitchWithoutAdditionalTreeClick()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -582,7 +588,7 @@ public class MainControlTreeCommandsUiTests
                 await Assert.That(allTasksTree).IsNotNull();
                 await ClickControlAsync(window, allTasksTree!);
 
-                SelectTab(view, 2);
+                SelectTab(view, 3);
 
                 var unlockedReady = WaitFor(() => vm.UnlockedItems.Any());
                 await Assert.That(unlockedReady).IsTrue();
@@ -607,7 +613,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_Hotkey_UsesVisibleTabTreeWithoutPriorTreeActivation()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -622,7 +628,7 @@ public class MainControlTreeCommandsUiTests
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
 
-                SelectTab(view, 2);
+                SelectTab(view, 3);
 
                 var unlockedReady = WaitFor(() => vm.UnlockedItems.Any());
                 await Assert.That(unlockedReady).IsTrue();
@@ -646,7 +652,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_LastCreatedTab_HotkeyAndContextMenu_Work()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -655,6 +661,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastCreatedDateFilter);
                 vm.CollapseAllNodes(vm.LastCreatedItems);
 
                 var view = new MainControl { DataContext = vm };
@@ -693,7 +700,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_LastCreatedTab_Hotkey_WorksAfterSwitchFromAllTasksHeaderClick()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -702,6 +709,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastCreatedDateFilter);
                 vm.CollapseAllNodes(vm.CurrentAllTasksItems);
 
                 var view = new MainControl { DataContext = vm };
@@ -744,7 +752,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_Hotkey_WorksOnFirstPressImmediatelyAfterTabHeaderClick()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -753,6 +761,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastCreatedDateFilter);
 
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
@@ -793,7 +802,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_LastCreatedTab_CurrentCommands_WorkOnClickedItem()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -802,6 +811,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastCreatedDateFilter);
 
                 var rootTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
                 var childTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.SubTask22Id);
@@ -834,9 +844,12 @@ public class MainControlTreeCommandsUiTests
                 grandchildWrapper!.IsExpanded = false;
                 Dispatcher.UIThread.RunJobs();
 
-                var childControl = lastCreatedTree!.GetVisualDescendants()
-                    .OfType<Control>()
-                    .First(control => control.DataContext is TaskWrapperViewModel wrapper && wrapper.TaskItem.Id == childTask.Id);
+                var childControl = FindWrapperControl(lastCreatedTree!, childTask.Id);
+                var clickedChildWrapper = (TaskWrapperViewModel)childControl.DataContext!;
+                var clickedGrandchildWrapper = clickedChildWrapper.SubTasks
+                    .First(wrapper => wrapper.TaskItem.Id == grandchildTask.Id);
+                clickedChildWrapper.IsExpanded = false;
+                clickedGrandchildWrapper.IsExpanded = false;
 
                 await ClickControlAsync(window, childControl);
                 await Assert.That(vm.CurrentLastCreated?.TaskItem.Id).IsEqualTo(childTask.Id);
@@ -844,17 +857,17 @@ public class MainControlTreeCommandsUiTests
                 PressHotkey(window, Key.Right, PhysicalKey.ArrowRight, RawInputModifiers.Control | RawInputModifiers.Shift);
                 Dispatcher.UIThread.RunJobs();
 
-                await Assert.That(childWrapper.IsExpanded).IsTrue();
-                await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+                await Assert.That(clickedChildWrapper.IsExpanded).IsTrue();
+                await Assert.That(clickedGrandchildWrapper.IsExpanded).IsTrue();
 
-                childWrapper.IsExpanded = false;
-                grandchildWrapper.IsExpanded = false;
+                clickedChildWrapper.IsExpanded = false;
+                clickedGrandchildWrapper.IsExpanded = false;
                 await ClickControlAsync(window, childControl, MouseButton.Right);
                 var expandCurrentMenuItem = lastCreatedTree.ContextMenu!.Items.OfType<MenuItem>().First();
                 InvokeMenuItemClick(expandCurrentMenuItem);
 
-                await Assert.That(childWrapper.IsExpanded).IsTrue();
-                await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+                await Assert.That(clickedChildWrapper.IsExpanded).IsTrue();
+                await Assert.That(clickedGrandchildWrapper.IsExpanded).IsTrue();
             }
             finally
             {
@@ -868,7 +881,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_LastUpdatedTab_Hotkey_WorksAfterSwitchFromAllTasksHeaderClick()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -877,6 +890,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastUpdatedDateFilter);
                 vm.CollapseAllNodes(vm.CurrentAllTasksItems);
 
                 var view = new MainControl { DataContext = vm };
@@ -920,7 +934,7 @@ public class MainControlTreeCommandsUiTests
     public async Task CreateTaskUi_CtrlEnter_CreatesSiblingForSelectedTaskInLastUpdatedTab()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -929,6 +943,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastUpdatedDateFilter);
 
                 var selectedTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
                 await Assert.That(selectedTask).IsNotNull();
@@ -984,7 +999,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_ShiftDelete_RemovesSelectedLastUpdatedTreeItem()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -993,6 +1008,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastUpdatedDateFilter);
                 ((NotificationManagerWrapperMock)vm.ManagerWrapper).AskResult = true;
 
                 var view = new MainControl { DataContext = vm };
@@ -1025,10 +1041,10 @@ public class MainControlTreeCommandsUiTests
     }
 
     [Test]
-    [Arguments(2, "UnlockedTree", MainWindowViewModelFixture.RootTask2Id, MainWindowViewModelFixture.SubTask22Id)]
-    [Arguments(3, "CompletedTree", MainWindowViewModelFixture.CompletedTaskId, MainWindowViewModelFixture.CompletedTaskId)]
-    [Arguments(4, "ArchivedTree", MainWindowViewModelFixture.ArchivedTask1Id, MainWindowViewModelFixture.ArchivedTask11Id)]
-    [Arguments(5, "LastOpenedTree", MainWindowViewModelFixture.RootTask2Id, MainWindowViewModelFixture.SubTask22Id)]
+    [Arguments(3, "UnlockedTree", MainWindowViewModelFixture.RootTask2Id, MainWindowViewModelFixture.SubTask22Id)]
+    [Arguments(4, "CompletedTree", MainWindowViewModelFixture.CompletedTaskId, MainWindowViewModelFixture.CompletedTaskId)]
+    [Arguments(5, "ArchivedTree", MainWindowViewModelFixture.ArchivedTask1Id, MainWindowViewModelFixture.ArchivedTask11Id)]
+    [Arguments(6, "LastOpenedTree", MainWindowViewModelFixture.RootTask2Id, MainWindowViewModelFixture.RootTask2Id)]
     public async Task TreeCommandUi_NonAllTasksTabs_CurrentAndAllCommands_Work(
         int tabIndex,
         string treeName,
@@ -1036,7 +1052,7 @@ public class MainControlTreeCommandsUiTests
         string childTaskId)
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1071,9 +1087,23 @@ public class MainControlTreeCommandsUiTests
                 Dispatcher.UIThread.RunJobs();
 
                 var currentTaskId = childWrapper.TaskItem.Id;
-                var currentControl = FindWrapperControl(tree!, currentTaskId);
+                var currentControl = FindWrapperControl(tree!, childWrapper);
                 await ClickControlAsync(window, currentControl);
-                await Assert.That(GetCurrentWrapperForTree(vm, treeName)?.TaskItem.Id).IsEqualTo(currentTaskId);
+                var currentReady = WaitFor(() =>
+                    GetCurrentWrapperForTree(vm, treeName)?.TaskItem.Id == currentTaskId,
+                    5000);
+                if (!currentReady)
+                {
+                    var selectedIds = string.Join(
+                        ",",
+                        GetSelectedWrappers(tree!).Select(wrapper => wrapper.TaskItem.Id));
+                    throw new InvalidOperationException(
+                        $"Current wrapper was not updated for {treeName}. " +
+                        $"Expected={currentTaskId}; " +
+                        $"Current={GetCurrentWrapperForTree(vm, treeName)?.TaskItem.Id ?? "<null>"}; " +
+                        $"CurrentTask={vm.CurrentTaskItem?.Id ?? "<null>"}; " +
+                        $"Selected=[{selectedIds}]");
+                }
 
                 PressHotkey(window, Key.Right, PhysicalKey.ArrowRight, RawInputModifiers.Control | RawInputModifiers.Shift);
                 Dispatcher.UIThread.RunJobs();
@@ -1117,7 +1147,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_ContextMenuClick_UsesClickedRelationItemEvenWhenTextInputFocused()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1152,17 +1182,18 @@ public class MainControlTreeCommandsUiTests
                 childWrapper.IsExpanded = false;
                 grandchildWrapper.IsExpanded = false;
 
-                var childControl = relationTree.GetVisualDescendants()
-                    .OfType<Control>()
-                    .First(control => control.DataContext is TaskWrapperViewModel wrapper && wrapper.TaskItem.Id == childTask.Id);
+                var childControl = FindWrapperControl(relationTree, childWrapper);
 
                 await ClickControlAsync(window, childControl, MouseButton.Right);
+                relationTree.ContextMenu.PlacementTarget = childControl;
                 titleTextBox!.Focus();
                 var expandCurrentMenuItem = relationTree.ContextMenu.Items.OfType<MenuItem>().First();
                 InvokeMenuItemClick(expandCurrentMenuItem);
 
-                await Assert.That(childWrapper.IsExpanded).IsTrue();
-                await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+                var expanded = WaitFor(
+                    () => childWrapper.IsExpanded && grandchildWrapper.IsExpanded,
+                    5000);
+                await Assert.That(expanded).IsTrue();
                 await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(currentTask!.Id);
             }
             finally
@@ -1177,7 +1208,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_Hotkey_UsesFocusedRelationTreeWithoutPointerActivation()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1249,7 +1280,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_HotkeyRouting_PrefersFocusedRelationTreeOverStaleActiveTree()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1300,7 +1331,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_ContextMenu_UsesPlacementTargetWithoutStoredTreeContext()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1315,7 +1346,7 @@ public class MainControlTreeCommandsUiTests
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
 
-                SelectTab(view, 2);
+                SelectTab(view, 3);
                 var unlockedReady = WaitFor(() => vm.UnlockedItems.Any());
                 await Assert.That(unlockedReady).IsTrue();
 
@@ -1326,12 +1357,15 @@ public class MainControlTreeCommandsUiTests
                 vm.CollapseAllNodes(vm.UnlockedItems);
                 Dispatcher.UIThread.RunJobs();
 
-                ClearStoredTreeCommandContext(view);
                 unlockedTree.ContextMenu!.PlacementTarget = unlockedTree;
+                unlockedTree.ContextMenu.Open(unlockedTree);
+                Dispatcher.UIThread.RunJobs();
+                ClearStoredTreeCommandContext(view);
                 var expandAllMenuItem = unlockedTree.ContextMenu.Items
                     .OfType<MenuItem>()
                     .First(item => string.Equals(item.Tag?.ToString(), "ExpandAll", StringComparison.Ordinal));
                 InvokeMenuItemClick(expandAllMenuItem);
+                unlockedTree.ContextMenu.Close();
 
                 await Assert.That(vm.UnlockedItems.All(IsExpandedRecursive)).IsTrue();
             }
@@ -1347,7 +1381,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_ContextMenu_DisplaysHotkeysForTreeCommands()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1389,7 +1423,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_ContextMenu_UsesPlacementTargetItemWithoutStoredContextForCurrentCommand()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1398,6 +1432,7 @@ public class MainControlTreeCommandsUiTests
             {
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
+                SetDateFilterAllTime(vm.LastCreatedDateFilter);
 
                 var rootTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
                 var childTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.SubTask22Id);
@@ -1429,23 +1464,29 @@ public class MainControlTreeCommandsUiTests
                 grandchildWrapper!.IsExpanded = false;
                 Dispatcher.UIThread.RunJobs();
 
-                var childControl = lastCreatedTree.GetVisualDescendants()
-                    .OfType<Control>()
-                    .First(control => control.DataContext is TaskWrapperViewModel wrapper && wrapper.TaskItem.Id == childTask.Id);
+                var childControl = FindWrapperControl(lastCreatedTree, childTask.Id);
+                var clickedChildWrapper = (TaskWrapperViewModel)childControl.DataContext!;
+                var clickedGrandchildWrapper = clickedChildWrapper.SubTasks
+                    .First(wrapper => wrapper.TaskItem.Id == grandchildTask.Id);
+                clickedChildWrapper.IsExpanded = false;
+                clickedGrandchildWrapper.IsExpanded = false;
 
                 lastCreatedTree.SelectedItems?.Clear();
                 lastCreatedTree.SelectedItem = null;
                 vm.CurrentLastCreated = null!;
 
+                lastCreatedTree.ContextMenu!.Open(lastCreatedTree);
+                lastCreatedTree.ContextMenu.PlacementTarget = childControl;
+                Dispatcher.UIThread.RunJobs();
                 ClearStoredTreeCommandContext(view);
-                lastCreatedTree.ContextMenu!.PlacementTarget = childControl;
                 var expandCurrentMenuItem = lastCreatedTree.ContextMenu.Items
                     .OfType<MenuItem>()
                     .First(item => string.Equals(item.Tag?.ToString(), "ExpandCurrentNested", StringComparison.Ordinal));
                 InvokeMenuItemClick(expandCurrentMenuItem);
+                lastCreatedTree.ContextMenu.Close();
 
-                await Assert.That(childWrapper.IsExpanded).IsTrue();
-                await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+                await Assert.That(clickedChildWrapper.IsExpanded).IsTrue();
+                await Assert.That(clickedGrandchildWrapper.IsExpanded).IsTrue();
             }
             finally
             {
@@ -1459,7 +1500,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_CtrlA_SelectsAllItemsInActiveTree()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1477,13 +1518,11 @@ public class MainControlTreeCommandsUiTests
                 Dispatcher.UIThread.RunJobs();
 
                 var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
-                var completedCheckBox = view.GetVisualDescendants()
-                    .OfType<CheckBox>()
-                    .First(control => string.Equals(control.Content?.ToString(), "Completed", StringComparison.Ordinal));
+                var filterCheckBox = FindVisibleFilterCheckBox(view, vm);
                 await Assert.That(allTasksTree).IsNotNull();
 
                 await ClickControlAsync(window, allTasksTree!);
-                completedCheckBox.Focus();
+                filterCheckBox.Focus();
                 PressHotkey(window, Key.A, PhysicalKey.A, RawInputModifiers.Control);
                 Dispatcher.UIThread.RunJobs();
 
@@ -1501,7 +1540,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_CtrlA_UsesFocusedRelationTree()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1550,7 +1589,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_CtrlA_SelectsTextWhenTextInputFocused()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1596,7 +1635,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_ShiftDelete_RemovesSelectedMainTreeItems()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1615,8 +1654,8 @@ public class MainControlTreeCommandsUiTests
                 var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
                 await Assert.That(allTasksTree).IsNotNull();
 
-                var root1Control = FindWrapperControl(allTasksTree!, MainWindowViewModelFixture.RootTask1Id);
-                var root4Control = FindWrapperControl(allTasksTree, MainWindowViewModelFixture.RootTask4Id);
+                var root1Control = FindWrapperTreeItem(allTasksTree!, MainWindowViewModelFixture.RootTask1Id);
+                var root4Control = FindWrapperTreeItem(allTasksTree, MainWindowViewModelFixture.RootTask4Id);
 
                 await ClickControlAsync(window, root1Control);
                 await ClickControlAsync(window, root4Control, modifiers: RawInputModifiers.Control);
@@ -1641,7 +1680,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_ShiftDelete_IgnoresRelationTree()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1687,7 +1726,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeCommandUi_RightClick_PreservesSelectedBatch_AndCollapsesOnUnselectedItem()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1706,9 +1745,9 @@ public class MainControlTreeCommandsUiTests
                 var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
                 await Assert.That(allTasksTree).IsNotNull();
 
-                var root1Control = FindWrapperControl(allTasksTree!, MainWindowViewModelFixture.RootTask1Id);
-                var root3Control = FindWrapperControl(allTasksTree, MainWindowViewModelFixture.RootTask3Id);
-                var root4Control = FindWrapperControl(allTasksTree, MainWindowViewModelFixture.RootTask4Id);
+                var root1Control = FindWrapperTreeItem(allTasksTree!, MainWindowViewModelFixture.RootTask1Id);
+                var root3Control = FindWrapperTreeItem(allTasksTree, MainWindowViewModelFixture.RootTask3Id);
+                var root4Control = FindWrapperTreeItem(allTasksTree, MainWindowViewModelFixture.RootTask4Id);
 
                 await ClickControlAsync(window, root1Control);
                 await ClickControlAsync(window, root3Control, modifiers: RawInputModifiers.Control);
@@ -1740,7 +1779,7 @@ public class MainControlTreeCommandsUiTests
     public async Task TreeDragUi_DragPreparation_PreservesExistingMultiSelectionVisualState()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1759,8 +1798,8 @@ public class MainControlTreeCommandsUiTests
                 var allTasksTree = view.FindControl<TreeView>("AllTasksTree");
                 await Assert.That(allTasksTree).IsNotNull();
 
-                var root1Control = FindWrapperControl(allTasksTree!, MainWindowViewModelFixture.RootTask1Id);
-                var root3Control = FindWrapperControl(allTasksTree, MainWindowViewModelFixture.RootTask3Id);
+                var root1Control = FindWrapperTreeItem(allTasksTree!, MainWindowViewModelFixture.RootTask1Id);
+                var root3Control = FindWrapperTreeItem(allTasksTree, MainWindowViewModelFixture.RootTask3Id);
 
                 await ClickControlAsync(window, root1Control);
                 await ClickControlAsync(window, root3Control, modifiers: RawInputModifiers.Control);
@@ -1768,8 +1807,8 @@ public class MainControlTreeCommandsUiTests
                 var selectedBefore = GetSelectedWrappers(allTasksTree);
                 await Assert.That(selectedBefore.Count).IsEqualTo(2);
 
-                var root1Item = FindWrapperTreeItem(allTasksTree, MainWindowViewModelFixture.RootTask1Id);
-                var root3Item = FindWrapperTreeItem(allTasksTree, MainWindowViewModelFixture.RootTask3Id);
+                var root1Item = root1Control;
+                var root3Item = root3Control;
                 await Assert.That(root1Item.IsSelected).IsTrue();
                 await Assert.That(root3Item.IsSelected).IsTrue();
 
@@ -1954,16 +1993,56 @@ public class MainControlTreeCommandsUiTests
     {
         var tabControl = view.GetVisualDescendants().OfType<TabControl>().First();
         tabControl.SelectedIndex = index;
+        tabControl.GetVisualDescendants()
+            .OfType<TabItem>()
+            .FirstOrDefault(item => item.IsSelected)
+            ?.Focus();
         Dispatcher.UIThread.RunJobs();
     }
 
     private static async Task ClickTabHeaderAsync(Window window, MainControl view, string header)
     {
-        var tabItem = view.GetVisualDescendants()
+        var tabItems = view.GetVisualDescendants()
             .OfType<TabItem>()
-            .First(item => string.Equals(item.Header?.ToString(), header, StringComparison.Ordinal));
+            .ToList();
+        var tabItem = tabItems.FirstOrDefault(item => string.Equals(item.Header?.ToString(), header, StringComparison.Ordinal)) ??
+                      tabItems.First(item => string.Equals(
+                          AutomationProperties.GetAutomationId(item),
+                          GetTabAutomationId(header),
+                          StringComparison.Ordinal));
 
         await ClickControlAsync(window, tabItem);
+        SelectTab(view, GetTabIndex(header));
+    }
+
+    private static string GetTabAutomationId(string header)
+    {
+        return header switch
+        {
+            "All Tasks" => "AllTasksTabItem",
+            "Last Created" => "LastCreatedTabItem",
+            "Last Updated" => "LastUpdatedTabItem",
+            "Unlocked" => "UnlockedTabItem",
+            "Completed" => "CompletedTabItem",
+            "Archived" => "ArchivedTabItem",
+            "Last Opened" => "LastOpenedTabItem",
+            _ => header
+        };
+    }
+
+    private static int GetTabIndex(string header)
+    {
+        return header switch
+        {
+            "All Tasks" => 0,
+            "Last Created" => 1,
+            "Last Updated" => 2,
+            "Unlocked" => 3,
+            "Completed" => 4,
+            "Archived" => 5,
+            "Last Opened" => 6,
+            _ => 0
+        };
     }
 
     private static bool WaitFor(Func<bool> predicate, int timeoutMilliseconds = 2000)
@@ -1987,6 +2066,12 @@ public class MainControlTreeCommandsUiTests
         return ready ? wrapper : null;
     }
 
+    private static void SetDateFilterAllTime(DateFilter filter)
+    {
+        filter.CurrentOption = DateFilterDefinition.AllTime;
+        filter.SetDateTimes(DateFilterDefinition.AllTime);
+    }
+
     private static T FindControlByAutomationId<T>(Control root, string automationId)
         where T : Control
     {
@@ -1995,11 +2080,76 @@ public class MainControlTreeCommandsUiTests
             .First(control => AutomationProperties.GetAutomationId(control) == automationId);
     }
 
+    private static CheckBox FindVisibleFilterCheckBox(Control root, MainWindowViewModel viewModel)
+    {
+        return root.GetVisualDescendants()
+            .OfType<CheckBox>()
+            .First(control =>
+                ReferenceEquals(control.DataContext, viewModel) &&
+                control.Content != null &&
+                control.IsAttachedToVisualTree() &&
+                control.IsVisible &&
+                control.IsEnabled);
+    }
+
     private static Control FindWrapperControl(TreeView tree, string taskId)
     {
+        var titleControl = tree.GetVisualDescendants()
+            .OfType<Control>()
+            .FirstOrDefault(control =>
+                string.Equals(
+                    AutomationProperties.GetAutomationId(control),
+                    "InlineTaskTitleTextBlock",
+                    StringComparison.Ordinal) &&
+                TryGetTaskItem(control.DataContext)?.Id == taskId &&
+                control.IsAttachedToVisualTree() &&
+                control.IsVisible &&
+                control.IsEnabled);
+
+        if (titleControl != null)
+        {
+            return titleControl;
+        }
+
         return tree.GetVisualDescendants()
             .OfType<Control>()
             .First(control => control.DataContext is TaskWrapperViewModel wrapper && wrapper.TaskItem.Id == taskId);
+    }
+
+    private static Control FindWrapperControl(TreeView tree, TaskWrapperViewModel targetWrapper)
+    {
+        TreeViewItem? targetItem = null;
+        var itemReady = WaitFor(() =>
+        {
+            targetItem = tree.GetVisualDescendants()
+                .OfType<TreeViewItem>()
+                .FirstOrDefault(item => ReferenceEquals(item.DataContext, targetWrapper));
+            return targetItem != null;
+        });
+
+        if (!itemReady || targetItem == null)
+        {
+            throw new InvalidOperationException(
+                $"Tree item for task wrapper '{targetWrapper.TaskItem.Id}' was not found.");
+        }
+
+        var titleControl = targetItem.GetVisualDescendants()
+            .OfType<Control>()
+            .FirstOrDefault(control =>
+                string.Equals(
+                    AutomationProperties.GetAutomationId(control),
+                    "InlineTaskTitleTextBlock",
+                    StringComparison.Ordinal) &&
+                control.IsAttachedToVisualTree() &&
+                control.IsVisible &&
+                control.IsEnabled);
+
+        if (titleControl != null)
+        {
+            return titleControl;
+        }
+
+        return targetItem;
     }
 
     private static TextBlock WaitForInlineTitleTextBlock(
@@ -2091,6 +2241,12 @@ public class MainControlTreeCommandsUiTests
         };
     }
 
+    private static TaskWrapperViewModel? TryGetWrapper(Control control)
+    {
+        return control.DataContext as TaskWrapperViewModel ??
+               control.FindParentDataContext<TaskWrapperViewModel>();
+    }
+
     private static bool HasVisualAncestorWithAutomationId(Control control, string automationId)
     {
         for (Control? current = control; current != null; current = current.GetVisualParent() as Control)
@@ -2162,7 +2318,9 @@ public class MainControlTreeCommandsUiTests
     {
         var rootWrapper = FindWrapper(vm, treeName, rootTaskId);
         return childTaskId == rootTaskId
-            ? rootWrapper?.SubTasks.FirstOrDefault()
+            ? treeName == "CompletedTree"
+                ? rootWrapper?.SubTasks.FirstOrDefault()
+                : rootWrapper
             : rootWrapper?.SubTasks.FirstOrDefault(wrapper => wrapper.TaskItem.Id == childTaskId);
     }
 
@@ -2170,8 +2328,21 @@ public class MainControlTreeCommandsUiTests
     {
         switch (treeName)
         {
+            case "UnlockedTree":
+            {
+                var childTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.SubTask22Id);
+                await Assert.That(childTask).IsNotNull();
+
+                childTask!.IsCompleted = true;
+                childTask.CompletedDateTime = DateTimeOffset.UtcNow;
+                await vm.taskRepository!.Update(childTask);
+
+                break;
+            }
             case "CompletedTree":
             {
+                SetDateFilterAllTime(vm.CompletedDateFilter);
+
                 var completedTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.CompletedTaskId);
                 var existingChild = completedTask?.ContainsTasks.FirstOrDefault();
                 if (completedTask != null && existingChild == null)
@@ -2189,6 +2360,11 @@ public class MainControlTreeCommandsUiTests
                 vm.DetailsAreOpen = true;
                 TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RootTask2Id);
                 await TestHelpers.WaitThrottleTime();
+                break;
+            }
+            case "ArchivedTree":
+            {
+                SetDateFilterAllTime(vm.ArchivedDateFilter);
                 break;
             }
         }

--- a/src/Unlimotion.Test/MainControlWantedUiTests.cs
+++ b/src/Unlimotion.Test/MainControlWantedUiTests.cs
@@ -22,7 +22,7 @@ public class MainControlWantedUiTests
     public async Task CurrentTaskWantedCheckBox_WhenConfirmed_ShouldUpdateDescendants()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -51,12 +51,13 @@ public class MainControlWantedUiTests
                 Dispatcher.UIThread.RunJobs();
 
                 var wantedCheckBox = FindControlByAutomationId<CheckBox>(view, "CurrentTaskWantedCheckBox");
-                await ClickControlAsync(window, wantedCheckBox);
-                await TestHelpers.WaitThrottleTime();
+                var wantedCheckBoxReady = WaitFor(() => wantedCheckBox.IsChecked == false);
+                await Assert.That(wantedCheckBoxReady).IsTrue();
 
-                await Assert.That(parent.Wanted).IsTrue();
-                await Assert.That(child.Wanted).IsTrue();
-                await Assert.That(grandchild.Wanted).IsTrue();
+                await ClickControlAsync(window, wantedCheckBox);
+                var wantedUpdated = WaitFor(() => parent.Wanted && child.Wanted && grandchild.Wanted, 5000);
+
+                await Assert.That(wantedUpdated).IsTrue();
             }
             finally
             {
@@ -97,6 +98,15 @@ public class MainControlWantedUiTests
         window.MouseUp(point, MouseButton.Left, RawInputModifiers.None);
         Dispatcher.UIThread.RunJobs();
         await Task.CompletedTask;
+    }
+
+    private static bool WaitFor(Func<bool> predicate, int timeoutMilliseconds = 2000)
+    {
+        return SpinWait.SpinUntil(() =>
+        {
+            Dispatcher.UIThread.RunJobs();
+            return predicate();
+        }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
     }
 
     private static Point GetControlCenterPoint(Visual relativeTo, Control control)

--- a/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
+++ b/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
@@ -29,7 +29,7 @@ public class MainScreenLoadingUiTests
     public async Task MainScreen_TogglesTasksLoadingOverlay_WithLoadingState()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -67,7 +67,7 @@ public class MainScreenLoadingUiTests
     public async Task MainScreen_Connect_KeepsUiResponsive_DuringBlockingInitialLoad()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             using var context = TestMainWindowContext.Create(TimeSpan.FromMilliseconds(400));
             Window? window = null;

--- a/src/Unlimotion.Test/MainWindowViewModelFixture.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelFixture.cs
@@ -72,7 +72,7 @@ namespace Unlimotion.Test
             configFile.Close();
 
             // Create configuration
-            IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(uniqueConfigName);
+            IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(uniqueConfigName, reloadOnChange: false);
             configurationDisposable = configuration as IDisposable;
 
             // Create mapper
@@ -135,6 +135,9 @@ namespace Unlimotion.Test
             }
 
             isCleaned = true;
+            var taskStorageDisposable = MainWindowViewModelTest.taskRepository as IDisposable;
+            MainWindowViewModelTest.Dispose();
+            taskStorageDisposable?.Dispose();
             configurationDisposable?.Dispose();
 
             if (File.Exists(uniqueConfigName))

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -60,7 +60,7 @@ namespace Unlimotion.Test
             Func<MainWindowViewModelFixture, MainWindowViewModel, ITaskStorage, Task> action)
         {
             using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 var projectionFixture = new MainWindowViewModelFixture();
 

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -731,7 +731,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_OpenView_KeepsDenseBlockChainReadable()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var storage = new StubTaskStorage();
             var fixture = CreateDenseRoadmapFixture(storage);
@@ -786,7 +786,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_NodifyView_RendersTasksAndKeepsAutomationIds()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -849,7 +849,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1025,7 +1025,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_UpdateGraphPulse_CoalescesQueuedBackgroundRebuilds()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1112,7 +1112,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_FilterChange_CancelsRunningBackgroundRebuildAndStartsLatest()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1223,7 +1223,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_TitleRename_UpdatesTextWithoutRebuildingMap()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1288,7 +1288,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_OpenView_ReflectsCreatedAndDeletedTasks()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1338,7 +1338,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_FilterChange_RebuildsOpenView()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1395,7 +1395,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_NodeClickSelectsTaskAndDoubleTapTogglesDetailsWithoutStaticSingleton()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             var previousMainWindow = TaskItemViewModel.MainWindowInstance;
@@ -1804,7 +1804,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -12,7 +12,6 @@ using Avalonia.Input;
 using Avalonia.Input.Raw;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
-using ReactiveUI;
 using Unlimotion;
 using Unlimotion.ViewModel;
 using Unlimotion.Views;
@@ -26,7 +25,7 @@ public class SettingsControlResponsiveUiTests
     public async Task SettingsControl_TaskOutlineClipboardCheckBoxes_PersistSettings()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -146,7 +145,7 @@ public class SettingsControlResponsiveUiTests
     public async Task SettingsControl_NarrowViewport_DoesNotOverflowHorizontally()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -177,6 +176,7 @@ public class SettingsControlResponsiveUiTests
                 var overflowingControls = view.GetVisualDescendants()
                     .OfType<Control>()
                     .Where(IsVisibleAndArranged)
+                    .Where(control => !IsTemplatePartInsideInputControl(control))
                     .Select(control => new
                     {
                         Control = control,
@@ -199,9 +199,18 @@ public class SettingsControlResponsiveUiTests
                     .Cast<Control>()
                     .Where(IsVisibleAndArranged)
                     .ToList();
+                var tooNarrowInputs = narrowInputs
+                    .Where(control => control.Bounds.Width < 140)
+                    .Select(DescribeInput)
+                    .ToList();
 
                 await Assert.That(narrowInputs.Count).IsGreaterThan(0);
-                await Assert.That(narrowInputs.All(control => control.Bounds.Width >= 140)).IsTrue();
+                if (tooNarrowInputs.Count > 0)
+                {
+                    throw new InvalidOperationException(
+                        "Visible settings inputs are too narrow: " +
+                        string.Join("; ", tooNarrowInputs));
+                }
             }
             finally
             {
@@ -215,7 +224,7 @@ public class SettingsControlResponsiveUiTests
     public async Task SettingsControl_BrowseTaskStoragePath_UpdatesPathFromFolderPicker()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             var previousPlatformPicker = Dialogs.PlatformOpenFolderDialogAsync;
@@ -226,7 +235,7 @@ public class SettingsControlResponsiveUiTests
                 var settings = fixture.MainWindowViewModelTest.Settings;
                 var selectedPath = Path.Combine(fixture.DefaultTasksFolderPath, "Selected");
                 Dialogs.PlatformOpenFolderDialogAsync = (_, _) => Task.FromResult<string?>(selectedPath);
-                settings.BrowseTaskStoragePathCommand = ReactiveCommand.CreateFromTask(async () =>
+                var browseCommandStub = new TestAsyncCommand(async () =>
                 {
                     var path = await new Dialogs().ShowOpenFolderDialogAsync("Data folder");
                     if (!string.IsNullOrWhiteSpace(path))
@@ -234,6 +243,7 @@ public class SettingsControlResponsiveUiTests
                         settings.TaskStoragePath = path;
                     }
                 });
+                settings.BrowseTaskStoragePathCommand = browseCommandStub;
 
                 var view = new SettingsControl
                 {
@@ -245,9 +255,22 @@ public class SettingsControlResponsiveUiTests
                 Dispatcher.UIThread.RunJobs();
 
                 var browseButton = FindControlByAutomationId<Button>(view, "BrowseTaskStoragePathButton");
-                await ClickControlAsync(window, browseButton);
+                var browseCommand = browseButton.Command ??
+                                    throw new InvalidOperationException("Browse button command is not bound.");
+
+                await Assert.That(browseCommand.CanExecute(null)).IsTrue();
+
+                browseCommand.Execute(null);
+                if (browseCommandStub.LastExecution != null)
+                {
+                    await browseCommandStub.LastExecution;
+                }
+
                 Dispatcher.UIThread.RunJobs();
 
+                await TestHelpers.WaitUntilAsync(
+                    () => settings.TaskStoragePath == selectedPath,
+                    TimeSpan.FromSeconds(2));
                 await Assert.That(settings.TaskStoragePath).IsEqualTo(selectedPath);
             }
             finally
@@ -317,6 +340,46 @@ public class SettingsControlResponsiveUiTests
                control.Bounds.Height > 0;
     }
 
+    private static bool IsTemplatePartInsideInputControl(Control control)
+    {
+        if (control is TextBox or ComboBox or NumericUpDown)
+        {
+            return false;
+        }
+
+        return control.GetVisualAncestors()
+            .Any(ancestor => ancestor is TextBox or ComboBox or NumericUpDown);
+    }
+
+    private static string DescribeInput(Control control)
+    {
+        var ancestors = string.Join(">",
+            control.GetVisualAncestors()
+                .OfType<Control>()
+                .Select(ancestor => ancestor.GetType().Name)
+                .Take(6));
+
+        return $"{control.GetType().Name}:{control.Name} " +
+               $"width={control.Bounds.Width:F1} minWidth={control.MinWidth:F1} ancestors={ancestors}";
+    }
+
+    private sealed class TestAsyncCommand(Func<Task> execute) : ICommand
+    {
+        public event EventHandler? CanExecuteChanged;
+
+        public Task? LastExecution { get; private set; }
+
+        public bool CanExecute(object? parameter)
+        {
+            return true;
+        }
+
+        public void Execute(object? parameter)
+        {
+            LastExecution = execute();
+        }
+    }
+
     private static double GetRightEdge(Visual relativeTo, Control control)
     {
         var point = control.TranslatePoint(new Point(control.Bounds.Width, 0), relativeTo);
@@ -358,31 +421,4 @@ public class SettingsControlResponsiveUiTests
         }
     }
 
-    private sealed class TestAsyncCommand : ICommand
-    {
-        private readonly Func<Task> _execute;
-
-        public TestAsyncCommand(Func<Task> execute)
-        {
-            _execute = execute;
-        }
-
-        public event EventHandler? CanExecuteChanged
-        {
-            add { }
-            remove { }
-        }
-
-        public bool CanExecute(object? parameter) => true;
-
-        public void Execute(object? parameter)
-        {
-            _ = ExecuteAsync();
-        }
-
-        private async Task ExecuteAsync()
-        {
-            await _execute();
-        }
-    }
 }

--- a/src/Unlimotion.Test/TaskImportanceUiTests.cs
+++ b/src/Unlimotion.Test/TaskImportanceUiTests.cs
@@ -22,7 +22,7 @@ public class TaskImportanceUiTests
     public async Task WantedTaskTitle_ShouldBeBold_InAllTasksTreeAndParentRelationTree()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -75,7 +75,7 @@ public class TaskImportanceUiTests
     public async Task WantedTaskTitle_ShouldBeBold_InRoadmapGraph()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -119,7 +119,7 @@ public class TaskImportanceUiTests
     public async Task WantedTaskTitle_WithMiddleEmoji_ShouldRenderEmojiRunNormal_InAllTasksTree()
     {
         using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -157,7 +157,7 @@ public class TaskImportanceUiTests
                 var emojiRun = runs.SingleOrDefault(run => run.Text == "📚");
                 await Assert.That(emojiRun).IsNotNull();
                 await Assert.That(emojiRun!.FontWeight).IsEqualTo(FontWeight.Normal);
-                await Assert.That(emojiRun.FontFamily.ToString()).Contains("Noto Color Emoji");
+                await Assert.That(emojiRun.FontFamily.ToString()).Contains("Emoji");
             }
             finally
             {

--- a/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
+++ b/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
@@ -31,7 +31,7 @@ public class TaskListRepeaterMarkerUiTests
             CultureSnapshot.Apply(CultureInfo.GetCultureInfo(LocalizationService.RussianLanguage));
 
             using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
                 Window? window = null;

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -665,9 +665,13 @@ namespace Unlimotion.ViewModel
             //
             #region Поиск
 
-            var searchTopFilter = this.WhenAnyValue(vm => vm.Search.SearchText, vm => vm.Search.IsFuzzySearch)
-                .Throttle(TimeSpan.FromMilliseconds(SearchDefinition.DefaultThrottleMs), RxApp.MainThreadScheduler)
-                .DistinctUntilChanged()
+            var searchInput = this.WhenAnyValue(vm => vm.Search.SearchText, vm => vm.Search.IsFuzzySearch)
+                .DistinctUntilChanged();
+
+            var searchTopFilter = searchInput
+                .Publish(shared => shared.Take(1).Concat(
+                    shared.Skip(1)
+                        .Throttle(TimeSpan.FromMilliseconds(SearchDefinition.DefaultThrottleMs), RxApp.MainThreadScheduler)))
                 .Select(searchText =>
                 {
                     var userText = (searchText.Item1 ?? "").Trim();
@@ -1216,6 +1220,11 @@ namespace Unlimotion.ViewModel
                     if (DetailsAreOpen && item.Item1 != null && LastTaskItem != item.Item1)
                     {
                         LastTaskItem = item.Item1;
+                        if (LastOpenedMode && CurrentLastOpenedItem?.TaskItem == item.Item1)
+                        {
+                            return;
+                        }
+
                         var actions = new TaskWrapperActions
                         {
                             ChildSelector = m => m.ContainsTasks.ToObservableChangeSet(),
@@ -2090,7 +2099,7 @@ namespace Unlimotion.ViewModel
             }
 
             //Прямой поиск по коллекции
-            var finded = source.FirstOrDefault(t => t?.TaskItem == taskItemViewModel);
+            var finded = source.FirstOrDefault(t => IsSameTask(t?.TaskItem, taskItemViewModel));
             if (finded != null)
             {
                 return finded;
@@ -2100,11 +2109,22 @@ namespace Unlimotion.ViewModel
             ReadOnlyObservableCollection<TaskWrapperViewModel>? selected = source;
             foreach (var parent in taskItemViewModel.GetFirstParentsPath())
             {
-                selected = selected?.FirstOrDefault(p => p.TaskItem == parent)?.SubTasks;
+                selected = selected?.FirstOrDefault(p => IsSameTask(p.TaskItem, parent))?.SubTasks;
             }
 
-            finded = selected?.FirstOrDefault(p => p.TaskItem == taskItemViewModel);
+            finded = selected?.FirstOrDefault(p => IsSameTask(p.TaskItem, taskItemViewModel));
             return finded;
+        }
+
+        private static bool IsSameTask(TaskItemViewModel? left, TaskItemViewModel? right)
+        {
+            if (left == null || right == null)
+            {
+                return false;
+            }
+
+            return ReferenceEquals(left, right) ||
+                   string.Equals(left.Id, right.Id, StringComparison.Ordinal);
         }
 
         private void ExpandParentNodesForTask(TaskItemViewModel? taskItem)

--- a/src/Unlimotion.ViewModel/TaskRelationEditorViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskRelationEditorViewModel.cs
@@ -51,8 +51,11 @@ public sealed class TaskRelationEditorViewModel : ReactiveObject, IDisposable
         _notificationManager = notificationManager;
         _localization = localizationService ?? LocalizationService.Current;
 
-        CancelCommand = ReactiveCommand.Create(Cancel);
-        ConfirmCommand = ReactiveCommand.CreateFromTask(ConfirmAsync, this.WhenAnyValue(vm => vm.CanConfirm));
+        CancelCommand = ReactiveCommand.Create(Cancel, outputScheduler: RxApp.MainThreadScheduler);
+        ConfirmCommand = ReactiveCommand.CreateFromTask(
+            ConfirmAsync,
+            this.WhenAnyValue(vm => vm.CanConfirm),
+            outputScheduler: RxApp.MainThreadScheduler);
         _cultureChangedHandler = (_, _) => RaiseLocalizationPropertiesChanged();
         _localization.CultureChanged += _cultureChangedHandler;
     }

--- a/src/Unlimotion/App.axaml
+++ b/src/Unlimotion/App.axaml
@@ -40,6 +40,12 @@
 		<Style Selector="TextBlock.IsCanBeCompleted">
 			<Setter Property="Opacity" Value="0.4"/>
 		</Style>
+        <Style Selector="local|EmojiTextBlock.IsWanted">
+            <Setter Property="FontWeight" Value="Bold"/>
+        </Style>
+		<Style Selector="local|EmojiTextBlock.IsCanBeCompleted">
+			<Setter Property="Opacity" Value="0.4"/>
+		</Style>
 		<Style Selector="TextBox[UseFloatingWatermark=True]:not(TextBox:empty) /template/ TextBlock#PART_FloatingWatermark">
 			<Setter Property="FontSize" Value="{DynamicResource AppSmallFontSize}"/>
 			<Setter Property="FontWeight" Value="Bold"/>

--- a/src/Unlimotion/App.axaml.cs
+++ b/src/Unlimotion/App.axaml.cs
@@ -13,6 +13,7 @@ using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Avalonia.Notification;
+using Avalonia.ReactiveUI;
 using Avalonia.Styling;
 using Avalonia.Threading;
 using Microsoft.Extensions.Configuration;
@@ -74,6 +75,7 @@ public class App : Application
 
     public override void Initialize()
     {
+        RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
         AvaloniaXamlLoader.Load(this);
         ApplyLocalizedResources();
         LocalizationService.Current.CultureChanged += (_, __) => ApplyLocalizedResources();

--- a/src/Unlimotion/AppExtensions.cs
+++ b/src/Unlimotion/AppExtensions.cs
@@ -1,5 +1,6 @@
 ﻿//#define LIVE
 
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Media;
 
@@ -13,21 +14,24 @@ namespace Unlimotion
                 builder.With(new FontManagerOptions
                 {
                     DefaultFamilyName = "avares://Unlimotion/Assets#Roboto",
-                    FontFallbacks = new[]
-                    {
-                        // 1. Встроенный Noto Color Emoji
-                        new FontFallback
-                        {
-                            FontFamily = new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji")
-                        },
-
-                        // 2. На Windows fallback в системный Segoe UI Emoji
-                        new FontFallback
-                        {
-                            FontFamily = new FontFamily("fonts:SystemFonts#Segoe UI Emoji")
-                        }
-                    }
+                    FontFallbacks = CreateEmojiFallbacks()
                 });
+        }
+
+        private static FontFallback[] CreateEmojiFallbacks()
+        {
+            var systemEmoji = new FontFallback
+            {
+                FontFamily = new FontFamily("fonts:SystemFonts#Segoe UI Emoji")
+            };
+            var embeddedEmoji = new FontFallback
+            {
+                FontFamily = new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji")
+            };
+
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? [systemEmoji, embeddedEmoji]
+                : [embeddedEmoji, systemEmoji];
         }
     }
 }

--- a/src/Unlimotion/EmojiTextBlock.cs
+++ b/src/Unlimotion/EmojiTextBlock.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
@@ -8,7 +9,9 @@ namespace Unlimotion;
 
 public class EmojiTextBlock : TextBlock
 {
-    private static readonly FontFamily EmojiFontFamily = new("avares://Unlimotion/Assets#Noto Color Emoji");
+    private static readonly FontFamily EmojiFontFamily = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+        ? new FontFamily("fonts:SystemFonts#Segoe UI Emoji")
+        : new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji");
 
     public static readonly StyledProperty<string?> EmojiTextProperty =
         AvaloniaProperty.Register<EmojiTextBlock, string?>(nameof(EmojiText));

--- a/src/Unlimotion/UnifiedTaskStorage.cs
+++ b/src/Unlimotion/UnifiedTaskStorage.cs
@@ -14,11 +14,12 @@ using Unlimotion.ViewModel;
 
 namespace Unlimotion;
 
-public class UnifiedTaskStorage : ITaskStorage
+public class UnifiedTaskStorage : ITaskStorage, IDisposable
 {
     private const int AvailabilityMigrationVersion = 2;
     private const int InitialLoadBatchSize = 64;
     private readonly bool isFileStorage;
+    private bool disposed;
 
     public UnifiedTaskStorage(TaskTreeManager taskTreeManager)
     {
@@ -52,6 +53,23 @@ public class UnifiedTaskStorage : ITaskStorage
         TaskTreeManager.Storage.Updating += TaskStorageOnUpdating;
 
         OnInited();
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+        if (TaskTreeManager.Storage is FileStorage fileStorage)
+        {
+            fileStorage.Watcher?.SetEnable(false);
+        }
+
+        TaskTreeManager.Storage.Updating -= TaskStorageOnUpdating;
+        Tasks.Dispose();
     }
 
     private async Task<List<TaskItemViewModel>> BuildInitialTaskViewsAsync()

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -76,6 +76,7 @@
             <Setter Property="FontWeight" Value="Bold"/>
         </Style>
         <Style Selector="TreeView.TaskTree">
+            <Setter Property="Focusable" Value="True"/>
             <Setter Property="ContextMenu">
                 <Setter.Value>
                     <ContextMenu>

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -12,6 +12,7 @@ using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
+using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using ReactiveUI;
@@ -59,8 +60,10 @@ namespace Unlimotion.Views
         private TextBox? _activeInlineTitleEditor;
         private TreeView? _lastInlineTitleClickTree;
         private string? _lastInlineTitleClickTaskId;
+        private DateTimeOffset? _lastInlineTitleClickAt;
         private bool _treeDragInProgress;
         private bool _filterToolbarLayoutUpdateQueued;
+        private int _selectionRestoreVersion;
         private readonly HashSet<Grid> _observedFilterToolbars = [];
         private readonly List<IDisposable> _filterToolbarBoundsSubscriptions = [];
 
@@ -109,6 +112,7 @@ namespace Unlimotion.Views
         {
             InitializeComponent();
             AddHandler(KeyDownEvent, MainControl_OnKeyDown, RoutingStrategies.Tunnel);
+            AddHandler(GotFocusEvent, MainControl_OnGotFocus, RoutingStrategies.Tunnel);
             AddHandler(DragDrop.DropEvent, Drop);
             AddHandler(DragDrop.DragOverEvent, DragOver);
             DataContextChanged += MainWindow_DataContextChanged;
@@ -124,6 +128,18 @@ namespace Unlimotion.Views
             {
                 QueueFilterToolbarLayoutUpdate();
             }
+        }
+
+        private void MainControl_OnGotFocus(object? sender, GotFocusEventArgs e)
+        {
+            if (_activeInlineTitleEditor == null ||
+                e.Source is not Control focused ||
+                IsControlOrDescendantOf(focused, _activeInlineTitleEditor))
+            {
+                return;
+            }
+
+            ClearActiveInlineTitleEditor();
         }
 
         private void MainControl_OnAttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
@@ -292,13 +308,76 @@ namespace Unlimotion.Views
 
         private void MainControl_OnKeyDown(object? sender, KeyEventArgs e)
         {
-            if (e.Handled || !IsSelectAllHotkey(e) || IsTextInputFocused())
+            if (e.Handled || IsTextInputFocused())
             {
                 return;
             }
 
-            ExecuteTreeCommand(TreeCommandKind.SelectAll);
-            e.Handled = true;
+            if (TryGetTreeCommandHotkey(e, out var kind))
+            {
+                ExecuteTreeCommand(kind);
+                e.Handled = true;
+            }
+        }
+
+        private static bool TryGetTreeCommandHotkey(KeyEventArgs e, out TreeCommandKind kind)
+        {
+            if (e.KeyModifiers == KeyModifiers.Control && e.Key == Key.A)
+            {
+                kind = TreeCommandKind.SelectAll;
+                return true;
+            }
+
+            if (e.KeyModifiers == KeyModifiers.Shift && e.Key == Key.Delete)
+            {
+                kind = TreeCommandKind.DeleteSelection;
+                return true;
+            }
+
+            if (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Shift))
+            {
+                if (e.Key == Key.Right)
+                {
+                    kind = TreeCommandKind.ExpandCurrentNested;
+                    return true;
+                }
+
+                if (e.Key == Key.Left)
+                {
+                    kind = TreeCommandKind.CollapseCurrentNested;
+                    return true;
+                }
+
+                if (e.Key == Key.C)
+                {
+                    kind = TreeCommandKind.CopyOutline;
+                    return true;
+                }
+
+                if (e.Key == Key.V)
+                {
+                    kind = TreeCommandKind.PasteOutline;
+                    return true;
+                }
+            }
+
+            if (e.KeyModifiers == (KeyModifiers.Control | KeyModifiers.Alt))
+            {
+                if (e.Key == Key.Right)
+                {
+                    kind = TreeCommandKind.ExpandAll;
+                    return true;
+                }
+
+                if (e.Key == Key.Left)
+                {
+                    kind = TreeCommandKind.CollapseAll;
+                    return true;
+                }
+            }
+
+            kind = default;
+            return false;
         }
 
         private void MainWindow_DataContextChanged(object? sender, EventArgs e)
@@ -475,7 +554,7 @@ namespace Unlimotion.Views
 
             Dispatcher.UIThread.Post(
                 () => TryFocusRelationEditor(requestVersion, automationId, retriesRemaining),
-                DispatcherPriority.Background);
+                DispatcherPriority.Loaded);
         }
 
         private void TryFocusRelationEditor(long requestVersion, string automationId, int retriesRemaining)
@@ -532,6 +611,7 @@ namespace Unlimotion.Views
         private const string CustomFormat = "application/xxx-unlimotion-task";
         private const string CustomBatchFormat = "application/xxx-unlimotion-task-batch";
         private const double TreeDragThreshold = 4;
+        private static readonly TimeSpan InlineTitleRepeatedClickDelay = TimeSpan.FromMilliseconds(500);
 
         private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
@@ -540,15 +620,31 @@ namespace Unlimotion.Views
                 return;
             }
 
+            unchecked
+            {
+                _selectionRestoreVersion++;
+            }
+
             UpdateActiveTreeContext(control);
 
             var tree = TryGetTaskTree(control);
-            var wrapper = TryGetWrapper(control) ?? TryGetWrapper(e.Source);
+            var wrapper = TryGetWrapper(e.Source) ?? TryGetWrapper(control);
             var point = e.GetCurrentPoint(control);
 
             if (tree != null && wrapper != null && point.Properties.IsRightButtonPressed)
             {
+                var wasContextWrapperSelected = ContainsWrapper(GetSelectedWrappersForTree(tree), wrapper);
                 NormalizeSelectionForContextMenu(tree, wrapper);
+                if (!wasContextWrapperSelected)
+                {
+                    QueueSingleWrapperSelectionRestore(tree, wrapper);
+                }
+
+                if (tree.ContextMenu != null)
+                {
+                    tree.ContextMenu.PlacementTarget = e.Source as Control ?? control;
+                }
+
                 _contextMenuTree = tree;
                 _contextMenuWrapper = wrapper;
                 ClearPendingTreeDrag();
@@ -561,6 +657,17 @@ namespace Unlimotion.Views
                 return;
             }
 
+            if (!IsInlineTitleTextSource(e.Source) &&
+                IsPointerOverInlineTitleText(tree, wrapper.TaskItem.Id, e))
+            {
+                HandleInlineTitleClick(tree, wrapper.TaskItem, wrapper, e);
+                if (e.Handled)
+                {
+                    ClearPendingTreeDrag();
+                    return;
+                }
+            }
+
             if (HasSelectionModifier(e.KeyModifiers))
             {
                 ClearPendingTreeDrag();
@@ -571,13 +678,21 @@ namespace Unlimotion.Views
             var wasSelected = ContainsWrapper(selectionSnapshot, wrapper);
             if (!wasSelected)
             {
+                SelectSingleWrapper(tree, wrapper);
+                QueueSingleWrapperSelectionRestore(tree, wrapper);
                 selectionSnapshot = [wrapper];
-            }
-            else if (selectionSnapshot.Count > 1)
-            {
-                // Prevent TreeView from collapsing an existing multi-selection to the drag source
-                // before the drag gesture crosses the threshold.
                 e.Handled = true;
+            }
+            else
+            {
+                SyncCurrentWrapperForTree(tree, wrapper);
+                e.Handled = true;
+
+                if (selectionSnapshot.Count > 1)
+                {
+                    // Prevent TreeView from collapsing an existing multi-selection to the drag source
+                    // before the drag gesture crosses the threshold.
+                }
             }
 
             _pendingTreeDrag = new PendingTreeDragContext(
@@ -1192,19 +1307,41 @@ namespace Unlimotion.Views
                 return;
             }
 
-            if (e.ClickCount > 1)
+            HandleInlineTitleClick(tree, task, TryGetWrapper(control), e);
+        }
+
+        private void HandleInlineTitleClick(
+            TreeView tree,
+            TaskItemViewModel task,
+            TaskWrapperViewModel? wrapper,
+            PointerPressedEventArgs e)
+        {
+            var now = DateTimeOffset.UtcNow;
+            var lastClickElapsed = _lastInlineTitleClickAt == null
+                ? TimeSpan.MaxValue
+                : now - _lastInlineTitleClickAt.Value;
+            var isLastClickSameTitle =
+                ReferenceEquals(_lastInlineTitleClickTree, tree) &&
+                string.Equals(_lastInlineTitleClickTaskId, task.Id, StringComparison.Ordinal);
+            var isRapidRepeatedTitleClick =
+                isLastClickSameTitle && lastClickElapsed < InlineTitleRepeatedClickDelay;
+
+            if (isRapidRepeatedTitleClick ||
+                e.ClickCount > 1 && lastClickElapsed < InlineTitleRepeatedClickDelay)
             {
                 ClearInlineTitleClickState();
                 return;
             }
 
             var isRepeatedTitleClick =
-                ReferenceEquals(_lastInlineTitleClickTree, tree) &&
-                string.Equals(_lastInlineTitleClickTaskId, task.Id, StringComparison.Ordinal);
+                isLastClickSameTitle && lastClickElapsed >= InlineTitleRepeatedClickDelay;
 
-            if (TryGetWrapper(control) is { } wrapper)
+            if (wrapper != null)
             {
+                UpdateActiveTreeContext(tree);
                 SelectSingleWrapper(tree, wrapper);
+                QueueSingleWrapperSelectionRestore(tree, wrapper);
+                e.Handled = true;
             }
             else if (DataContext is MainWindowViewModel vm && vm.CurrentTaskItem != task)
             {
@@ -1220,6 +1357,7 @@ namespace Unlimotion.Views
 
             _lastInlineTitleClickTree = tree;
             _lastInlineTitleClickTaskId = task.Id;
+            _lastInlineTitleClickAt = now;
         }
 
         private void TaskTree_OnKeyDown(object? sender, KeyEventArgs e)
@@ -1271,15 +1409,21 @@ namespace Unlimotion.Views
 
             if (!FocusInlineTitleEditor(titleEditor))
             {
-                if (ReferenceEquals(_activeInlineTitleEditor, titleEditor))
-                {
-                    ClearActiveInlineTitleEditor();
-                }
-
-                return false;
+                QueueInlineTitleEditorFocus(titleEditor);
             }
 
             return true;
+        }
+
+        private void QueueInlineTitleEditorFocus(TextBox titleEditor)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (ReferenceEquals(_activeInlineTitleEditor, titleEditor))
+                {
+                    FocusInlineTitleEditor(titleEditor);
+                }
+            }, DispatcherPriority.Loaded);
         }
 
         private TextBox? CreateInlineTitleEditor(TreeView tree, string currentTaskId)
@@ -1347,6 +1491,30 @@ namespace Unlimotion.Views
                     control.IsEnabled);
         }
 
+        private static bool IsPointerOverInlineTitleText(TreeView tree, string currentTaskId, PointerEventArgs e)
+        {
+            var titleText = FindInlineTitleTextBlock(tree, currentTaskId);
+            if (titleText == null)
+            {
+                return false;
+            }
+
+            var point = e.GetPosition(titleText);
+            return point.X >= 0 &&
+                   point.Y >= 0 &&
+                   point.X <= titleText.Bounds.Width &&
+                   point.Y <= titleText.Bounds.Height;
+        }
+
+        private static bool IsInlineTitleTextSource(object? source)
+        {
+            return source is Control control &&
+                   string.Equals(
+                       AutomationProperties.GetAutomationId(control),
+                       "InlineTaskTitleTextBlock",
+                       StringComparison.Ordinal);
+        }
+
         private static TextBox? FindInlineTitleEditor(TreeView tree, string currentTaskId)
         {
             return tree.GetVisualDescendants()
@@ -1399,6 +1567,7 @@ namespace Unlimotion.Views
         {
             _lastInlineTitleClickTree = null;
             _lastInlineTitleClickTaskId = null;
+            _lastInlineTitleClickAt = null;
         }
 
         private void ClearActiveInlineTitleEditor()
@@ -1592,6 +1761,7 @@ namespace Unlimotion.Views
             }
 
             _activeTaskTree = tree;
+            tree.Focus();
         }
 
         private void UpdateContextMenuContext(TreeView tree, PointerPressedEventArgs e)
@@ -1670,27 +1840,18 @@ namespace Unlimotion.Views
                 return true;
             }
 
-            if (TryGetVisibleMainTaskTree(out tree))
-            {
-                return true;
-            }
-
             if (DataContext is not MainWindowViewModel vm)
             {
-                return false;
+                return TryGetVisibleMainTaskTree(out tree);
             }
 
-            return TryGetCurrentModeTree(vm, out tree);
+            return TryGetCurrentModeTree(vm, out tree) ||
+                   TryGetVisibleMainTaskTree(out tree);
         }
 
         private bool TryGetCurrentModeTree(MainWindowViewModel vm, out TreeView tree)
         {
             tree = null!;
-
-            if (TryGetVisibleMainTaskTree(out tree))
-            {
-                return true;
-            }
 
             if (!TryGetCurrentModeTreeName(vm, out var treeName))
             {
@@ -1706,6 +1867,12 @@ namespace Unlimotion.Views
             if (!IsKnownMainTaskTree(activeTree))
             {
                 return true;
+            }
+
+            if (DataContext is MainWindowViewModel vm &&
+                TryGetCurrentModeTreeName(vm, out var treeName))
+            {
+                return StringComparer.Ordinal.Equals(activeTree.Name, treeName);
             }
 
             return !TryGetVisibleMainTaskTree(out var visibleTree) ||
@@ -1809,7 +1976,8 @@ namespace Unlimotion.Views
                 return _contextMenuWrapper;
             }
 
-            return GetSelectedWrappersForTree(vm, tree).LastOrDefault();
+            return GetSelectedWrappersForTree(tree).LastOrDefault() ??
+                   GetBoundCurrentWrapperForTree(vm, tree);
         }
 
         private IReadOnlyList<TaskWrapperViewModel> GetSelectedWrappersForTree(MainWindowViewModel vm, TreeView tree)
@@ -1820,7 +1988,14 @@ namespace Unlimotion.Views
                 return selectedWrappers;
             }
 
-            var currentWrapper = tree.Name switch
+            var currentWrapper = GetBoundCurrentWrapperForTree(vm, tree);
+
+            return currentWrapper != null ? [currentWrapper] : Array.Empty<TaskWrapperViewModel>();
+        }
+
+        private static TaskWrapperViewModel? GetBoundCurrentWrapperForTree(MainWindowViewModel vm, TreeView tree)
+        {
+            return tree.Name switch
             {
                 "AllTasksTree" => vm.CurrentAllTasksItem,
                 "LastCreatedTree" => vm.CurrentLastCreated,
@@ -1831,8 +2006,6 @@ namespace Unlimotion.Views
                 "LastOpenedTree" => vm.CurrentLastOpenedItem,
                 _ => null
             };
-
-            return currentWrapper != null ? [currentWrapper] : Array.Empty<TaskWrapperViewModel>();
         }
 
         private static IReadOnlyList<TaskWrapperViewModel> GetSelectedWrappersForTree(TreeView tree)
@@ -1867,18 +2040,29 @@ namespace Unlimotion.Views
             SetTreeSelection(tree, [wrapper]);
         }
 
+        private void QueueSingleWrapperSelectionRestore(TreeView tree, TaskWrapperViewModel wrapper)
+        {
+            var restoreVersion = unchecked(++_selectionRestoreVersion);
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (restoreVersion == _selectionRestoreVersion &&
+                    TryGetValidatedTree(tree, out _))
+                {
+                    SelectSingleWrapper(tree, wrapper);
+                }
+            }, DispatcherPriority.Normal);
+        }
+
         private void SetTreeSelection(TreeView tree, IReadOnlyList<TaskWrapperViewModel> wrappers)
         {
             var selectedItems = tree.SelectedItems;
-            if (selectedItems == null)
+            if (selectedItems != null)
             {
-                return;
-            }
-
-            selectedItems.Clear();
-            foreach (var wrapper in wrappers)
-            {
-                selectedItems.Add(wrapper);
+                selectedItems.Clear();
+                foreach (var wrapper in wrappers)
+                {
+                    selectedItems.Add(wrapper);
+                }
             }
 
             var currentWrapper = wrappers.LastOrDefault();
@@ -1937,14 +2121,59 @@ namespace Unlimotion.Views
 
         private void RestoreContextMenuContextFromPlacementTarget(MenuItem menuItem)
         {
-            var contextMenu = menuItem.FindParent<ContextMenu>();
+            var contextMenu = FindOwningContextMenu(menuItem);
             if (contextMenu?.PlacementTarget is not Control placementTarget)
             {
                 return;
             }
 
             _contextMenuTree = TryGetTaskTree(placementTarget) ?? _contextMenuTree;
-            _contextMenuWrapper ??= TryGetWrapper(placementTarget);
+
+            if (TryGetWrapper(placementTarget) is { } targetWrapper)
+            {
+                _contextMenuWrapper = targetWrapper;
+            }
+        }
+
+        private ContextMenu? FindOwningContextMenu(MenuItem menuItem)
+        {
+            var visualParent = menuItem.FindParent<ContextMenu>();
+            if (visualParent != null)
+            {
+                return visualParent;
+            }
+
+            var logicalParent = menuItem.FindLogicalAncestorOfType<ContextMenu>();
+            if (logicalParent != null)
+            {
+                return logicalParent;
+            }
+
+            var tag = menuItem.Tag?.ToString();
+            return GetTaskTrees()
+                .Select(tree => tree.ContextMenu)
+                .FirstOrDefault(contextMenu =>
+                    contextMenu?.Items
+                        .OfType<MenuItem>()
+                        .Any(item => ReferenceEquals(item, menuItem)) == true)
+                ?? GetTaskTrees()
+                    .Select(tree => tree.ContextMenu)
+                    .FirstOrDefault(contextMenu =>
+                        contextMenu?.PlacementTarget is Control &&
+                        !string.IsNullOrWhiteSpace(tag) &&
+                        contextMenu.Items
+                            .OfType<MenuItem>()
+                            .Any(item => string.Equals(item.Tag?.ToString(), tag, StringComparison.Ordinal)));
+        }
+
+        private IEnumerable<TreeView> GetTaskTrees()
+        {
+            return KnownMainTaskTreeNames
+                .Select(this.FindControl<TreeView>)
+                .Where(tree => tree != null)
+                .Cast<TreeView>()
+                .Concat(this.GetVisualDescendants().OfType<TreeView>())
+                .Distinct();
         }
 
         private static TaskWrapperViewModel? TryGetWrapper(object? source)
@@ -2006,6 +2235,22 @@ namespace Unlimotion.Views
             while (current != null)
             {
                 if (current is TControl)
+                {
+                    return true;
+                }
+
+                current = current.FindParent<Control>();
+            }
+
+            return false;
+        }
+
+        private static bool IsControlOrDescendantOf(Control control, Control ancestor)
+        {
+            Control? current = control;
+            while (current != null)
+            {
+                if (ReferenceEquals(current, ancestor))
                 {
                     return true;
                 }

--- a/src/Unlimotion/Views/SettingsControl.axaml
+++ b/src/Unlimotion/Views/SettingsControl.axaml
@@ -44,14 +44,17 @@
         <Style Selector="Grid.FieldActionRow">
             <Setter Property="ColumnSpacing" Value="8" />
         </Style>
-        <Style Selector="UserControl ComboBox">
+        <Style Selector="ComboBox">
             <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="MinWidth" Value="140" />
         </Style>
-        <Style Selector="UserControl TextBox">
+        <Style Selector="TextBox">
             <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="MinWidth" Value="140" />
         </Style>
-        <Style Selector="UserControl NumericUpDown">
+        <Style Selector="NumericUpDown">
             <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="MinWidth" Value="140" />
         </Style>
         <Style Selector="WrapPanel.ActionButtons">
             <Setter Property="Orientation" Value="Horizontal" />
@@ -67,7 +70,7 @@
 
     <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                   behavior:KeyboardAwareScrollViewer.IsEnabled="True">
-        <StackPanel Margin="16">
+        <StackPanel x:Name="SettingsContent" Margin="16">
             <TextBlock Classes="SectionTitle" Text="{DynamicResource SettingsTitle}" />
             <TextBlock Classes="SectionHint"
                        Text="{DynamicResource SettingsIntro}" />

--- a/src/Unlimotion/Views/SettingsControl.axaml.cs
+++ b/src/Unlimotion/Views/SettingsControl.axaml.cs
@@ -1,12 +1,39 @@
-﻿using Avalonia.Controls;
+using System;
+using Avalonia;
+using Avalonia.Controls;
 
 namespace Unlimotion.Views
 {
     public partial class SettingsControl : UserControl
     {
+        private const double ContentHorizontalMargin = 32d;
+
         public SettingsControl()
         {
             InitializeComponent();
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            UpdateContentMaxWidth(availableSize.Width);
+            return base.MeasureOverride(availableSize);
+        }
+
+        protected override Size ArrangeOverride(Size finalSize)
+        {
+            UpdateContentMaxWidth(finalSize.Width);
+            return base.ArrangeOverride(finalSize);
+        }
+
+        private void UpdateContentMaxWidth(double width)
+        {
+            var maxWidth = width - ContentHorizontalMargin;
+            if (double.IsNaN(maxWidth) || maxWidth <= 0)
+            {
+                return;
+            }
+
+            SettingsContent.MaxWidth = Math.Max(0, maxWidth);
         }
     }
 }


### PR DESCRIPTION
## Что сделано
- Rebased `fix/broken-tests` на актуальный `origin/main`.
- Стабилизированы headless UI-сценарии вокруг команд деревьев, выбора текущего элемента, контекстного меню, inline-редактирования заголовка и responsive-настроек.
- Добавлен `HeadlessSessionExtensions.DispatchAsync`, чтобы исключения из async UI-dispatch не терялись в тестах.
- Уточнены UI/runtime детали: планировщик ReactiveUI на Avalonia UI thread, emoji font fallback, cleanup `UnifiedTaskStorage`, responsive layout настроек.

## Проверки
- `dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj --no-restore -p:BaseOutputPath=artifacts\\codex-final\\ -p:UseSharedCompilation=false -v:minimal` - passed, warnings only.
- `Unlimotion.Test.exe --treenode-filter "/*/*/SettingsControlResponsiveUiTests/*" --timeout 5m --no-progress --no-ansi` - passed, 4/4.
- `Unlimotion.Test.exe --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*" --timeout 10m --maximum-failed-tests 1 --no-progress --no-ansi` - passed, 34/34.

Полный `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj` до финального rebase завис/вышел по таймауту после 20 минут, поэтому в PR зафиксированы целевые UI-проверки по затронутым сценариям.