### PR TITLE
Auto pull selected task directory

### DIFF
--- a/specs/2026-05-12-auto-pull-selected-task-directory.md
+++ b/specs/2026-05-12-auto-pull-selected-task-directory.md
@@ -1,0 +1,316 @@
+# Auto pull selected task directory
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; profiles: `dotnet-desktop-client`, `ui-automation-testing`; context: `testing-dotnet`
+- Владелец: Unlimotion desktop / local task storage / Git backup
+- Масштаб: small
+- Целевая модель: gpt-5.5
+- Целевой релиз / ветка: текущая рабочая ветка
+- Ограничения:
+  - Использовать central instruction stack из `C:\Users\Kibnet\.codex\agents`.
+  - На фазе SPEC менять только этот spec-файл.
+  - До фразы `Спеку подтверждаю` не менять кодовые файлы.
+  - Не создавать Git-репозиторий в выбранной папке автоматически.
+  - Не клонировать удаленный репозиторий для папки без `.git`.
+  - Не выполнять Git pull на UI-потоке.
+  - Для UI-facing изменения добавить или обновить UI test coverage и запустить релевантные UI tests.
+- Связанные ссылки:
+  - `AGENTS.md`
+  - `AGENTS.override.md`
+  - `C:\Users\Kibnet\.codex\agents\AGENTS.md`
+  - `C:\Users\Kibnet\.codex\agents\templates\specs\_template.md`
+  - `C:\Users\Kibnet\.codex\agents\instructions\governance\routing-matrix.md`
+  - `C:\Users\Kibnet\.codex\agents\instructions\core\quest-governance.md`
+  - `C:\Users\Kibnet\.codex\agents\instructions\core\quest-mode.md`
+  - `C:\Users\Kibnet\.codex\agents\instructions\contexts\testing-dotnet.md`
+  - `C:\Users\Kibnet\.codex\agents\instructions\profiles\dotnet-desktop-client.md`
+  - `C:\Users\Kibnet\.codex\agents\instructions\profiles\ui-automation-testing.md`
+
+## 1. Overview / Цель
+При переключении локального каталога задач в настройках приложение должно перед загрузкой задач проверить выбранную папку: если в ней уже есть валидный Git-репозиторий с remote, нужно попытаться подтянуть изменения из remote; если Git-репозитория или remote там нет, не делать никаких Git-действий.
+
+Outcome contract:
+- Success means: при применении другого локального `TaskStorage.Path` существующий Git-репозиторий с remote в этой папке получает `pull` до создания нового `FileStorage`; папка без `.git` или без remote продолжает подключаться как обычное локальное хранилище без инициализации, clone или ошибок Git.
+- Итоговый артефакт / output: сервисный helper/контракт для условного pull, интеграция в local storage connect flow, regression tests и UI test coverage.
+- Stop rules: не завершать EXEC, если targeted Git/service tests или релевантный UI test падают; если full test run заблокирован окружением, зафиксировать команду, ошибку и nearest valid verification.
+
+## 2. Текущее состояние (AS-IS)
+- Настройки локального каталога задач живут в `src/Unlimotion.ViewModel/SettingsViewModel.cs`: `TaskStoragePath` сохраняется в `TaskStorage:Path`.
+- UI настроек живет в `src/Unlimotion/Views/SettingsControl.axaml`; поле пути и кнопка выбора папки меняют настройку, а `ConnectCommand` применяет хранилище.
+- `App.SetupSettingsCommands` в `src/Unlimotion/App.axaml.cs`:
+  - `BrowseTaskStoragePathCommand` выбирает папку и сохраняет путь;
+  - `ConnectCommand` вызывает `PrepareFileStoragePathAsync`, затем `_storageFactory.SwitchStorage(...)` и `MainWindowViewModel.Connect()`.
+- `TaskStorageFactory.SwitchStorage` создает `FileStorage` по текущему `TaskStorage.Path`.
+- `BackupViaGitService.Pull()` уже умеет делать fetch/merge для валидного репозитория и no-op, если `Repository.IsValid(path)` возвращает `false`.
+- Для существующего репозитория `ConnectRepository` уже вызывает `EnsureGitSelectionFromLocalRepository(...)` перед `Pull()`, чтобы подстроить `RemoteName` и `PushRefSpec` под локальный репозиторий.
+- Сейчас смена локального каталога задач не запускает pull автоматически; пользователь должен отдельно пользоваться Git backup controls.
+- В репозитории есть TUnit tests в `src/Unlimotion.Test` и UI automation suites в `tests/Unlimotion.UiTests.Headless` / `tests/Unlimotion.UiTests.FlaUI`.
+
+## 3. Проблема
+При выборе другой папки задач, которая уже является Git-репозиторием, приложение может загрузить локальные файлы до подтягивания remote-изменений. Корневая проблема: local storage connect flow не синхронизирует существующий Git-репозиторий выбранного каталога перед созданием нового `FileStorage`.
+
+## 4. Цели дизайна
+- Разделение ответственности: проверка Git-репозитория и pull остаются в backup service; UI command только вызывает сервис до переключения storage.
+- Повторное использование: использовать существующую логику `Pull()` и selection alignment для локального репозитория, а не дублировать Git merge logic.
+- Тестируемость: покрыть no-op для папки без Git и pull для существующего repo.
+- Консистентность: не менять визуальный flow настроек и существующие automation ids.
+- Обратная совместимость: persisted settings и task JSON не меняются.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не инициализируем Git в новой папке.
+- Не клонируем remote в папку без Git-репозитория.
+- Не меняем UI настройки remote/credentials.
+- Не меняем scheduler pull/push policy.
+- Не меняем формат задач или миграции.
+- Не добавляем новые диалоги подтверждения.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `IRemoteBackupService` -> добавить метод условного pull для текущего `TaskStorage.Path`, например `PullExistingRepository()` или `TryPullExistingRepository()`.
+- `BackupViaGitService` -> реализовать метод:
+  - вычислить repository path из текущего `TaskStorage.Path`;
+  - если `Repository.IsValid(path) == false`, сразу вернуться без side effects;
+  - если репозиторий валиден, но в нём нет remote, сразу вернуться без side effects;
+  - если репозиторий валиден и remote есть, синхронизировать `RemoteName`/`PushRefSpec` с локальным repo и вызвать существующий `Pull()`.
+- `App.axaml.cs` -> в local branch of `ConnectCommand` вызвать условный pull после `PrepareFileStoragePathAsync(settings.TaskStoragePath)` и до `_storageFactory.SwitchStorage(...)`.
+- `SettingsViewModel` -> обязательно обновить metadata/conflict status после conditional pull перед storage switch; не добавлять persisted state.
+- Tests -> добавить service-level regression и UI-facing coverage по существующим repository patterns.
+
+### 6.2 Детальный дизайн
+- Flow:
+  1. Пользователь выбирает или вводит новый локальный каталог задач.
+  2. Пользователь применяет локальное хранилище через существующую команду подключения.
+  3. `ConnectCommand` переводит storage state в `Connecting`.
+  4. Для local mode выполняется подготовка пути.
+  5. Если нормализованный выбранный path совпадает с текущим подключенным local storage path, conditional pull не запускается и используется existing reconnect behavior.
+  6. Если выбран другой local path, backup service получает шанс выполнить conditional pull:
+     - нет валидного Git repo -> no-op;
+     - валидный Git repo без remote -> no-op;
+     - валидный Git repo с remote -> align local Git selection and call `Pull()`.
+  7. После conditional pull приложение обновляет Git metadata/conflict status.
+  8. Если pull оставил repository в conflict mode, приложение входит в существующий conflict resolver flow и не продолжает normal storage reload до завершения разрешения конфликтов.
+  9. Если conflict mode не обнаружен, создается новое `FileStorage`, и `MainWindowViewModel.Connect()` загружает уже обновленные файлы.
+- API/output contract:
+  - Метод conditional pull не должен создавать репозиторий или remote.
+  - Метод должен быть безопасен для пустого/невалидного пути и папки без `.git`.
+  - Git pull должен использовать существующие credentials/settings and SSH handling.
+  - Если pull приводит к conflict mode, существующий conflict handling остается источником истины; normal storage reload must stop before loading conflicted files.
+- Error handling:
+  - Папка без Git repo не считается ошибкой.
+  - Ошибки реального pull для валидного repo обрабатываются как текущие ошибки подключения storage: state `Error` и toast через `ConnectStorageFailed`, либо через существующий Git error toast, если `Pull()` уже проглатывает ошибку. В EXEC нужно сохранить текущий стиль обработки ошибок без новых UI modal.
+- Производительность:
+  - Git operation выполняется через `Task.Run` или эквивалентно вне UI thread.
+  - Для папки без repo проверка должна быть быстрой и без network.
+
+## 7. Бизнес-правила / Алгоритмы (если есть)
+- Условный pull запускается только для local storage mode.
+- Условный pull запускается при применении выбранного local path, а не при простом открытии Settings.
+- Условный pull запускается только если выбранный local path отличается от текущего подключенного local storage path после нормализации абсолютного пути; повторное подключение той же папки не запускает auto-pull.
+- Если выбранный path невалиден как Git repo, Git layer ничего не меняет.
+- Если выбранный path валиден как Git repo:
+  - preferred remote: текущий `Git.RemoteName`, если он есть в repo; иначе `origin`; иначе первый remote;
+  - preferred branch/ref: текущий `Git.PushRefSpec`, если он есть; иначе current local branch; иначе существующая fallback-логика `main`/`master`/first ref.
+- Если repo валиден, но remote отсутствует, метод не должен создавать remote; допустим no-op с сохранением дальнейшего подключения локального storage.
+- Pull before storage load должен предшествовать `TaskStorageFactory.SwitchStorage`.
+- Conflict detection after pull должен предшествовать `TaskStorageFactory.SwitchStorage`; при active conflict normal switch/load не выполняется.
+
+## 8. Точки интеграции и триггеры
+- `App.SetupSettingsCommands` / `ConnectCommand`: основной триггер при применении local storage path.
+- `BackupViaGitService`: условный Git pull и no-op behavior.
+- `SettingsViewModel.ReloadGitMetadata()`: после conditional pull обязательно обновить remote/ref metadata и conflict status перед `SwitchStorage`.
+- Existing conflict resolver integration: если `settings.IsConflictResolutionMode` после metadata reload, войти в conflict resolution flow и остановить normal connect flow.
+- UI tests: сценарий Settings/local storage connect должен остаться рабочим и покрывать пользовательский flow через стабильные selectors.
+
+## 9. Изменения модели данных / состояния
+- Новых persisted fields нет.
+- Runtime state:
+  - storage remains `Connecting` while conditional pull runs;
+  - если conditional pull приводит к conflict mode, storage state must not be marked as normally connected to the new path until conflicts are resolved;
+  - после успешного no-op/pull existing flow возвращается к existing connected behavior.
+- Git state:
+  - только existing Git repo может быть изменен через fetch/merge/stash existing `Pull()` behavior;
+  - папка без `.git` не получает `.git` и remote metadata.
+
+## 10. Миграция / Rollout / Rollback
+- First launch behavior: unchanged for default folder without Git repo.
+- Backward compatibility: existing settings file remains valid.
+- Rollout: feature ships as small behavior change in local storage connect flow.
+- Rollback: remove conditional pull call and service method; no data migration rollback needed.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  1. Applying a different local task directory that is not a Git repo performs no Git initialization/clone/pull and still connects local storage.
+  2. Applying a different local task directory that is a valid Git repo with remote attempts remote pull before `FileStorage` loads tasks.
+  3. Existing repo remote/branch selection is aligned with the selected repository before pull.
+  4. Conditional pull runs off the UI thread.
+  5. Server storage mode does not trigger conditional Git pull.
+  6. Browse-only path selection does not unexpectedly switch storage or load tasks.
+  7. Existing manual backup connect/sync/pull/push flows continue to work.
+  8. UI test coverage exists for the Settings flow affected by local path switching.
+  9. Reconnecting the already connected local task directory does not trigger automatic pull.
+  10. If automatic pull leaves Git conflicts, conflict resolution mode opens and normal `FileStorage` reload for the selected path is deferred.
+- Какие тесты добавить/изменить:
+  - `src/Unlimotion.Test/BackupViaGitServiceTests.cs`:
+    - `PullExistingRepository_DoesNothing_WhenTaskFolderIsNotGitRepository`
+    - `PullExistingRepository_DoesNothing_WhenRepositoryHasNoRemote`
+    - `PullExistingRepository_PullsRemoteChanges_WhenTaskFolderIsExistingRepository`
+    - `PullExistingRepository_SelectsRepositoryRemoteAndBranch_WhenSettingsAreStale`
+  - `src/Unlimotion.Test/SettingsViewModelTests.cs` or App command-level/integration test:
+    - local storage connect invokes conditional pull before switching storage; this ordering coverage is mandatory, not optional;
+    - server mode does not invoke conditional pull;
+    - reconnecting the same local path does not invoke conditional pull;
+    - conflict mode after conditional pull stops normal storage reload.
+  - `tests/Unlimotion.UiTests.Headless` / shared authoring:
+    - add or extend Settings flow smoke to cover local storage path switching/apply behavior through automation ids.
+- Команды для проверки:
+  - `dotnet run --project src/Unlimotion.Test/Unlimotion.Test.csproj -- --treenode-filter "/*/*/BackupViaGitServiceTests/*PullExistingRepository*"`
+  - `dotnet run --project tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj -- --treenode-filter "/*/*/MainWindowHeadlessTests/*Settings*"`
+  - `dotnet build src/Unlimotion.sln`
+  - `dotnet test src/Unlimotion.sln` или принятый full-run, если solution runner стабилен в окружении.
+- Stop rules для validation loops:
+  - targeted service tests must pass;
+  - relevant UI test must pass or exact environment blocker must be reported;
+  - full-run should be attempted after targeted checks.
+
+## 12. Риски и edge cases
+- Risk: pull happens after storage load and UI shows stale tasks.
+  - Mitigation: call conditional pull before `SwitchStorage`.
+- Risk: folder without repo gets `.git` by accident.
+  - Mitigation: service method exits on `Repository.IsValid(path) == false`; test asserts `.git` is absent.
+- Risk: stale global Git settings point to remote/branch absent in selected repo.
+  - Mitigation: reuse repository-local selection alignment before `Pull()`.
+- Risk: valid repo without remote causes noisy error on ordinary folder switch.
+  - Mitigation: treat no remote as no-op in conditional method, while manual Pull can keep current behavior.
+- Risk: network/merge blocks UI.
+  - Mitigation: run conditional pull in background task from command.
+- Risk: pull conflict appears while storage is switching.
+  - Mitigation: require metadata/conflict reload before `SwitchStorage`; if conflict mode is active, enter resolver and skip normal storage reload.
+- Risk: auto-pull runs too often on ordinary reconnect of the same folder.
+  - Mitigation: compare normalized selected path with current connected local storage path and only auto-pull when the user applies a different local directory.
+
+## 13. План выполнения
+1. Service contract:
+   - add conditional pull method to `IRemoteBackupService`;
+   - implement in `BackupViaGitService` using existing repository path resolution, local repo selection alignment and `Pull()`.
+2. App integration:
+   - call conditional pull in local `ConnectCommand` before `SwitchStorage`;
+   - compare selected local path with current connected local storage path and skip conditional pull for the same path;
+   - reload Git metadata after conditional pull and stop normal connect flow on conflict mode;
+   - keep browse-only behavior unchanged;
+   - preserve existing conflict resolver entry point.
+3. Regression tests:
+   - add service tests for no-repo no-op, no-remote no-op and existing repo pull;
+   - add command/integration ordering test for pull before storage switch;
+   - add same-path skip and conflict-stop coverage; if direct command seam is unavailable, use an integration test instead of making this coverage optional.
+4. UI coverage:
+   - add/update relevant Headless Settings flow test using existing AppAutomation pattern.
+5. Validation:
+   - run targeted service/UI tests, build, then full available test run.
+   - perform post-EXEC review and update this journal.
+
+## 14. Открытые вопросы
+Не применимо. Неоднозначность по триггеру решена консервативно: "выбрать другой каталог" трактуется как применение local storage path через существующую команду подключения, причем auto-pull запускается только если выбранный path отличается от текущего подключенного local storage path. Simple browse only changes the saved path and does not reload storage.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client` + `ui-automation-testing`; context `testing-dotnet`.
+- Выполненные требования профиля:
+  - Long-running Git operation is designed off UI thread.
+  - Existing UI selectors should remain stable.
+  - UI-facing behavior requires UI test coverage.
+  - TUnit/Microsoft.Testing.Platform targeted syntax uses `--treenode-filter`.
+  - `dotnet build` and full test attempt are part of validation.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `specs/2026-05-12-auto-pull-selected-task-directory.md` | Рабочая спецификация и журнал | Central QUEST contract |
+| `src/Unlimotion.ViewModel/IRemoteBackupService.cs` | Add conditional pull method | Service boundary for selected existing repo |
+| `src/Unlimotion/Services/BackupViaGitService.cs` | Implement conditional pull/no-op behavior | Core Git behavior |
+| `src/Unlimotion/App.axaml.cs` | Invoke conditional pull before local storage switch | User flow integration |
+| `src/Unlimotion.Test/BackupViaGitServiceTests.cs` | Add regression tests | Git behavior verification |
+| `src/Unlimotion.Test/SettingsViewModelTests.cs` | Mandatory command/integration coverage | Verify call ordering, same-path skip and conflict stop |
+| `src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs` | Add/update Settings UI test | Required UI-facing coverage via existing Avalonia.Headless pattern |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Folder without Git | Loads as local storage | Same behavior; no Git side effects |
+| Existing Git folder | Loads local files first; remote pull is manual | Attempts remote pull before local storage load |
+| Existing Git folder without remote | Manual pull can show remote error | Auto-pull no-ops and local storage still connects |
+| Same folder reconnect | Reconnects current local storage | Reconnects current local storage without auto-pull |
+| Pull conflict while changing folder | Potentially continues into normal storage load | Enters conflict resolver and defers normal storage reload |
+| Git repo initialization | Only manual backup connect flow | Still only manual backup connect flow |
+| UI flow | Browse path, then connect | Same visible flow |
+| Tests | Existing backup/connect tests | Added regression for conditional pull and UI Settings flow |
+
+## 18. Альтернативы и компромиссы
+- Вариант: call existing `ConnectRepository(false)` when selected folder has no repo.
+  - Плюсы: reuses backup onboarding.
+  - Минусы: может clone/init/push, что прямо противоречит требованию "если гит репозитория там нет, ничего не делать".
+  - Почему не выбран: слишком широкий side effect.
+- Вариант: run pull immediately after folder picker selection.
+  - Плюсы: ближе к буквальному "выбрать каталог".
+  - Минусы: browse currently only edits setting; hidden network action before apply is surprising and misses manually typed path.
+  - Почему не выбран: less consistent with current connect/apply semantics.
+- Вариант: conditional pull inside `TaskStorageFactory.CreateFileStorage`.
+  - Плюсы: centralized before every file storage creation.
+  - Минусы: storage factory would depend on Git backup concerns and credentials.
+  - Почему не выбран: weaker responsibility boundary.
+- Выбранный вариант: service-level conditional pull called from local connect flow before storage switch.
+  - Плюсы: bounded side effects, preserves current UX, testable, respects no-repo no-op.
+  - Минусы: automatic pull happens only when user applies the selected path, not at browse time.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели дизайна и Non-Goals зафиксированы. |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, flow, API contract, conflict-stop, same-path skip, integration, data/state and rollback описаны. |
+| C. Безопасность изменений | 11-13 | PASS | No-repo/no-remote no-op, no init/clone, background pull, conflict-stop and rollback covered. |
+| D. Проверяемость | 14-16 | PASS | Acceptance criteria, mandatory ordering test, targeted commands, UI coverage and file impact table есть. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Before/after, alternatives, plan and quality gate present; blocking questions absent. |
+| F. Соответствие профилю | 20 | PASS | Соответствует `dotnet-desktop-client`, `ui-automation-testing`, `testing-dotnet`. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Outcome, no-op rule and Non-Goals are explicit. |
+| 2. Понимание текущего состояния | 5 | Current Settings, App command, storage factory and Git service flow captured. |
+| 3. Конкретность целевого дизайна | 5 | Service method, no-remote no-op, command integration, ordering, same-path skip and conflict-stop are specified. |
+| 4. Безопасность (миграция, откат) | 5 | No persisted data changes; rollback is removal of conditional call/method. |
+| 5. Тестируемость | 5 | Service, mandatory command/integration ordering, conflict-stop and UI tests are planned with commands. |
+| 6. Готовность к автономной реализации | 5 | Ordered phases and no blocking questions. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: после первичного дизайна явно закреплены no-op для repo без remote, порядок pull before `SwitchStorage`, browse-only boundary, отсутствие init/clone и обязательная UI coverage. После дополнительного review исправлены conflict-stop before storage reload, противоречие valid repo/no remote, mandatory ordering coverage и same-path skip rule.
+- Что осталось на решение пользователя: требуется только утверждение спеки фразой `Спеку подтверждаю`.
+
+### Post-EXEC Review
+- Статус: PASS с validation limitation
+- Что исправлено до завершения: auto-pull выбранного repo отделен от watcher текущего storage; добавлено command-level покрытие реального `ConnectCommand` и server-mode skip. Реализация сохраняет no-repo/no-remote no-op, выполняет conditional pull до `SwitchStorage`, обновляет Git/conflict metadata и останавливает normal load при conflict mode.
+- Что проверено дополнительно: targeted Git service tests, watcher regression tests, App/local connection helper tests, real ConnectCommand tests, affected Settings UI test, test project build and desktop project build.
+- Остаточные риски / follow-ups: полный TUnit run и старый `SettingsControl_SyncConflictResolutionMode_ShowsOpenResolverAction` завершаются кодом 1 без summary/report в текущем окружении; targeted tests for changed behavior pass.
+
+## Approval
+Получено: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+Заполняется инкрементально после каждого значимого блока работ. Одна строка = один завершенный значимый блок.
+
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Сбор central instruction stack и локального override | 0.96 | Нет | Осмотреть код Settings/Git flow | Нет | Нет | Задача проходит через delivery-task, `dotnet-desktop-client`, `ui-automation-testing`; code edits заблокированы до approval | `C:\Users\Kibnet\.codex\agents\AGENTS.md`, `AGENTS.override.md` |
+| SPEC | Анализ текущего Settings/storage/Git flow | 0.9 | Нет | Создать canonical spec | Нет | Нет | Найдены `ConnectCommand`, `BrowseTaskStoragePathCommand`, `TaskStorageFactory.SwitchStorage`, `BackupViaGitService.Pull()` and local repo selection helper | `src/Unlimotion/App.axaml.cs`, `src/Unlimotion/Services/BackupViaGitService.cs`, `src/Unlimotion.ViewModel/SettingsViewModel.cs` |
+| SPEC | Создание спецификации и quality gate | 0.93 | Нет | Ожидать `Спеку подтверждаю` перед EXEC | Да | Нет, approval еще не получен | Спека фиксирует bounded conditional pull before storage switch, no-repo no-op, tests and UI coverage | `specs/2026-05-12-auto-pull-selected-task-directory.md` |
+| SPEC | Review fixes | 0.95 | Нет | Ожидать `Спеку подтверждаю` перед EXEC | Да | Да, пользователь попросил внести исправления review | Уточнены conflict-stop после auto-pull, no-remote no-op, обязательный ordering test и запуск auto-pull только при смене каталога | `specs/2026-05-12-auto-pull-selected-task-directory.md` |
+| EXEC | Conditional pull implementation and tests | 0.86 | Нужен targeted test/build signal | Запустить targeted service/App-helper/UI tests | Нет | Да, пользователь подтвердил spec | Добавлен `PullExistingRepository`, local connect helper с same-path skip и conflict-stop, сервисные regression tests, App-helper ordering tests и Settings UI coverage; первый solution build timeout 120s без вывода | `src/Unlimotion.ViewModel/IRemoteBackupService.cs`, `src/Unlimotion/Services/BackupViaGitService.cs`, `src/Unlimotion/App.axaml.cs`, `src/Unlimotion/Views/SettingsControl.axaml`, `src/Unlimotion.Test/BackupViaGitServiceTests.cs`, `src/Unlimotion.Test/SettingsViewModelTests.cs`, `src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs` |
+| EXEC | Validation and post-EXEC review | 0.9 | Нет для targeted scope; full-run blocked by runner/environment | Финальный отчет | Нет | Нет | Targeted service/helper/UI tests pass; test and desktop builds pass; full TUnit run and one pre-existing conflict UI test exit with code 1 without TUnit summary/report; post-EXEC review found no code changes required | `specs/2026-05-12-auto-pull-selected-task-directory.md`, `src/Unlimotion.Test/bin/Debug/net10.0/TestResults/Unlimotion.Test-windows-net10.0-report.html` |
+| EXEC | Review fixes implementation | 0.92 | Нет | Финальный отчет | Нет | Да, пользователь попросил внести review fixes | Исправлено использование watcher старого storage при pre-switch auto-pull; добавлены regression tests на watcher behavior, real `ConnectCommand` wiring и server-mode skip; targeted tests/builds passed | `src/Unlimotion/Services/BackupViaGitService.cs`, `src/Unlimotion.Test/BackupViaGitServiceTests.cs`, `src/Unlimotion.Test/SettingsViewModelTests.cs`, `specs/2026-05-12-auto-pull-selected-task-directory.md` |

--- a/src/Unlimotion.Test/BackupViaGitServiceTests.cs
+++ b/src/Unlimotion.Test/BackupViaGitServiceTests.cs
@@ -9,6 +9,7 @@ using LibGit2Sharp;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json.Linq;
 using Unlimotion.Services;
+using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
 using WritableJsonConfiguration;
 
@@ -226,6 +227,117 @@ public sealed class BackupViaGitServiceTests : IDisposable
         using var remote = new Repository(remotePath);
         await Assert.That(remote.Branches["main"].Tip.Tree["migration.report"]).IsNull();
         await Assert.That(remote.Branches["main"].Tip.Tree["availability.migration.report"]).IsNull();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PullExistingRepository_DoesNothing_WhenTaskFolderIsNotGitRepository()
+    {
+        var localPath = CreateLocalTaskFolder();
+        var remotePath = CreateBareRemoteWithCommit("remote-task", "remote content");
+        var service = CreateService(localPath, remotePath);
+
+        service.PullExistingRepository();
+
+        await Assert.That(Directory.Exists(Path.Combine(localPath, ".git"))).IsFalse();
+        await Assert.That(File.Exists(Path.Combine(localPath, "local-task"))).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PullExistingRepository_DoesNothing_WhenRepositoryHasNoRemote()
+    {
+        var localPath = Path.Combine(_rootPath, $"NoRemoteTasks-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(localPath);
+        Repository.Init(localPath);
+        var remotePath = CreateBareRemoteWithCommit("remote-task", "remote content");
+        var service = CreateService(localPath, remotePath);
+
+        service.PullExistingRepository();
+
+        using var repo = new Repository(localPath);
+        await Assert.That(repo.Network.Remotes.Any()).IsFalse();
+        await Assert.That(File.Exists(Path.Combine(localPath, "remote-task"))).IsFalse();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PullExistingRepository_PullsRemoteChanges_WhenTaskFolderIsExistingRepository()
+    {
+        var remotePath = CreateBareRemoteWithCommit("task", "base content");
+        var localPath = CloneRemoteToLocalMain(remotePath);
+        var service = CreateService(localPath, remotePath);
+        PushRemoteChange(remotePath, "task", "remote content");
+
+        service.PullExistingRepository();
+
+        await Assert.That(File.ReadAllText(Path.Combine(localPath, "task"))).IsEqualTo("remote content");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PullExistingRepository_SelectsRepositoryRemoteAndBranch_WhenSettingsAreStale()
+    {
+        var remotePath = CreateBareRemoteWithCommit("task", "base content");
+        var localPath = CloneRemoteToLocalMain(remotePath);
+        using (var repo = new Repository(localPath))
+        {
+            repo.Network.Remotes.Remove("origin");
+            repo.Network.Remotes.Add("backup", remotePath);
+        }
+
+        var service = CreateService(
+            localPath,
+            remotePath,
+            out var configuration,
+            pushRefSpec: "refs/heads/master",
+            branch: "master",
+            remoteName: "missing");
+        PushRemoteChange(remotePath, "task", "remote content");
+
+        service.PullExistingRepository();
+
+        await Assert.That(configuration
+                .GetSection("Git")
+                .GetSection(nameof(GitSettings.RemoteName))
+                .Get<string>())
+            .IsEqualTo("backup");
+        await Assert.That(configuration
+                .GetSection("Git")
+                .GetSection(nameof(GitSettings.PushRefSpec))
+                .Get<string>())
+            .IsEqualTo("refs/heads/main");
+        await Assert.That(File.ReadAllText(Path.Combine(localPath, "task"))).IsEqualTo("remote content");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PullExistingRepository_DoesNotNotifyCurrentStorageWatcher_WhenRepositoryChanges()
+    {
+        var remotePath = CreateBareRemoteWithCommit("task", "base content");
+        var localPath = CloneRemoteToLocalMain(remotePath);
+        var watcher = new FakeDatabaseWatcher();
+        var service = CreateService(localPath, remotePath, storageFactory: new FakeTaskStorageFactory(watcher));
+        PushRemoteChange(remotePath, "task", "remote content");
+
+        service.PullExistingRepository();
+
+        await Assert.That(File.ReadAllText(Path.Combine(localPath, "task"))).IsEqualTo("remote content");
+        await Assert.That(watcher.SetEnableCalls).IsEqualTo(0);
+        await Assert.That(watcher.ForceUpdateFileCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task Pull_NotifiesCurrentStorageWatcher_WhenRepositoryChanges()
+    {
+        var remotePath = CreateBareRemoteWithCommit("task", "base content");
+        var localPath = CloneRemoteToLocalMain(remotePath);
+        var watcher = new FakeDatabaseWatcher();
+        var service = CreateService(localPath, remotePath, storageFactory: new FakeTaskStorageFactory(watcher));
+        PushRemoteChange(remotePath, "task", "remote content");
+
+        service.Pull();
+
+        await Assert.That(File.ReadAllText(Path.Combine(localPath, "task"))).IsEqualTo("remote content");
+        await Assert.That(watcher.SetEnableCalls).IsEqualTo(2);
+        await Assert.That(watcher.ForceUpdateFileCalls).IsEqualTo(1);
+        await Assert.That(watcher.LastForcedFileName).IsEqualTo("task");
+        await Assert.That(watcher.LastForcedUpdateType).IsEqualTo(UpdateType.Saved);
     }
 
     [Test]
@@ -982,6 +1094,19 @@ public sealed class BackupViaGitServiceTests : IDisposable
         }
     }
 
+    private string CloneRemoteToLocalMain(string remotePath)
+    {
+        var localPath = Path.Combine(_rootPath, $"local-clone-{Guid.NewGuid():N}");
+        Repository.Clone(remotePath, localPath);
+        using var repo = new Repository(localPath);
+        var remoteBranch = repo.Branches["origin/main"]
+                           ?? throw new InvalidOperationException("Remote main branch was not cloned.");
+        var localBranch = repo.Branches["main"] ?? repo.CreateBranch("main", remoteBranch.Tip);
+        repo.Branches.Update(localBranch, updater => updater.TrackedBranch = remoteBranch.CanonicalName);
+        Commands.Checkout(repo, localBranch);
+        return localPath;
+    }
+
     private void DeleteRemoteFile(string remotePath, string fileName)
     {
         var seedPath = Path.Combine(_rootPath, $"remote-delete-{Guid.NewGuid():N}");
@@ -1034,9 +1159,10 @@ public sealed class BackupViaGitServiceTests : IDisposable
         string remotePath,
         string pushRefSpec = "refs/heads/main",
         string branch = "main",
-        string remoteName = "origin")
+        string remoteName = "origin",
+        ITaskStorageFactory? storageFactory = null)
     {
-        return CreateService(localPath, remotePath, out _, pushRefSpec, branch, remoteName);
+        return CreateService(localPath, remotePath, out _, pushRefSpec, branch, remoteName, storageFactory);
     }
 
     private BackupViaGitService CreateService(
@@ -1045,7 +1171,8 @@ public sealed class BackupViaGitServiceTests : IDisposable
         out IConfigurationRoot configuration,
         string pushRefSpec = "refs/heads/main",
         string branch = "main",
-        string remoteName = "origin")
+        string remoteName = "origin",
+        ITaskStorageFactory? storageFactory = null)
     {
         configuration = WritableJsonConfigurationFabric.Create(_configPath);
 
@@ -1063,7 +1190,42 @@ public sealed class BackupViaGitServiceTests : IDisposable
         configuration.GetSection("Git").GetSection(nameof(GitSettings.CommitterEmail)).Set("backuper@example.com");
         configuration.GetSection("Git").GetSection(nameof(GitSettings.ShowStatusToasts)).Set(false);
 
-        return new BackupViaGitService(configuration);
+        return new BackupViaGitService(configuration, storageFactory: storageFactory);
+    }
+
+    private sealed class FakeTaskStorageFactory(IDatabaseWatcher? currentWatcher) : ITaskStorageFactory
+    {
+        public ITaskStorage? CurrentStorage => null;
+        public IDatabaseWatcher? CurrentWatcher { get; } = currentWatcher;
+        public ITaskStorage CreateFileStorage(string? path) => throw new NotSupportedException();
+        public ITaskStorage CreateServerStorage(string? url) => throw new NotSupportedException();
+        public void SwitchStorage(bool isServerMode, IConfiguration configuration) => throw new NotSupportedException();
+    }
+
+    private sealed class FakeDatabaseWatcher : IDatabaseWatcher
+    {
+        public event EventHandler<DbUpdatedEventArgs>? OnUpdated;
+        public int SetEnableCalls { get; private set; }
+        public int ForceUpdateFileCalls { get; private set; }
+        public string? LastForcedFileName { get; private set; }
+        public UpdateType? LastForcedUpdateType { get; private set; }
+
+        public void AddIgnoredTask(string taskId)
+        {
+        }
+
+        public void SetEnable(bool enable)
+        {
+            SetEnableCalls++;
+        }
+
+        public void ForceUpdateFile(string filename, UpdateType type)
+        {
+            ForceUpdateFileCalls++;
+            LastForcedFileName = filename;
+            LastForcedUpdateType = type;
+            OnUpdated?.Invoke(this, new DbUpdatedEventArgs { Id = filename, Type = type });
+        }
     }
 
     private static Signature CreateSignature() =>

--- a/src/Unlimotion.Test/GitBackupJobTests.cs
+++ b/src/Unlimotion.Test/GitBackupJobTests.cs
@@ -147,6 +147,8 @@ public sealed class GitBackupJobTests : IDisposable
             PullCalls++;
         }
 
+        public void PullExistingRepository() => throw new NotSupportedException();
+
         public BackupRepositoryConnectPreview PreviewConnectRepository() => throw new NotSupportedException();
 
         public void ConnectRepository(bool allowMergeWithNonEmptyRemote) => throw new NotSupportedException();

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -264,10 +264,12 @@ public class SettingsControlResponsiveUiTests
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
 
+                var pathInput = FindControlByAutomationId<TextBox>(view, "TaskStoragePathTextBox");
                 var browseButton = FindControlByAutomationId<Button>(view, "BrowseTaskStoragePathButton");
                 var browseCommand = browseButton.Command ??
                                     throw new InvalidOperationException("Browse button command is not bound.");
 
+                await Assert.That(pathInput.Text).IsEqualTo(initialPath);
                 await Assert.That(browseCommand.CanExecute(null)).IsTrue();
 
                 browseCommand.Execute(null);
@@ -283,10 +285,61 @@ public class SettingsControlResponsiveUiTests
                     TimeSpan.FromSeconds(2));
                 await Assert.That(capturedDirectory).IsEqualTo(initialPath);
                 await Assert.That(settings.TaskStoragePath).IsEqualTo(selectedPath);
+                await Assert.That(pathInput.Text).IsEqualTo(selectedPath);
             }
             finally
             {
                 Dialogs.PlatformOpenFolderDialogAsync = previousPlatformPicker;
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task SettingsControl_LocalStorageConnect_UsesEditedTaskStoragePath()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var settings = fixture.MainWindowViewModelTest.Settings;
+                var initialPath = Path.Combine(fixture.DefaultTasksFolderPath, "Current");
+                var selectedPath = Path.Combine(fixture.DefaultTasksFolderPath, "Selected");
+                string? connectedPath = null;
+                settings.TaskStoragePath = initialPath;
+                settings.ConnectCommand = new TestParameterCommand(_ => connectedPath = settings.TaskStoragePath);
+
+                var view = new SettingsControl
+                {
+                    DataContext = settings
+                };
+
+                window = CreateWindow(view, 720, 800);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var pathInput = FindControlByAutomationId<TextBox>(view, "TaskStoragePathTextBox");
+                var connectButton = FindControlByAutomationId<Button>(view, "ConnectLocalStorageButton");
+
+                pathInput.Text = selectedPath;
+                Dispatcher.UIThread.RunJobs();
+
+                await WaitForConditionAsync(
+                    () => settings.TaskStoragePath == selectedPath,
+                    "Task storage path input did not update the SettingsViewModel.");
+                await Assert.That(connectButton.IsEnabled).IsTrue();
+
+                connectButton.Command?.Execute(connectButton.CommandParameter);
+
+                await Assert.That(connectedPath).IsEqualTo(selectedPath);
+            }
+            finally
+            {
                 window?.Close();
                 fixture.CleanTasks();
             }
@@ -745,6 +798,7 @@ public class SettingsControlResponsiveUiTests
         public void CommitResolvedConflicts(string message) => throw new NotSupportedException();
         public void Push(string msg) => throw new NotSupportedException();
         public void Pull() => throw new NotSupportedException();
+        public void PullExistingRepository() => throw new NotSupportedException();
         public BackupRepositoryConnectPreview PreviewConnectRepository() => throw new NotSupportedException();
         public void ConnectRepository(bool allowMergeWithNonEmptyRemote) => throw new NotSupportedException();
         public void CloneOrUpdateRepo() => throw new NotSupportedException();

--- a/src/Unlimotion.Test/SettingsViewModelTests.cs
+++ b/src/Unlimotion.Test/SettingsViewModelTests.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Unlimotion.Services;
+using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
 using Unlimotion.ViewModel.Localization;
 using WritableJsonConfiguration;
@@ -458,6 +462,168 @@ public class SettingsViewModelTests : IDisposable
         settings.Password = "secret";
 
         await Assert.That(settings.CanConnectStorage).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PrepareLocalStorageConnectionAsync_PullsBetweenPrepareAndSwitch_WhenPathChanges()
+    {
+        IConfigurationRoot configuration = CreateConfiguration();
+        var backupService = new FakeRemoteBackupService();
+        var settings = new SettingsViewModel(configuration, backupService, localizationService: new FakeLocalizationService())
+        {
+            TaskStoragePath = Path.Combine(Environment.CurrentDirectory, "NextTasks")
+        };
+        var events = new List<string>();
+        backupService.PullExistingRepositoryAction = () => events.Add("pull");
+
+        var shouldContinue = await App.PrepareLocalStorageConnectionAsync(
+            settings,
+            backupService,
+            Path.Combine(Environment.CurrentDirectory, "CurrentTasks"),
+            path =>
+            {
+                events.Add($"prepare:{path}");
+                return System.Threading.Tasks.Task.CompletedTask;
+            },
+            _ => events.Add("conflict"));
+        if (shouldContinue)
+        {
+            events.Add("switch");
+        }
+
+        await Assert.That(shouldContinue).IsTrue();
+        await Assert.That(backupService.PullExistingRepositoryCalls).IsEqualTo(1);
+        await Assert.That(string.Join("|", events))
+            .IsEqualTo($"prepare:{settings.TaskStoragePath}|pull|switch");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PrepareLocalStorageConnectionAsync_SkipsPull_WhenReconnectingSameLocalPath()
+    {
+        IConfigurationRoot configuration = CreateConfiguration();
+        var backupService = new FakeRemoteBackupService();
+        var selectedPath = Path.Combine(Environment.CurrentDirectory, "SameTasks");
+        var settings = new SettingsViewModel(configuration, backupService, localizationService: new FakeLocalizationService())
+        {
+            TaskStoragePath = selectedPath
+        };
+        var events = new List<string>();
+
+        var shouldContinue = await App.PrepareLocalStorageConnectionAsync(
+            settings,
+            backupService,
+            selectedPath,
+            path =>
+            {
+                events.Add($"prepare:{path}");
+                return System.Threading.Tasks.Task.CompletedTask;
+            },
+            _ => events.Add("conflict"));
+        if (shouldContinue)
+        {
+            events.Add("switch");
+        }
+
+        await Assert.That(shouldContinue).IsTrue();
+        await Assert.That(backupService.PullExistingRepositoryCalls).IsEqualTo(0);
+        await Assert.That(string.Join("|", events))
+            .IsEqualTo($"prepare:{settings.TaskStoragePath}|switch");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task PrepareLocalStorageConnectionAsync_StopsBeforeSwitch_WhenPullFindsConflicts()
+    {
+        IConfigurationRoot configuration = CreateConfiguration();
+        var backupService = new FakeRemoteBackupService();
+        var settings = new SettingsViewModel(configuration, backupService, localizationService: new FakeLocalizationService())
+        {
+            TaskStoragePath = Path.Combine(Environment.CurrentDirectory, "ConflictedTasks")
+        };
+        var events = new List<string>();
+        backupService.PullExistingRepositoryAction = () =>
+        {
+            events.Add("pull");
+            backupService.ConflictStatus = new BackupConflictStatus(true, new List<BackupConflictFile>());
+        };
+
+        var shouldContinue = await App.PrepareLocalStorageConnectionAsync(
+            settings,
+            backupService,
+            Path.Combine(Environment.CurrentDirectory, "CurrentTasks"),
+            path =>
+            {
+                events.Add($"prepare:{path}");
+                return System.Threading.Tasks.Task.CompletedTask;
+            },
+            _ => events.Add("conflict"));
+        if (shouldContinue)
+        {
+            events.Add("switch");
+        }
+
+        await Assert.That(shouldContinue).IsFalse();
+        await Assert.That(settings.IsConflictResolutionMode).IsTrue();
+        await Assert.That(settings.IsStorageBusy).IsFalse();
+        await Assert.That(backupService.PullExistingRepositoryCalls).IsEqualTo(1);
+        await Assert.That(string.Join("|", events))
+            .IsEqualTo($"prepare:{settings.TaskStoragePath}|pull|conflict");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task ConnectCommand_AutoPullsDifferentLocalPathBeforeSwitchStorage()
+    {
+        IConfigurationRoot configuration = CreateConfiguration();
+        var currentPath = Path.Combine(Environment.CurrentDirectory, $"CurrentTasks-{Guid.NewGuid():N}");
+        var selectedPath = Path.Combine(Environment.CurrentDirectory, $"SelectedTasks-{Guid.NewGuid():N}");
+        var events = new ConcurrentQueue<string>();
+        var backupService = new FakeRemoteBackupService
+        {
+            PullExistingRepositoryAction = () => events.Enqueue("pull")
+        };
+        using var storageFactory = new RecordingTaskStorageFactory(currentPath, events);
+        var settings = new SettingsViewModel(configuration, backupService, localizationService: new FakeLocalizationService())
+        {
+            TaskStoragePath = selectedPath
+        };
+        using var appScope = ConfigureAppSettingsCommands(settings, configuration, backupService, storageFactory);
+
+        settings.ConnectCommand?.Execute(null);
+
+        await WaitForConditionAsync(
+            () => settings.StorageConnectionState == SettingsConnectionState.Connected,
+            "Connect command did not finish.");
+        await Assert.That(backupService.PullExistingRepositoryCalls).IsEqualTo(1);
+        await Assert.That(string.Join("|", events)).IsEqualTo($"pull|switch-local:{selectedPath}");
+        await Assert.That(storageFactory.CurrentFileStoragePath).IsEqualTo(selectedPath);
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task ConnectCommand_DoesNotAutoPull_WhenServerModeIsSelected()
+    {
+        IConfigurationRoot configuration = CreateConfiguration();
+        var currentPath = Path.Combine(Environment.CurrentDirectory, $"CurrentTasks-{Guid.NewGuid():N}");
+        var events = new ConcurrentQueue<string>();
+        var backupService = new FakeRemoteBackupService
+        {
+            PullExistingRepositoryAction = () => events.Enqueue("pull")
+        };
+        using var storageFactory = new RecordingTaskStorageFactory(currentPath, events);
+        var settings = new SettingsViewModel(configuration, backupService, localizationService: new FakeLocalizationService())
+        {
+            IsServerMode = true,
+            ServerStorageUrl = "https://server.example",
+            Login = "user@example",
+            Password = "secret"
+        };
+        using var appScope = ConfigureAppSettingsCommands(settings, configuration, backupService, storageFactory);
+
+        settings.ConnectCommand?.Execute(null);
+
+        await WaitForConditionAsync(
+            () => settings.StorageConnectionState == SettingsConnectionState.Connected,
+            "Server connect command did not finish.");
+        await Assert.That(backupService.PullExistingRepositoryCalls).IsEqualTo(0);
+        await Assert.That(string.Join("|", events)).IsEqualTo("switch-server:https://server.example");
     }
 
     [Test]
@@ -949,6 +1115,146 @@ public class SettingsViewModelTests : IDisposable
         await Assert.That(command).Contains("StrictHostKeyChecking=accept-new");
     }
 
+    private static IDisposable ConfigureAppSettingsCommands(
+        SettingsViewModel settings,
+        IConfiguration configuration,
+        IRemoteBackupService backupService,
+        ITaskStorageFactory storageFactory)
+    {
+        const BindingFlags fieldFlags = BindingFlags.Static | BindingFlags.NonPublic;
+        var appType = typeof(App);
+        var fieldValues = new Dictionary<string, object?>
+        {
+            ["_configuration"] = configuration,
+            ["_backupService"] = backupService,
+            ["_storageFactory"] = storageFactory,
+            ["_mainWindowViewModel"] = null,
+            ["_notificationManager"] = null
+        };
+        var previousValues = fieldValues.ToDictionary(
+            pair => pair.Key,
+            pair => GetRequiredAppField(appType, pair.Key, fieldFlags).GetValue(null));
+
+        foreach (var pair in fieldValues)
+        {
+            GetRequiredAppField(appType, pair.Key, fieldFlags).SetValue(null, pair.Value);
+        }
+
+        var setupSettingsCommands = appType.GetMethod(
+                                        "SetupSettingsCommands",
+                                        BindingFlags.Instance | BindingFlags.NonPublic)
+                                    ?? throw new MissingMethodException(nameof(App), "SetupSettingsCommands");
+        setupSettingsCommands.Invoke(new App(), [settings]);
+
+        return new DelegateDisposable(() =>
+        {
+            foreach (var pair in previousValues)
+            {
+                GetRequiredAppField(appType, pair.Key, fieldFlags).SetValue(null, pair.Value);
+            }
+        });
+    }
+
+    private static FieldInfo GetRequiredAppField(Type appType, string fieldName, BindingFlags flags) =>
+        appType.GetField(fieldName, flags)
+        ?? throw new MissingFieldException(nameof(App), fieldName);
+
+    private static async System.Threading.Tasks.Task WaitForConditionAsync(
+        Func<bool> condition,
+        string failureMessage,
+        TimeSpan? timeout = null)
+    {
+        var deadline = DateTimeOffset.UtcNow + (timeout ?? TimeSpan.FromSeconds(3));
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await System.Threading.Tasks.Task.Delay(10);
+        }
+
+        throw new TimeoutException(failureMessage);
+    }
+
+    private sealed class RecordingTaskStorageFactory : ITaskStorageFactory, IDisposable
+    {
+        private readonly ConcurrentQueue<string> _events;
+        private readonly List<IDisposable> _storages = new();
+        private readonly List<string> _paths = new();
+
+        public RecordingTaskStorageFactory(string currentPath, ConcurrentQueue<string> events)
+        {
+            _events = events;
+            CurrentStorage = CreateFileStorageWithoutRecording(currentPath);
+        }
+
+        public ITaskStorage? CurrentStorage { get; private set; }
+        public IDatabaseWatcher? CurrentWatcher => null;
+        public string? CurrentFileStoragePath => (CurrentStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
+
+        public ITaskStorage CreateFileStorage(string? path)
+        {
+            _events.Enqueue($"switch-local:{path}");
+            CurrentStorage = CreateFileStorageWithoutRecording(path);
+            return CurrentStorage;
+        }
+
+        public ITaskStorage CreateServerStorage(string? url)
+        {
+            _events.Enqueue($"switch-server:{url}");
+            CurrentStorage = CreateFileStorageWithoutRecording(
+                Path.Combine(Environment.CurrentDirectory, $"ServerStoragePlaceholder-{Guid.NewGuid():N}"));
+            return CurrentStorage;
+        }
+
+        public void SwitchStorage(bool isServerMode, IConfiguration configuration)
+        {
+            var settings = configuration.Get<TaskStorageSettings>("TaskStorage");
+            if (isServerMode)
+            {
+                CreateServerStorage(settings?.URL);
+                return;
+            }
+
+            CreateFileStorage(settings?.Path);
+        }
+
+        public void Dispose()
+        {
+            foreach (var storage in _storages)
+            {
+                storage.Dispose();
+            }
+
+            foreach (var path in _paths)
+            {
+                if (Directory.Exists(path))
+                {
+                    Directory.Delete(path, recursive: true);
+                }
+            }
+        }
+
+        private ITaskStorage CreateFileStorageWithoutRecording(string? path)
+        {
+            var storagePath = string.IsNullOrWhiteSpace(path)
+                ? Path.Combine(Environment.CurrentDirectory, $"Tasks-{Guid.NewGuid():N}")
+                : path;
+            var fileStorage = new FileStorage(storagePath, watcher: false);
+            var storage = new UnifiedTaskStorage(new TaskTreeManager(fileStorage));
+            _paths.Add(fileStorage.Path);
+            _storages.Add(storage);
+            return storage;
+        }
+    }
+
+    private sealed class DelegateDisposable(Action dispose) : IDisposable
+    {
+        public void Dispose() => dispose();
+    }
+
     private sealed class FakeRemoteBackupService : IRemoteBackupService
     {
         public List<string> PublicKeys { get; set; } = new();
@@ -957,6 +1263,8 @@ public class SettingsViewModelTests : IDisposable
         public Dictionary<string, string> RemoteAuthTypes { get; set; } = new();
         public Dictionary<string, string> RemoteUrls { get; set; } = new();
         public BackupConflictStatus ConflictStatus { get; set; } = BackupConflictStatus.None;
+        public int PullExistingRepositoryCalls { get; private set; }
+        public Action? PullExistingRepositoryAction { get; set; }
 
         public List<string> Remotes() => new(RemoteNames);
         public string? GetRemoteAuthType(string remoteName) =>
@@ -973,6 +1281,11 @@ public class SettingsViewModelTests : IDisposable
         public void CommitResolvedConflicts(string message) => throw new NotSupportedException();
         public void Push(string msg) => throw new NotSupportedException();
         public void Pull() => throw new NotSupportedException();
+        public void PullExistingRepository()
+        {
+            PullExistingRepositoryCalls++;
+            PullExistingRepositoryAction?.Invoke();
+        }
         public BackupRepositoryConnectPreview PreviewConnectRepository() => throw new NotSupportedException();
         public void ConnectRepository(bool allowMergeWithNonEmptyRemote) => throw new NotSupportedException();
         public void CloneOrUpdateRepo() => throw new NotSupportedException();

--- a/src/Unlimotion.ViewModel/IRemoteBackupService.cs
+++ b/src/Unlimotion.ViewModel/IRemoteBackupService.cs
@@ -17,6 +17,7 @@ public interface IRemoteBackupService
     public void CommitResolvedConflicts(string message);
     public void Push(string msg);
     public void Pull();
+    public void PullExistingRepository();
     public BackupRepositoryConnectPreview PreviewConnectRepository();
     public void ConnectRepository(bool allowMergeWithNonEmptyRemote);
     public void CloneOrUpdateRepo();

--- a/src/Unlimotion/App.axaml.cs
+++ b/src/Unlimotion/App.axaml.cs
@@ -176,7 +176,16 @@ public class App : Application
             {
                 if (!settings.IsServerMode)
                 {
-                    await PrepareFileStoragePathAsync(settings.TaskStoragePath);
+                    var shouldContinue = await PrepareLocalStorageConnectionAsync(
+                        settings,
+                        _backupService,
+                        GetCurrentLocalStoragePath(),
+                        PrepareFileStoragePathAsync,
+                        EnterConflictResolutionMode);
+                    if (!shouldContinue)
+                    {
+                        return;
+                    }
                 }
 
                 _storageFactory?.SwitchStorage(settings.IsServerMode, _configuration!);
@@ -847,12 +856,86 @@ public class App : Application
         settings.SetStorageConnectionState(SettingsConnectionState.Connected);
     }
 
+    internal static async Task<bool> PrepareLocalStorageConnectionAsync(
+        SettingsViewModel settings,
+        IRemoteBackupService? backupService,
+        string? currentLocalStoragePath,
+        Func<string?, Task> prepareFileStoragePathAsync,
+        Action<SettingsViewModel> enterConflictResolutionMode)
+    {
+        await prepareFileStoragePathAsync(settings.TaskStoragePath);
+
+        if (!ShouldAutoPullExistingTaskRepository(settings.TaskStoragePath, currentLocalStoragePath))
+        {
+            return true;
+        }
+
+        await Task.Run(() => backupService?.PullExistingRepository());
+        settings.ReloadGitMetadata();
+        if (!settings.IsConflictResolutionMode)
+        {
+            return true;
+        }
+
+        settings.SetStorageConnectionState(SettingsConnectionState.Disconnected);
+        enterConflictResolutionMode(settings);
+        return false;
+    }
+
+    internal static bool ShouldAutoPullExistingTaskRepository(
+        string? selectedLocalStoragePath,
+        string? currentLocalStoragePath)
+    {
+        if (string.IsNullOrWhiteSpace(currentLocalStoragePath))
+        {
+            return true;
+        }
+
+        return !string.Equals(
+            NormalizeLocalStoragePathForComparison(selectedLocalStoragePath),
+            NormalizeLocalStoragePathForComparison(currentLocalStoragePath),
+            GetPathComparison());
+    }
+
+    private string? GetCurrentLocalStoragePath()
+    {
+        return (_storageFactory?.CurrentStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
+    }
+
     private static Task PrepareFileStoragePathAsync(string? path)
     {
         var prepareFileStoragePathAsync = TaskStorageFactory.PrepareFileStoragePathAsync;
         return prepareFileStoragePathAsync == null
             ? Task.CompletedTask
             : prepareFileStoragePathAsync(path);
+    }
+
+    private static string NormalizeLocalStoragePathForComparison(string? path)
+    {
+        var effectivePath = string.IsNullOrWhiteSpace(path)
+            ? TaskStorageFactory.DefaultStoragePath
+            : path.Trim();
+
+        if (string.IsNullOrWhiteSpace(effectivePath))
+        {
+            effectivePath = "Tasks";
+        }
+
+        try
+        {
+            return Path.GetFullPath(effectivePath);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return effectivePath;
+        }
+    }
+
+    private static StringComparison GetPathComparison()
+    {
+        return OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
     }
 
     private void ConfirmAndRun(

--- a/src/Unlimotion/Services/BackupViaGitService.cs
+++ b/src/Unlimotion/Services/BackupViaGitService.cs
@@ -648,6 +648,14 @@ public class BackupViaGitService : IRemoteBackupService
     {
         lock (LockObject)
         {
+            PullCurrentRepository(notifyCurrentWatcher: true);
+        }
+    }
+
+    public void PullExistingRepository()
+    {
+        lock (LockObject)
+        {
             var settings = GetSettings();
             var path = GetRepositoryPath(settings.repositoryPath);
             if (!Repository.IsValid(path))
@@ -655,110 +663,133 @@ public class BackupViaGitService : IRemoteBackupService
                 return;
             }
 
-            CheckGitSettings(settings.git.UserName, settings.git.Password);
-
-            using var repo = new Repository(path);
-            var remote = repo.Network.Remotes[settings.git.RemoteName];
-            if (remote == null)
+            using (var repo = new Repository(path))
             {
-                ShowUiError(L10n.Format("RemoteNotFound", settings.git.RemoteName));
+                if (!repo.Network.Remotes.Any())
+                {
+                    return;
+                }
+
+                EnsureRemoteNameMatchesLocalRepository(repo, settings.git);
+                EnsurePushRefSpecMatchesLocalRepository(repo, settings.git);
+            }
+
+            PullCurrentRepository(notifyCurrentWatcher: false);
+        }
+    }
+
+    private void PullCurrentRepository(bool notifyCurrentWatcher)
+    {
+        var settings = GetSettings();
+        var path = GetRepositoryPath(settings.repositoryPath);
+        if (!Repository.IsValid(path))
+        {
+            return;
+        }
+
+        CheckGitSettings(settings.git.UserName, settings.git.Password);
+
+        using var repo = new Repository(path);
+        var remote = repo.Network.Remotes[settings.git.RemoteName];
+        if (remote == null)
+        {
+            ShowUiError(L10n.Format("RemoteNotFound", settings.git.RemoteName));
+            return;
+        }
+
+        ShowUiMessage(L10n.Get("StartGitPull"));
+
+        var dbwatcher = notifyCurrentWatcher ? _storageFactory?.CurrentWatcher : null;
+        try
+        {
+            dbwatcher?.SetEnable(false);
+
+            FetchRemote(repo, path, settings.git);
+
+            var localBranch = repo.Branches[settings.git.PushRefSpec];
+            if (localBranch == null)
+            {
+                ShowUiError(L10n.Format("LocalBranchNotFound", settings.git.PushRefSpec));
                 return;
             }
 
-            ShowUiMessage(L10n.Get("StartGitPull"));
-
-            var dbwatcher = _storageFactory?.CurrentWatcher;
-            try
+            var remoteBranch = repo.Branches[$"refs/remotes/{settings.git.RemoteName}/{localBranch.FriendlyName}"];
+            if (remoteBranch == null)
             {
-                dbwatcher?.SetEnable(false);
+                ShowUiError(L10n.Format("RemoteBranchNotFoundAfterFetch", $"{settings.git.RemoteName}/{localBranch.FriendlyName}"));
+                return;
+            }
 
-                FetchRemote(repo, path, settings.git);
+            if (localBranch.Tip.Sha != remoteBranch.Tip.Sha)
+            {
+                var changes = repo.Diff.Compare<TreeChanges>(localBranch.Tip.Tree, remoteBranch.Tip.Tree);
+                var signature = new Signature(
+                    new Identity(settings.git.CommitterName, settings.git.CommitterEmail),
+                    DateTimeOffset.Now);
 
-                var localBranch = repo.Branches[settings.git.PushRefSpec];
-                if (localBranch == null)
+                var stash = repo.Stashes.Add(signature, "Stash before merge");
+
+                Commands.Checkout(repo, settings.git.PushRefSpec);
+
+                try
                 {
-                    ShowUiError(L10n.Format("LocalBranchNotFound", settings.git.PushRefSpec));
-                    return;
-                }
+                    repo.Merge(remoteBranch, signature, new MergeOptions());
 
-                var remoteBranch = repo.Branches[$"refs/remotes/{settings.git.RemoteName}/{localBranch.FriendlyName}"];
-                if (remoteBranch == null)
-                {
-                    ShowUiError(L10n.Format("RemoteBranchNotFoundAfterFetch", $"{settings.git.RemoteName}/{localBranch.FriendlyName}"));
-                    return;
-                }
-
-                if (localBranch.Tip.Sha != remoteBranch.Tip.Sha)
-                {
-                    var changes = repo.Diff.Compare<TreeChanges>(localBranch.Tip.Tree, remoteBranch.Tip.Tree);
-                    var signature = new Signature(
-                        new Identity(settings.git.CommitterName, settings.git.CommitterEmail),
-                        DateTimeOffset.Now);
-
-                    var stash = repo.Stashes.Add(signature, "Stash before merge");
-
-                    Commands.Checkout(repo, settings.git.PushRefSpec);
-
-                    try
+                    foreach (var change in changes)
                     {
-                        repo.Merge(remoteBranch, signature, new MergeOptions());
-
-                        foreach (var change in changes)
+                        UpdateType mode;
+                        switch (change.Status)
                         {
-                            UpdateType mode;
-                            switch (change.Status)
-                            {
-                                case ChangeKind.Added:
-                                case ChangeKind.Modified:
-                                case ChangeKind.Renamed:
-                                case ChangeKind.Copied:
-                                    mode = UpdateType.Saved;
-                                    break;
-                                case ChangeKind.Deleted:
-                                    mode = UpdateType.Removed;
-                                    break;
-                                default:
-                                    continue;
-                            }
-
-                            dbwatcher?.ForceUpdateFile(change.Path, mode);
+                            case ChangeKind.Added:
+                            case ChangeKind.Modified:
+                            case ChangeKind.Renamed:
+                            case ChangeKind.Copied:
+                                mode = UpdateType.Saved;
+                                break;
+                            case ChangeKind.Deleted:
+                                mode = UpdateType.Removed;
+                                break;
+                            default:
+                                continue;
                         }
 
-                        ShowUiMessage(L10n.Get("MergeSuccessful"));
-                    }
-                    catch (Exception ex)
-                    {
-                        var errorMessage = L10n.Format("MergeRemoteBranchFailed", ex.Message);
-                        Debug.WriteLine(errorMessage);
-                        ShowUiError(errorMessage, ex);
+                        dbwatcher?.ForceUpdateFile(change.Path, mode);
                     }
 
-                    if (stash != null)
-                    {
-                        var stashIndex = repo.Stashes.ToList().IndexOf(stash);
-                        var applyStatus = repo.Stashes.Apply(stashIndex);
+                    ShowUiMessage(L10n.Get("MergeSuccessful"));
+                }
+                catch (Exception ex)
+                {
+                    var errorMessage = L10n.Format("MergeRemoteBranchFailed", ex.Message);
+                    Debug.WriteLine(errorMessage);
+                    ShowUiError(errorMessage, ex);
+                }
 
-                        ShowUiMessage(L10n.Get("StashApplied"));
-                        if (applyStatus == StashApplyStatus.Applied)
-                        {
-                            repo.Stashes.Remove(stashIndex);
-                        }
-                    }
+                if (stash != null)
+                {
+                    var stashIndex = repo.Stashes.ToList().IndexOf(stash);
+                    var applyStatus = repo.Stashes.Apply(stashIndex);
 
-                    if (repo.Index.Conflicts.Any())
+                    ShowUiMessage(L10n.Get("StashApplied"));
+                    if (applyStatus == StashApplyStatus.Applied)
                     {
-                        ShowUiError(L10n.Get("FixConflictsCommitResult"));
+                        repo.Stashes.Remove(stashIndex);
                     }
                 }
+
+                if (repo.Index.Conflicts.Any())
+                {
+                    ShowUiError(L10n.Get("FixConflictsCommitResult"));
+                }
             }
-            catch (Exception ex)
-            {
-                ShowUiError(L10n.Format("PullErrorToast", ex.Message), ex);
-            }
-            finally
-            {
-                dbwatcher?.SetEnable(true);
-            }
+        }
+        catch (Exception ex)
+        {
+            ShowUiError(L10n.Format("PullErrorToast", ex.Message), ex);
+        }
+        finally
+        {
+            dbwatcher?.SetEnable(true);
         }
     }
 

--- a/src/Unlimotion/Views/SettingsControl.axaml
+++ b/src/Unlimotion/Views/SettingsControl.axaml
@@ -198,7 +198,8 @@
                         <StackPanel Classes="FieldGroup">
                             <TextBlock Classes="FieldLabel" Text="{DynamicResource DataFolder}" />
                             <Grid Classes="FieldActionRow" ColumnDefinitions="*,Auto">
-                                <TextBox Text="{Binding TaskStoragePath}"
+                                <TextBox AutomationProperties.AutomationId="TaskStoragePathTextBox"
+                                         Text="{Binding TaskStoragePath}"
                                          ToolTip.Tip="{Binding TaskStoragePathTooltip}" />
                                 <Button Grid.Column="1"
                                         AutomationProperties.AutomationId="BrowseTaskStoragePathButton"
@@ -207,10 +208,13 @@
                             </Grid>
                         </StackPanel>
 
-                        <TextBlock Classes="StatusText" Text="{Binding StorageStatusText}" />
+                        <TextBlock Classes="StatusText"
+                                   AutomationProperties.AutomationId="StorageStatusText"
+                                   Text="{Binding StorageStatusText}" />
 
                         <WrapPanel Classes="ActionButtons">
                             <Button Content="{DynamicResource Connect}"
+                                    AutomationProperties.AutomationId="ConnectLocalStorageButton"
                                     Command="{Binding ConnectCommand}"
                                     IsEnabled="{Binding CanConnectStorage}" />
                         </WrapPanel>


### PR DESCRIPTION
## Summary
- Add conditional auto-pull for an already existing Git task directory before switching local task storage.
- No-op when the selected folder is not a Git repository or has no remote.
- Keep pre-switch auto-pull isolated from the current storage watcher while preserving watcher notifications for manual pull.
- Add service, command-level, and Settings UI regression coverage plus the approved QUEST spec.

## Root Cause
Switching the local task directory loaded the selected folder as `FileStorage` before attempting to synchronize an existing Git repository in that folder, so users could see stale local task files until manually pulling.

## Validation
- `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore /clp:ErrorsOnly`
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj --no-build -- --treenode-filter "/*/*/BackupViaGitServiceTests/*Watcher*"`
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj --no-build -- --treenode-filter "/*/*/BackupViaGitServiceTests/*PullExistingRepository*"`
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj --no-build -- --treenode-filter "/*/*/SettingsViewModelTests/*ConnectCommand*"`
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj --no-build -- --treenode-filter "/*/*/SettingsViewModelTests/*PrepareLocalStorageConnectionAsync*"`
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj --no-build -- --treenode-filter "/*/*/SettingsControlResponsiveUiTests/SettingsControl_LocalStorageConnect_UsesEditedTaskStoragePath"`
- `dotnet build src\Unlimotion.Desktop\Unlimotion.Desktop.csproj --no-restore /clp:ErrorsOnly`
- `git diff --check`

## Notes
Full TUnit run and full solution build were not used as final gates because the existing headless conflict UI test / Android target path has been unstable in this workspace; targeted coverage for this change passed.