### PR TITLE
Add roadmap multi-selection

### DIFF
--- a/specs/2026-05-13-roadmap-multi-selection.md
+++ b/specs/2026-05-13-roadmap-multi-selection.md
@@ -1,0 +1,384 @@
+# Roadmap multi-selection
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; stack profile `dotnet-desktop-client`; overlay profile `ui-automation-testing`.
+- Владелец: Codex / Unlimotion desktop UI.
+- Масштаб: medium.
+- Целевая модель: gpt-5.5.
+- Целевой релиз / ветка: текущая рабочая ветка.
+- Ограничения: central `QUEST` требует SPEC-first и подтверждение фразой `Спеку подтверждаю` до изменений кода; локальный override требует UI tests для UI-facing изменений.
+- Связанные ссылки: `AGENTS.md`, `AGENTS.override.md`, `C:\Users\Kibnet\.codex\agents\AGENTS.md`, `C:\Users\Kibnet\.codex\agents\instructions\governance\routing-matrix.md`, `C:\Users\Kibnet\.codex\agents\instructions\core\quest-mode.md`, `C:\Users\Kibnet\.codex\agents\instructions\profiles\dotnet-desktop-client.md`, `C:\Users\Kibnet\.codex\agents\instructions\profiles\ui-automation-testing.md`.
+
+Если секция не применима, явно указано `Не применимо`.
+
+## 1. Overview / Цель
+Добавить на вкладку Roadmap множественный выбор задач с двумя визуальными состояниями:
+- текущая задача, открытая/выбранная в правой карточке через `MainWindowViewModel.CurrentTaskItem`;
+- набор roadmap-задач, выделенных пользователем кликами или прямоугольником выделения.
+
+Outcome contract:
+- Success means: пользователь видит текущую открытую задачу и выделенные задачи на roadmap, а клики и прямоугольник выделения меняют набор выделения по правилам `None/Ctrl/Shift/Alt`.
+- Amendment 2026-05-14: выделенные roadmap-задачи участвуют в drag/drop массово, как selection в остальных вкладках.
+- Итоговый артефакт / output: scoped changes в `GraphControl`/roadmap node state плюс Avalonia.Headless regression UI tests.
+- Stop rules: не менять persisted task data, не менять roadmap layout algorithm, не завершать EXEC без релевантных UI tests или явного blocker report.
+
+## 2. Текущее состояние (AS-IS)
+- Roadmap живёт в `src/Unlimotion/Views/GraphControl.axaml` и рендерится через `nodify:NodifyEditor` с `RoadmapNodes` и `RoadmapConnections`.
+- Roadmap node представлен `RoadmapNode` в `src/Unlimotion/Views/Graph/RoadmapNode.cs`; сейчас он хранит `TaskItem`, `Location`, `Width`, anchors и не имеет state выбора.
+- Визуальная карточка node в `GraphControl.axaml` сейчас имеет прозрачный `Border`, `CheckBox`, emoji/marker и title. Есть только `Classes.highlighted` для поиска и task-state classes `IsWanted` / `IsCanBeCompleted`.
+- `GraphControl.InputElement_OnPointerPressed` уже выбирает clicked task через `SelectRoadmapTask`, а `InputElement_OnPointerMoved` запускает drag roadmap task после threshold.
+- Right-button drag поверх task уже используется для pan viewport; node drag source и drop behavior не должны регрессировать.
+- `MainWindowViewModel.CurrentTaskItem` и `SelectCurrentTask()` остаются текущим механизмом opened/current task; `CurrentGraphItem` синхронизируется через существующий VM path.
+- Обычные tree tabs уже поддерживают массовый drag/drop через batch drag payload из выбранных `TaskWrapperViewModel` и общий `MainControl.Drop`.
+- Roadmap single drag сейчас кладёт в `GraphControl.CustomDataFormat` один `TaskItemViewModel`; общий drop умеет принимать этот single graph payload, но не получает roadmap selection batch.
+- В `src/Unlimotion.Test/RoadmapGraphUiTests.cs` уже есть headless UI coverage для roadmap rendering, click/double-click, drag threshold, pan, hotkeys и overlay behavior.
+
+## 3. Проблема
+Roadmap не имеет отдельного множества выделенных задач и визуально не различает открытую текущую задачу от выделенных задач, поэтому пользователь не может выбирать несколько задач на графе ожидаемыми click/rectangle gestures.
+
+## 4. Цели дизайна
+- Разделение ответственности: transient roadmap selection хранить в `GraphControl`/`RoadmapNode`, а opened task оставить в `MainWindowViewModel.CurrentTaskItem`.
+- Повторное использование: использовать существующие pointer handlers, viewport adapter и headless UI helpers без нового доменного API.
+- Тестируемость: покрыть click selection и rectangle selection через Avalonia.Headless UI tests.
+- Консистентность: modifier semantics одинаковы для click и rectangle selection.
+- Обратная совместимость: не менять persisted model, task storage, graph builder layout и существующие automation ids.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не добавлять batch delete/copy commands для roadmap selection вне drag/drop flow.
+- Не менять drag-drop relation behavior, node drag threshold, right-button pan и double-click details toggle.
+- Не внедрять range-selection между anchor/current items; по запросу `Shift+click` именно добавляет clicked task.
+- Не сохранять roadmap selection между перезапусками.
+- Не менять алгоритм `RoadmapGraphBuilder` и порядок/координаты node layout.
+- Не менять tree tab multiple selection.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `src/Unlimotion/Views/Graph/RoadmapNode.cs` -> добавить observable flags для visual state: `IsSelected`, `IsCurrent`.
+- `src/Unlimotion/Views/GraphControl.axaml.cs` -> хранить selected task ids, применять selection operations, синхронизировать `IsCurrent` с owner VM, обрабатывать marquee selection lifecycle.
+- `src/Unlimotion/Views/GraphControl.axaml.cs` -> при drag start по выбранной roadmap node отдавать batch payload выбранных visible tasks.
+- `src/Unlimotion/Views/MainControl.axaml.cs` -> расширить общий drop parser, чтобы он принимал roadmap batch payload рядом с tree batch payload.
+- `src/Unlimotion/Views/GraphControl.axaml` -> добавить visual styling node border для `selected/current`, pointer handler на editor background, overlay rectangle selection.
+- `src/Unlimotion.Test/RoadmapGraphUiTests.cs` -> добавить/обновить Avalonia.Headless UI tests для click modifiers, rectangle modifiers и visual state bindings.
+- `specs/2026-05-13-roadmap-multi-selection.md` -> рабочая спецификация и журнал.
+
+### 6.2 Детальный дизайн
+- Roadmap selection state:
+  - `GraphControl` хранит `HashSet<string>` selected roadmap task ids.
+  - `RoadmapNode.IsSelected` отражает membership id в selected set.
+  - `RoadmapNode.IsCurrent` отражает `owner.CurrentTaskItem?.Id == node.Id`.
+  - После `ApplyProjection` state применяется к reused/new nodes; selection ids, которых больше нет среди visible `RoadmapNodes`, prune-ятся до visible set.
+  - Выделение касается только видимых roadmap-задач: если задача скрыта фильтрами roadmap, она теряет выделение.
+  - Поиск не меняет состав roadmap nodes и не должен менять выделение; он только обновляет `TaskItemViewModel.IsHighlighted` / visual highlight.
+- Current task synchronization:
+  - При кликах без удаления task из selection clicked task становится `CurrentTaskItem` через существующий `SelectRoadmapTask`.
+  - При external change `CurrentTaskItem` нужно обновить node `IsCurrent`; допустимо подписаться на owner VM через `WhenAnyValue(m => m.CurrentTaskItem)` в roadmap control scope.
+  - Rectangle selection меняет только selected set и не переключает открытую карточку, чтобы не открывать произвольную задачу при массовом выделении.
+- Click selection semantics:
+  - Plain click: selected set = только clicked task; clicked task становится current/opened.
+  - `Ctrl+click`: если clicked task selected, убрать её; иначе добавить. При добавлении clicked task становится current/opened; при удалении current/opened task не меняется.
+  - `Shift+click`: добавить clicked task; clicked task становится current/opened.
+  - `Alt+click`: убрать clicked task; current/opened task не меняется.
+  - Если нажато несколько selection modifiers одновременно, precedence: `Alt` remove, иначе `Ctrl` toggle, иначе `Shift` add, иначе replace.
+- Double-click selection semantics:
+  - Double-click без modifiers применяет plain click selection один раз за жест и затем переключает details pane.
+  - Double-click с `Ctrl`/`Shift`/`Alt` применяет соответствующую modifier selection operation один раз за жест и затем переключает details pane.
+  - Второй press/click внутри double-click не должен повторно менять selected set, чтобы `Ctrl+double-click` не превращался в toggle туда-обратно.
+- Rectangle selection semantics:
+  - Rectangle gesture начинается левым drag по пустой области `RoadmapEditor`, а не по node, чтобы не конфликтовать с roadmap node drag.
+  - Plain rectangle: selected set = все visible nodes, whose rendered bounds intersect rectangle.
+  - `Ctrl+rectangle`: invert selection state for all intersecting nodes.
+  - `Shift+rectangle`: add all intersecting nodes.
+  - `Alt+rectangle`: remove all intersecting nodes.
+  - Rectangle with no hits applies the same operation to empty hit set; for plain rectangle this clears selection.
+  - Click on empty editor without drag threshold does not change current task; selection clearing is done by plain rectangle result, not by accidental background click.
+- Rectangle hit testing:
+  - Track pointer start/current points in the same visual coordinate space that draws the selection rectangle.
+  - Collect rendered node `Border` controls by `DataContext is RoadmapNode`.
+  - Use `TranslatePoint` + `Bounds` to compare rendered node bounds with selection rectangle in that same coordinate space. This avoids depending on raw layout coordinates and keeps overlay drawing and hit testing aligned after viewport transforms or non-zero editor offset.
+- Visual design:
+  - Add classes/bindings on node `Border`: `roadmapSelected`, `roadmapCurrent`.
+  - Selected nodes receive visible fill/border; current node receives a distinct stronger border/accent. If both states apply, combined state must be readable.
+  - Search highlight (`IsHighlighted`) on text remains independent.
+  - Add selection rectangle overlay with semi-transparent fill and border, `IsHitTestVisible=false`, stable automation id such as `RoadmapSelectionRectangle`.
+- Output contract / evidence rules:
+  - UI tests must assert both state (`RoadmapNode.IsSelected`/`IsCurrent`) and at least one visual binding/class or visible selection rectangle behavior.
+  - Existing tests for node click, node drag threshold, right-drag pan, double-click and hotkeys must continue to pass.
+- Performance:
+  - Selection operations are O(visible nodes) only during pointer actions.
+  - No rebuild is triggered by selection state changes.
+  - No background task or storage mutation is introduced.
+
+### 6.3 Amendment 2026-05-14: batch drag/drop выбранных roadmap-задач
+- Roadmap drag source:
+  - Если drag начинается plain left-drag с выбранной roadmap node и selected set содержит больше одной visible task, drag payload должен содержать все выбранные visible roadmap tasks.
+  - Если drag начинается с невыбранной node, поведение остаётся single: task становится единственной selected/current и drag payload содержит только её.
+  - Если plain click по уже выбранной node не переходит threshold drag, selection после release схлопывается до clicked task, как и текущий plain click contract.
+  - Чтобы не конфликтовать с selection modifiers, drag candidate стартует только без `Ctrl`/`Shift`/`Alt` на исходном pointer press; operation modifiers можно нажимать уже во время drag/drop, как в остальных вкладках.
+- Drop behavior:
+  - Roadmap batch payload должен идти через существующий `MainControl.Drop` и использовать те же operation modifiers:
+    - none -> copy into target;
+    - `Shift` -> move into target;
+    - `Ctrl` -> dragged sources block target;
+    - `Alt` -> target blocks dragged sources;
+    - `Ctrl+Shift` -> clone into target.
+  - Для batch operations сохраняются существующие проверки `CanMoveInto` / `CanCreateBlockingRelation`, batch confirmation и error toast.
+  - Roadmap не имеет wrapper source context. Поэтому `Shift` move для roadmap batch разрешён только для source tasks, где source parent можно однозначно вывести так же, как для single `TaskItemViewModel` graph drag: `Parents.Count <= 1`; иначе операция отклоняется существующим `MoveMissingParent` / batch error.
+  - Drop на одну из dragged selected tasks должен отклоняться существующими validation rules.
+- Selection/current interaction:
+  - Начало drag по уже выбранной node не должно визуально сбрасывать multi-selection до пересечения drag threshold.
+  - После успешного или отменённого batch drag selected set остаётся выделенным.
+  - Rectangle selection и click modifier selection остаются transient visible-only state; hidden-by-filter tasks не попадают в batch payload.
+
+## 7. Бизнес-правила / Алгоритмы
+Selection operation table:
+
+| Gesture | Modifier | Operation on hit tasks | Current/opened task |
+| --- | --- | --- | --- |
+| Click task | none | Replace selection with clicked task | clicked task |
+| Click task | Ctrl | Toggle clicked task | clicked task only when added |
+| Click task | Shift | Add clicked task | clicked task |
+| Click task | Alt | Remove clicked task | unchanged |
+| Double-click task | none | Replace selection with clicked task once | clicked task, then toggle details |
+| Double-click task | Ctrl | Toggle clicked task once | clicked task only when added, then toggle details |
+| Double-click task | Shift | Add clicked task once | clicked task, then toggle details |
+| Double-click task | Alt | Remove clicked task once | unchanged, then toggle details |
+| Rectangle | none | Replace selection with intersecting tasks | unchanged |
+| Rectangle | Ctrl | Toggle every intersecting task | unchanged |
+| Rectangle | Shift | Add every intersecting task | unchanged |
+| Rectangle | Alt | Remove every intersecting task | unchanged |
+| Drag selected roadmap node | none on press | Drag all selected visible tasks if more than one selected; otherwise drag clicked task | clicked task/current unchanged except existing click sync |
+| Drop roadmap batch | none / Ctrl / Shift / Alt / Ctrl+Shift | Same batch operation semantics as tree tabs | unchanged by drop target selection |
+
+Invariants:
+- `IsCurrent` is not the same as `IsSelected`; a node may be current without being selected and selected without being current.
+- Selection is local to visible roadmap nodes and transient.
+- Фильтры roadmap могут убирать задачи из visible set, и тогда выделение скрытых задач сбрасывается.
+- Поиск не является фильтром состава roadmap nodes в рамках этой задачи и не меняет selected set.
+- Double-click применяет click selection semantics только один раз за gesture, включая modifier variants.
+- Node drag starts only from node left-drag after threshold; rectangle selection starts only from editor empty-space left-drag after threshold.
+- Batch roadmap drag includes only currently visible selected roadmap nodes.
+- Selection modifiers on pointer press are selection gestures; drag operation modifiers are evaluated by `DragOver`/`Drop`.
+
+## 8. Точки интеграции и триггеры
+- `GraphControl.DataContextChanged` / owner VM discovery -> subscribe/unsubscribe current task changes.
+- `ApplyProjection` -> reuse nodes, then apply selection/current flags.
+- Roadmap node `PointerPressed` -> click selection operation plus existing current selection and double-click behavior.
+- Roadmap node `PointerMoved` -> existing pending drag behavior unchanged.
+- Roadmap editor/background `PointerPressed` -> start pending rectangle selection candidate when left button starts outside task node.
+- `GraphControl` existing tunnel/bubble `PointerMoved`/`PointerReleased` handlers -> update/commit rectangle selection or keep existing node drag/pan paths.
+- `GraphControl.StartRoadmapDragAsync` -> build single or batch roadmap drag payload.
+- `MainControl.TryBuildOperationItems` / drag data recognition -> accept roadmap batch task payload in addition to tree batch wrapper payload and single task payload.
+- XAML overlay -> visualize active rectangle.
+
+## 9. Изменения модели данных / состояния
+- Новые runtime-only properties:
+  - `RoadmapNode.IsSelected`.
+  - `RoadmapNode.IsCurrent`.
+  - `GraphControl` private selected id set and pending rectangle context.
+  - `GraphControl` runtime-only roadmap batch drag data object.
+  - `GraphControl` styled/direct properties for rectangle overlay visibility/coordinates/sizes if needed for binding.
+- Persisted state: не применимо, хранилище задач не меняется.
+- Public API: не планируется. Если tests требуют inspection, использовать public `RoadmapNode` properties because `RoadmapNodes` is already public on `GraphControl`.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция данных: не применимо.
+- Первый запуск: selection пустой; current node подсвечивается только если `CurrentTaskItem` уже задан и roadmap открыт.
+- Rollout: обычный desktop build.
+- Rollback: откатить изменения в `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapNode.cs`, UI tests и эту спецификацию; пользовательские данные не затрагиваются.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  1. При открытой Roadmap текущая `CurrentTaskItem` visually marked as current node.
+  2. Plain click по task node оставляет selected set из одной task и делает clicked task current/opened.
+  3. `Ctrl+click` добавляет unselected task и убирает selected task без сброса остальных selected tasks.
+  4. `Shift+click` добавляет clicked task к selection.
+  5. `Alt+click` убирает clicked task из selection.
+  6. Plain rectangle по пустой области editor выбирает все visible nodes, пересекающиеся с rectangle, и заменяет прежнюю selection.
+  7. `Ctrl+rectangle` инвертирует selection для всех hit nodes.
+  8. `Shift+rectangle` добавляет все hit nodes к selection.
+  9. `Alt+rectangle` убирает все hit nodes из selection.
+  10. Rectangle overlay виден во время drag и скрывается после release/cancel.
+  11. Rectangle selection не меняет `CurrentTaskItem`.
+  12. Node left-drag после threshold всё ещё запускает roadmap drag source, а right-drag поверх node всё ещё двигает viewport и не выбирает задачу.
+  13. Double-click roadmap node продолжает переключать details pane и применяет click/modifier selection semantics ровно один раз за gesture.
+  14. Если roadmap-фильтр скрывает selected task, эта task исчезает из selected set; при возврате фильтра она не становится selected автоматически.
+  15. Изменение поискового текста и search highlight не меняют selected set.
+  16. Rectangle overlay и rectangle hit testing используют одну visual coordinate space; после pan/zoom или non-zero editor offset hit nodes соответствуют видимому прямоугольнику.
+  17. Plain drag с выбранной roadmap node при multi-selection создаёт batch drop operation для всех selected visible tasks.
+  18. Plain drag с невыбранной roadmap node остаётся single drag и схлопывает selection до dragged task.
+  19. Plain press/release по выбранной roadmap node без drag threshold всё ещё выполняет обычный plain click и оставляет выбранной только clicked task.
+  20. Roadmap batch drop использует те же operation modifiers и validation, что tree batch drop; как минимум UI test должен проверить массовое создание blocking relation или copy/move effect для двух выбранных roadmap tasks.
+- Какие тесты добавить/изменить:
+  - Добавить tests в `RoadmapGraphUiTests`:
+    - `RoadmapGraph_NodeClickSelection_AppliesModifierSemanticsAndVisualState`.
+    - `RoadmapGraph_RectangleSelection_AppliesModifierSemanticsAndDoesNotChangeCurrentTask`.
+    - `RoadmapGraph_SelectedNodesDragDrop_AppliesBatchOperation`.
+    - `RoadmapGraph_SelectedNodePlainClickWithoutDrag_CollapsesSelection`.
+    - При необходимости обновить existing node drag/pan tests только для новых assertions, не ослабляя их.
+  - UI tests должны использовать headless `Window.MouseDown/MouseMove/MouseUp` и `RawInputModifiers.Control/Shift/Alt`.
+  - Для visual evidence проверить `RoadmapNode.IsSelected`/`IsCurrent` и наличие соответствующих classes на node `Border` либо effective visual property after binding.
+  - Для rectangle выбрать стабильные visible nodes через existing `WaitForTaskNode` helper и построить drag rectangle по translated bounds.
+- Characterization tests:
+  - Existing roadmap tests for drag threshold, right pan, double click, hotkeys, build/update должны остаться зелёными.
+- Команды для проверки:
+  - `dotnet build src\Unlimotion\Unlimotion.csproj`
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj`
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/*"`
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj`
+- Stop rules для test/retrieval/tool/validation loops:
+  - Если targeted roadmap UI tests падают, не завершать EXEC.
+  - Если full test run падает на unrelated existing issue, зафиксировать конкретную ошибку и предоставить targeted UI + build evidence.
+
+## 12. Риски и edge cases
+- `NodifyEditor` может обрабатывать pointer events before/after `GraphControl`; для rectangle нужно использовать уже существующий `handledEventsToo` path или explicit editor handler так, чтобы не ломать node drag.
+- Pointer capture для rectangle не должен перехватывать node drag/pan gestures.
+- Rectangle start over child controls внутри node должен считаться node gesture, не background rectangle.
+- Selection state может пережить graph rebuild; prune to visible nodes предотвращает stale selection.
+- Фильтры и поиск имеют разный контракт: фильтры меняют visible set и могут сбрасывать selection скрытых задач, поиск только подсвечивает совпадения и не должен сбрасывать selection.
+- Current task может быть filtered out; тогда ни один visible node не имеет `IsCurrent`, но `CurrentTaskItem` не меняется.
+- Roadmap batch drag не имеет tree wrapper parent context; move для tasks с несколькими parent должен быть явно отклонён, а не выбирать случайный parent.
+- Plain drag по already-selected node требует deferred click collapse: нельзя сбрасывать selection на pointer press до того, как понятно, click это или drag.
+- `Alt` modifier в headless tests и на разных ОС может иметь platform nuances; tests должны использовать Avalonia `RawInputModifiers.Alt`.
+- Visual states selected/current/search-highlight must remain readable together.
+
+## 13. План выполнения
+1. Добавить failing Avalonia.Headless tests для click modifier semantics и rectangle selection semantics.
+2. Добавить `IsSelected`/`IsCurrent` в `RoadmapNode`.
+3. Добавить selection state и click modifier handling в `GraphControl`.
+4. Добавить rectangle selection lifecycle, hit testing и overlay properties в `GraphControl`.
+5. Обновить `GraphControl.axaml` styles, node classes и overlay rectangle.
+6. Amendment 2026-05-14: добавить roadmap batch drag payload и поддержку этого payload в `MainControl.Drop`.
+7. Amendment 2026-05-14: обновить click-vs-drag lifecycle для plain drag по already-selected roadmap node.
+8. Прогнать targeted UI tests, build, затем full test run или documented blocker.
+9. Выполнить post-EXEC review: scope, regressions, UI test evidence, stale comments, unintended storage/layout changes.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов.
+
+Принято:
+- Rectangle selection стартует только с пустой области editor, потому что drag от node уже занят существующим переносом task node.
+- Выделение касается только видимых задач; задачи, скрытые roadmap-фильтрами, теряют выделение.
+- Поиск не меняет состав задач и не меняет выделение, он только подкрашивает найденные задачи.
+- Double-click с зажатыми `Ctrl`/`Shift`/`Alt` меняет выделение по modifier semantics, но только один раз за double-click gesture.
+
+Amendment 2026-05-14 подтверждён пользователем после изменения прежнего Non-Goal про batch drag.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client` + `ui-automation-testing`; context `testing-dotnet`; local UI testing override.
+- Выполненные требования профиля:
+  - UI behavior покрывается Avalonia.Headless UI tests.
+  - Изменения не блокируют UI thread длительными синхронными операциями.
+  - Stable automation ids сохраняются; новый automation id добавляется только для rectangle overlay.
+  - Проверки используют TUnit/Microsoft.Testing.Platform style через `dotnet run --project ... -- --treenode-filter`.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion/Views/Graph/RoadmapNode.cs` | Добавить observable visual state `IsSelected`/`IsCurrent` | Node template должен отображать selection/current state |
+| `src/Unlimotion/Views/GraphControl.axaml.cs` | Selection set, click modifiers, rectangle selection lifecycle, current sync | Основное UI behavior roadmap multi-selection |
+| `src/Unlimotion/Views/MainControl.axaml.cs` | Roadmap batch drag payload parsing in common drop flow | Массовый drop выбранных roadmap-задач должен использовать существующий batch drop engine |
+| `src/Unlimotion/Views/GraphControl.axaml` | Node visual classes/styles и rectangle overlay | Пользователь должен видеть current/selected/drag rectangle |
+| `src/Unlimotion.Test/RoadmapGraphUiTests.cs` | Regression UI tests для click/rectangle selection | Локальный override и central profile требуют UI coverage |
+| `specs/2026-05-13-roadmap-multi-selection.md` | Рабочая спецификация и журнал | QUEST gate |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Current roadmap task visual | Нет отдельной подсветки opened/current task | `RoadmapNode.IsCurrent` driving distinct visual state |
+| Roadmap selected tasks | Нет multi-selection state | Local selected id set + `RoadmapNode.IsSelected` |
+| Plain click | Выбирает current task | Выбирает current task и заменяет selection одним node |
+| Ctrl/Shift/Alt click | Нет roadmap selection semantics | Toggle/add/remove по clicked node |
+| Rectangle selection | Нет | Replace/toggle/add/remove по rendered node bounds |
+| Roadmap drag source | Всегда single `TaskItemViewModel` | Single для невыбранной dragged task, batch для selected visible roadmap tasks |
+| Roadmap batch drop | Не поддержан | Общий `MainControl.Drop` применяет existing batch operation semantics к roadmap batch payload |
+| Storage/model | Не меняется | Не меняется |
+
+## 18. Альтернативы и компромиссы
+- Вариант: хранить roadmap selection в `MainWindowViewModel`.
+- Плюсы: selection могла бы стать общей для будущих batch commands.
+- Минусы: расширяет VM public surface и создаёт продуктовый контракт для batch operations, которые не входят в запрос.
+- Почему выбранное решение лучше в контексте этой задачи: пользователю нужна UI selection на вкладке roadmap; local transient state минимален и не меняет доменную модель.
+
+- Вариант: использовать built-in selection `NodifyEditor`.
+- Плюсы: потенциально меньше code-behind для selected nodes.
+- Минусы: `ItemContainer` сейчас `IsSelectable=False`, roadmap уже имеет custom pointer drag/drop behavior; built-in selection может конфликтовать с task drag, pan и existing tests.
+- Почему выбранное решение лучше в контексте этой задачи: custom local state точнее контролирует modifier semantics и не ломает существующие roadmap gestures.
+
+- Вариант: rectangle selection может стартовать с node.
+- Плюсы: пользователь мог бы начинать рамку из любой точки.
+- Минусы: конфликтует с существующим node drag source после threshold.
+- Почему выбранное решение лучше в контексте этой задачи: empty-space rectangle сохраняет текущий task drag contract.
+
+- Вариант: конвертировать selected roadmap tasks в synthetic `TaskWrapperViewModel`.
+- Плюсы: можно переиспользовать tree batch payload без изменений общего drop parser.
+- Минусы: roadmap не имеет wrapper path/source parent context; synthetic wrappers могут создать ложный источник для move и скрыть ambiguous multi-parent case.
+- Почему выбранное решение лучше в контексте этой задачи: отдельный roadmap batch payload честно передаёт только task identities, а общий drop parser явно применяет те же ограничения, что single graph drag.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+| --- | --- | --- | --- |
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, goals и Non-Goals зафиксированы. |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, алгоритмы, интеграции, state и rollout описаны. |
+| C. Безопасность изменений | 11-13 | PASS | Persisted data не меняется, rollback code-only, edge cases перечислены. |
+| D. Проверяемость | 14-16 | PASS | Acceptance Criteria, UI tests и команды TUnit/MTP указаны. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Этапы и компромиссы определены, блокирующих вопросов нет. |
+| F. Соответствие профилю | 20 | PASS | .NET desktop + UI automation + local UI test requirement учтены. |
+
+Итог: ГОТОВО.
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+| --- | --- | --- |
+| 1. Ясность цели и границ | 5 | Описаны две визуальные роли и точные Non-Goals. |
+| 2. Понимание текущего состояния | 5 | Зафиксированы `GraphControl`, `RoadmapNode`, VM current task и existing tests. |
+| 3. Конкретность целевого дизайна | 5 | Есть state model, click/rectangle tables, hit-testing и visual contract. |
+| 4. Безопасность (миграция, откат) | 5 | Нет persisted изменений; rollback локальный. |
+| 5. Тестируемость | 5 | Есть targeted UI tests и конкретные commands. |
+| 6. Готовность к автономной реализации | 5 | План линейный, открытых блокеров нет. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению.
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: добавлены явные правила различения `IsCurrent` и `IsSelected`; уточнено, что rectangle selection не меняет `CurrentTaskItem`; зафиксирован modifier precedence для конфликтующих modifiers; добавлен prune selected ids после rebuild; добавлены regression constraints для existing node drag и right pan; после review уточнено, что roadmap-фильтры сбрасывают выделение скрытых задач, а поиск выделение не меняет; double-click с modifiers применяет selection semantics один раз за gesture; hit testing и overlay rectangle привязаны к одной visual coordinate space.
+- Что осталось на решение пользователя: требуется утверждение спеки фразой `Спеку подтверждаю`.
+
+### Post-EXEC Review
+- Статус: PASS
+- Что исправлено до завершения: после первичного падения targeted roadmap UI tests исправлена setup-логика preselected task в filter/search сценариях; повторный targeted roadmap прогон зелёный.
+- Что исправлено до завершения amendment 2026-05-14: добавлен отдельный roadmap batch drag payload вместо synthetic wrappers; plain click по already-selected roadmap node перенесён на release, чтобы drag threshold не сбрасывал multi-selection; common drop parser расширен без изменения tree batch payload.
+- Что исправлено по review comments: marquee hit-testing ограничен main `RoadmapEditor`, чтобы не учитывать minimap item borders; double-click details toggle больше не принудительно меняет `CurrentTaskItem`, если modifier selection operation должна оставить current unchanged; duplicate-selection suppression для double-click теперь опирается на `ClickCount > 1` без локального `500ms` окна; после rebase на актуальный `origin/main` сохранена совместимость с inline-редактированием roadmap title.
+- Что проверено дополнительно для refactor / comments: просмотрен diff на выход за scope, скрытые storage/layout изменения, stale comments и regression risk в pointer gesture lifecycle; после rebase `git diff --check` не нашёл whitespace errors; `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj -v:minimal`, `dotnet build src\Unlimotion\Unlimotion.csproj -v:minimal`, Roadmap UI tests 43/43, новый targeted double-click interval regression 1/1 и MainControlTreeCommands UI tests 34/34 прошли.
+- Остаточные риски / follow-ups: полный прогон `dotnet run --no-build --project src\Unlimotion.Test\Unlimotion.Test.csproj` до rebase дважды был остановлен по timeout 10 минут без диагностического вывода; после rebase повторно остановлен по timeout 15 минут без диагностического вывода и оставшийся `dotnet` process был завершён.
+
+## Approval
+Получено подтверждение пользователя для исходной версии: "Спеку подтверждаю".
+
+Получено подтверждение пользователя для amendment 2026-05-14: "спеку подтверждаю".
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Сбор instruction stack и UI-контекста | 0.95 | Нет | Создать рабочую спецификацию | Да, перед EXEC | Нет | Central QUEST требует SPEC-first; локальный override требует UI tests для UI-facing roadmap behavior | `AGENTS.md`, `AGENTS.override.md`, central instructions |
+| SPEC | Анализ AS-IS roadmap selection | 0.90 | Нужен EXEC test-first для точного поведения hit testing | Зафиксировать TO-BE и tests | Да, перед EXEC | Нет | Roadmap node click/drag/pan уже живут в `GraphControl`, поэтому selection нужно встроить без изменения storage/layout | `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapNode.cs`, `RoadmapGraphUiTests.cs` |
+| SPEC | SPEC quality gate и post-SPEC review | 0.94 | Нет | Дождаться утверждения спеки | Да | Да, ожидается фраза `Спеку подтверждаю` | Spec прошёл linter/rubric; до approval central QUEST запрещает менять код | `specs/2026-05-13-roadmap-multi-selection.md` |
+| SPEC | Уточнение filter/search semantics | 0.95 | Нужно уточнить double-click modifiers | Задать вопрос пользователю | Да | Да, пользователь уточнил filter/search behavior | Зафиксировано: выделение только visible tasks; фильтры сбрасывают selection скрытых задач; поиск только подсвечивает и не меняет selection | `specs/2026-05-13-roadmap-multi-selection.md` |
+| SPEC | Уточнение double-click modifiers | 0.95 | Нет | Дождаться утверждения спеки | Да | Да, пользователь уточнил double-click behavior | Зафиксировано: double-click с `Ctrl`/`Shift`/`Alt` меняет selection по modifier semantics один раз за gesture и затем переключает details pane | `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Подтверждение спеки | 0.95 | Нет | Добавить UI tests и реализацию | Нет | Да, пользователь подтвердил фразой `Спеку подтверждаю` | Переход в EXEC разрешён central QUEST contract | `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Реализация roadmap multi-selection | 0.90 | Нет | Запустить targeted UI tests и сборки | Нет | Нет | Добавлены runtime-only state flags, click/rectangle selection lifecycle, visual classes и overlay без изменений storage/layout builder | `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapNode.cs`, `RoadmapGraphUiTests.cs` |
+| EXEC | Проверка targeted UI behavior | 0.92 | Нет | Запустить broader checks | Нет | Нет | Targeted roadmap UI tests сначала выявили setup issue, после исправления прошли; related tree command UI tests также прошли | `RoadmapGraphUiTests.cs` |
+| EXEC | Финальная validation и post-EXEC review | 0.88 | Полный test suite не завершился за 10 минут | Подготовить итоговый отчёт | Нет | Нет | Сборки приложения и тестового проекта прошли; `git diff --check` чистый по whitespace errors; полный прогон зафиксирован как остаточный риск из-за timeout | `specs/2026-05-13-roadmap-multi-selection.md` |
+| SPEC | Amendment: roadmap batch drag/drop | 0.88 | Нужно подтверждение изменения scope | Дождаться повторного утверждения amendment | Да | Нет | Пользователь указал недоделку: selected roadmap tasks должны drag/drop-аться массово как в остальных вкладках; это отменяет прежний Non-Goal про batch drag | `specs/2026-05-13-roadmap-multi-selection.md`, `GraphControl.axaml.cs`, `MainControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| EXEC | Подтверждение amendment 2026-05-14 | 0.95 | Нет | Реализовать batch drag/drop | Нет | Да, пользователь подтвердил фразой `спеку подтверждаю` | Переход в EXEC для amendment разрешён QUEST contract | `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Реализация roadmap batch drag/drop | 0.90 | Нет | Прогнать targeted UI tests и сборки | Нет | Нет | Roadmap drag теперь отдаёт batch payload для selected visible tasks; common drop parser применяет existing batch operation semantics; click collapse deferred до release | `GraphControl.axaml.cs`, `MainControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| EXEC | Проверка amendment и post-EXEC review | 0.86 | Полный test suite повторно не завершился за 10 минут | Обновить PR branch | Нет | Нет | Roadmap UI tests 39/39, MainControlTreeCommands UI tests 34/34, build app/test зелёные; full suite timeout без вывода зафиксирован как остаточный риск | `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Исправление PR review comments | 0.92 | Нет | Обновить PR branch | Нет | Да, пользователь передал 2 review findings | Исправлены minimap false-positive hit-testing и double-click modifier current semantics; добавлены UI regression tests; Roadmap UI tests 41/41 и сборки зелёные | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Rebase на актуальный main | 0.90 | Нет | Обновить PR branch | Нет | Нет | Разрешены конфликты с inline-редактированием roadmap title из `main`; сохранены roadmap selection/drag semantics; после rebase прошли build app/test, Roadmap UI 42/42, MainControlTreeCommands UI 34/34 и `git diff --check`; full suite timeout 15m без вывода зафиксирован как остаточный риск | `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Исправление PR review comment про double-click interval | 0.94 | Нет | Обновить PR branch | Нет | Да, пользователь попросил исправить | Убран локальный `500ms` guard из duplicate-selection suppression: `ClickCount > 1` уже отражает platform double-click interval; добавлен regression-тест на delayed second click with `ClickCount=2`; прошли build app/test, targeted regression 1/1, Roadmap UI 43/43 и `git diff --check` | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Исправление roadmap pan и layout shift | 0.90 | Full `Unlimotion.Test` run не завершился за 20m; full solution build требует отсутствующий workload `wasm-tools` для Android/iOS | Обновить PR branch | Нет | Да, пользователь сообщил 2 бага | Добавлены regression-тесты для right-drag pan по пустому canvas при выделении и для отсутствия resize/shift от selection frame; код переводит right pan в общий helper и держит border thickness постоянным; прошли desktop/test builds через temp output, targeted UI 2/2, Roadmap UI 45/45 и `git diff --check` | `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Исправление zoom-aware rectangle selection | 0.88 | Headless regression не воспроизвёл падение до фикса, но закрывает zoom-flow после правки | Обновить PR branch | Нет | Да, пользователь сообщил баг масштаба | Hit-test roadmap rectangle теперь строит bounds узла через трансформацию обоих углов в координаты selection overlay, а не смешивает transformed origin с unscaled size; добавлены zoom regression-тесты; прошли targeted UI 3/3, Roadmap UI 47/47, desktop/test builds через temp output и `git diff --check` | `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `specs/2026-05-13-roadmap-multi-selection.md` |
+| EXEC | Rebase на актуальный main после #240 | 0.93 | Full solution build по-прежнему требует отсутствующий workload `wasm-tools`; full `Unlimotion.Test` ранее timeout 20m | Обновить PR branch | Нет | Да, пользователь попросил rebase | Ветка перебазирована на `origin/main` `8e5d3c0` без конфликтов; после rebase прошли Roadmap UI 47/47, desktop/test builds через temp output и `git diff --check`; повторный test build запускался последовательно из-за локальной блокировки общего `obj` при параллельной сборке | `specs/2026-05-13-roadmap-multi-selection.md` |

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -1491,6 +1491,14 @@ public class RoadmapGraphUiTests
                     filter.Source != null &&
                     FindRoadmapNode(graphControl!, filter.Source.Id) != null);
                 var excludedTaskId = excludeFilter.Source.Id;
+                var excludedNodeControl = WaitForTaskNode(graphControl!, excludedTaskId);
+
+                ApplyRoadmapClickSelectionForTest(
+                    graphControl!,
+                    excludedNodeControl,
+                    excludeFilter.Source,
+                    KeyModifiers.None);
+                await Assert.That(FindRoadmapNode(graphControl!, excludedTaskId)?.IsSelected).IsTrue();
 
                 var updateCountBeforeFilterOut = graphControl!.RoadmapGraphUpdateCount;
                 excludeFilter.ShowTasks = true;
@@ -1503,6 +1511,7 @@ public class RoadmapGraphUiTests
                     FindRoadmapNode(graphControl!, excludedTaskId) == null &&
                     FindTaskTitleTextBlock(graphControl!, excludedTaskId) == null);
                 await Assert.That(filteredOut).IsTrue();
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl!).Contains(excludedTaskId)).IsFalse();
 
                 var updateCountBeforeRestore = graphControl.RoadmapGraphUpdateCount;
                 excludeFilter.ShowTasks = false;
@@ -1515,6 +1524,7 @@ public class RoadmapGraphUiTests
                     FindRoadmapNode(graphControl!, excludedTaskId) != null &&
                     FindTaskTitleTextBlock(graphControl!, excludedTaskId) != null);
                 await Assert.That(restored).IsTrue();
+                await Assert.That(FindRoadmapNode(graphControl!, excludedTaskId)?.IsSelected).IsFalse();
             }
             finally
             {
@@ -1581,6 +1591,510 @@ public class RoadmapGraphUiTests
     }
 
     [Test]
+    public async Task RoadmapGraph_NodeClickSelection_AppliesModifierSemanticsAndVisualState()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+                vm.CurrentTaskItem = null;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var root2 = WaitForTaskNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
+                var root3 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask3Id);
+                var blocked = WaitForTaskNode(graphControl, MainWindowViewModelFixture.BlockedTask2Id);
+                var root2Node = (RoadmapNode)root2.DataContext!;
+                var root3Node = (RoadmapNode)root3.DataContext!;
+                var blockedNode = (RoadmapNode)blocked.DataContext!;
+
+                await ClickControlAsync(window, root2);
+                await Assert.That(root2Node.IsSelected).IsTrue();
+                await Assert.That(root2Node.IsCurrent).IsTrue();
+                await Assert.That(root2.Classes.Contains("roadmapSelected")).IsTrue();
+                await Assert.That(root2.Classes.Contains("roadmapCurrent")).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    MainWindowViewModelFixture.RootTask2Id
+                });
+
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Control);
+                await Assert.That(root2Node.IsSelected).IsTrue();
+                await Assert.That(root3Node.IsSelected).IsTrue();
+                await Assert.That(root3Node.IsCurrent).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
+                await Assert.That(root2Node.IsSelected).IsFalse();
+                await Assert.That(root3Node.IsSelected).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+
+                await ClickControlAsync(window, blocked, modifiers: RawInputModifiers.Shift);
+                await Assert.That(root3Node.IsSelected).IsTrue();
+                await Assert.That(blockedNode.IsSelected).IsTrue();
+                await Assert.That(blockedNode.IsCurrent).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.BlockedTask2Id);
+
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Alt);
+                await Assert.That(root3Node.IsSelected).IsFalse();
+                await Assert.That(blockedNode.IsSelected).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.BlockedTask2Id);
+
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Control);
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Control);
+
+                await Assert.That(root3Node.IsSelected).IsTrue();
+                await Assert.That(root3Node.IsCurrent).IsTrue();
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_ModifierDoubleClick_PreservesCurrentTaskSemantics()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+                vm.CurrentTaskItem = null;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var root2 = WaitForTaskNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
+                var root3 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask3Id);
+                var blocked = WaitForTaskNode(graphControl, MainWindowViewModelFixture.BlockedTask2Id);
+                var root2Node = (RoadmapNode)root2.DataContext!;
+
+                await ClickControlAsync(window, blocked);
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Shift);
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
+
+                await Assert.That(root2Node.IsSelected).IsFalse();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+
+                await Task.Delay(600);
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Shift);
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Shift);
+                await Assert.That(root2Node.IsSelected).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+
+                await Task.Delay(600);
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Alt);
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Alt);
+
+                await Assert.That(root2Node.IsSelected).IsFalse();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_ModifierDoubleClickSuppression_UsesClickCountWithoutLocalTimeWindow()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var blocked = WaitForTaskNode(graphControl!, MainWindowViewModelFixture.BlockedTask2Id);
+                var root2 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask2Id);
+                var root3 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask3Id);
+                var root2Node = (RoadmapNode)root2.DataContext!;
+
+                await ClickControlAsync(window, blocked);
+                await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Shift);
+                await Assert.That(root2Node.IsSelected).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+
+                PressRoadmapNode(root2, KeyModifiers.Control, clickCount: 1);
+                await Assert.That(root2Node.IsSelected).IsFalse();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+
+                await Task.Delay(600);
+                PressRoadmapNode(root2, KeyModifiers.Control, clickCount: 2);
+
+                await Assert.That(root2Node.IsSelected).IsFalse();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_SelectedNodeFrame_DoesNotResizeNodeOrShiftContent()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+                vm.CurrentTaskItem = null;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var taskNode = WaitForTaskNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
+                var titleSurface = WaitForRoadmapInlineTitleSurface(
+                    graphControl,
+                    MainWindowViewModelFixture.RootTask2Id);
+                var nodeSizeBefore = taskNode.Bounds.Size;
+                var titleBoundsBefore = GetControlBounds(taskNode, titleSurface);
+
+                await ClickControlAsync(window, taskNode);
+
+                var titleBoundsAfter = GetControlBounds(taskNode, titleSurface);
+                await Assert.That(Math.Abs(taskNode.Bounds.Width - nodeSizeBefore.Width)).IsLessThan(0.001);
+                await Assert.That(Math.Abs(taskNode.Bounds.Height - nodeSizeBefore.Height)).IsLessThan(0.001);
+                await Assert.That(Math.Abs(titleBoundsAfter.X - titleBoundsBefore.X)).IsLessThan(0.001);
+                await Assert.That(Math.Abs(titleBoundsAfter.Y - titleBoundsBefore.Y)).IsLessThan(0.001);
+                await Assert.That(Math.Abs(titleBoundsAfter.Width - titleBoundsBefore.Width)).IsLessThan(0.001);
+                await Assert.That(Math.Abs(titleBoundsAfter.Height - titleBoundsBefore.Height)).IsLessThan(0.001);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_RectangleSelection_AppliesModifierSemanticsAndDoesNotChangeCurrentTask()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                var selectionRectangle = WaitForAutomationControl<Border>(view, "RoadmapSelectionRectangle");
+                var root2 = WaitForTaskNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
+
+                await ClickControlAsync(window, root2);
+                var currentTaskId = vm.CurrentTaskItem?.Id;
+                await Assert.That(currentTaskId).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
+
+                var allNodeBorders = FindRoadmapNodeBorders(graphControl).ToArray();
+                var start = FindEmptyEditorPoint(window, editor, allNodeBorders);
+                var end = FindRectangleEndPoint(window, editor, start, allNodeBorders);
+                var rectangle = CreateNormalizedRect(start, end);
+                var hitIds = GetRoadmapNodeIdsIntersectingWindowRect(window, graphControl, rectangle);
+
+                await Assert.That(hitIds.Count).IsGreaterThan(0);
+
+                window.MouseDown(start, MouseButton.Left, RawInputModifiers.None);
+                Dispatcher.UIThread.RunJobs();
+                window.MouseMove(end, RawInputModifiers.LeftMouseButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(selectionRectangle.IsVisible).IsTrue();
+
+                window.MouseUp(end, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(selectionRectangle.IsVisible).IsFalse();
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(hitIds);
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(currentTaskId);
+
+                await DragRoadmapRectangleAsync(window, start, end, RawInputModifiers.Control);
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl).Intersect(hitIds)).IsEmpty();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(currentTaskId);
+
+                await DragRoadmapRectangleAsync(window, start, end, RawInputModifiers.Shift);
+                await Assert.That(hitIds.All(id => FindRoadmapNode(graphControl, id)?.IsSelected == true)).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(currentTaskId);
+
+                await DragRoadmapRectangleAsync(window, start, end, RawInputModifiers.Alt);
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl).Intersect(hitIds)).IsEmpty();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(currentTaskId);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_RectangleHitTesting_IgnoresMinimapItems()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                graphControl!.IsRoadmapMinimapExpanded = true;
+                Dispatcher.UIThread.RunJobs();
+
+                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                var roadmapSurface = editor.Parent as Visual;
+                await Assert.That(roadmapSurface).IsNotNull();
+                var minimap = WaitForAutomationControl<Control>(view, "RoadmapMinimap");
+
+                Border? minimapNodeBorder = null;
+                var minimapItemReady = WaitFor(() =>
+                {
+                    minimapNodeBorder = minimap.GetVisualDescendants()
+                        .OfType<Border>()
+                        .FirstOrDefault(border =>
+                            border.DataContext is RoadmapNode &&
+                            border.Bounds.Width > 0 &&
+                            border.Bounds.Height > 0);
+                    return minimapNodeBorder != null;
+                });
+                await Assert.That(minimapItemReady).IsTrue();
+
+                var minimapNodeBounds = GetControlBounds(roadmapSurface!, minimapNodeBorder!);
+                var hits = GetRoadmapNodesIntersectingForTest(graphControl, minimapNodeBounds);
+
+                await Assert.That(hits).IsEmpty();
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_RectangleHitTesting_UsesZoomedNodeBounds()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                var roadmapSurface = editor.Parent as Visual;
+                await Assert.That(roadmapSurface).IsNotNull();
+
+                var zoomProperty = editor.GetType().GetProperty("ViewportZoom")!;
+                zoomProperty.SetValue(editor, 0.5d);
+                var zoomed = WaitFor(() => Math.Abs((double)zoomProperty.GetValue(editor)! - 0.5d) < 0.001);
+                await Assert.That(zoomed).IsTrue();
+
+                var hitTestNodeBorder = editor.GetVisualDescendants()
+                    .OfType<Border>()
+                    .First(border =>
+                        border.DataContext is RoadmapNode node &&
+                        node.Id == MainWindowViewModelFixture.RootTask2Id &&
+                        border.Bounds.Width > 0 &&
+                        border.Bounds.Height > 0);
+                var unscaledBounds = GetControlBounds(roadmapSurface!, hitTestNodeBorder);
+                var zoomedBounds = GetTransformedControlBounds(roadmapSurface, hitTestNodeBorder);
+                await Assert.That(unscaledBounds.Width).IsGreaterThan(zoomedBounds.Width + 1);
+
+                var probeRectangle = new Rect(
+                    zoomedBounds.Right + (unscaledBounds.Right - zoomedBounds.Right) / 2,
+                    zoomedBounds.Y + zoomedBounds.Height / 2,
+                    2,
+                    2);
+
+                await Assert.That(RectanglesIntersect(probeRectangle, zoomedBounds)).IsFalse();
+                await Assert.That(RectanglesIntersect(probeRectangle, unscaledBounds)).IsTrue();
+
+                var hits = GetRoadmapNodesIntersectingForTest(graphControl, probeRectangle);
+
+                await Assert.That(hits.Select(node => node.Id))
+                    .DoesNotContain(MainWindowViewModelFixture.RootTask2Id);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_RectangleSelection_UsesViewportZoom()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                graphControl!.IsRoadmapViewportToolbarExpanded = false;
+                graphControl.IsRoadmapMinimapExpanded = false;
+                Dispatcher.UIThread.RunJobs();
+
+                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                var zoomProperty = editor.GetType().GetProperty("ViewportZoom")!;
+                zoomProperty.SetValue(editor, 0.5d);
+                var zoomed = WaitFor(() => Math.Abs((double)zoomProperty.GetValue(editor)! - 0.5d) < 0.001);
+                await Assert.That(zoomed).IsTrue();
+
+                var taskNode = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask2Id);
+                var nodeBounds = GetTransformedControlBounds(window, taskNode);
+                var editorBounds = GetControlBounds(window, editor);
+                var start = new Point(
+                    Math.Max(editorBounds.X + 4, nodeBounds.X - 8),
+                    Math.Max(editorBounds.Y + 4, nodeBounds.Y - 8));
+                var end = new Point(
+                    Math.Min(editorBounds.Right - 4, nodeBounds.Right + 8),
+                    Math.Min(editorBounds.Bottom - 4, nodeBounds.Bottom + 8));
+                var rectangle = CreateNormalizedRect(start, end);
+
+                await Assert.That(FindRoadmapNodeBorders(graphControl)
+                    .Any(border => GetTransformedControlBounds(window, border).Contains(start))).IsFalse();
+                var expectedHitIds = GetRoadmapNodeIdsIntersectingTransformedWindowRect(
+                    window,
+                    graphControl,
+                    rectangle);
+                await Assert.That(expectedHitIds).Contains(MainWindowViewModelFixture.RootTask2Id);
+
+                await DragRoadmapRectangleAsync(window, start, end, RawInputModifiers.None);
+
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(expectedHitIds);
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
     public async Task RoadmapGraph_NodePointerDrag_StartsAfterMoveThresholdAndKeepsSelection()
     {
         await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
@@ -1633,6 +2147,151 @@ public class RoadmapGraphUiTests
 
                 await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask2Id);
                 await Assert.That(vm.DetailsAreOpen).IsFalse();
+            }
+            finally
+            {
+                if (mouseIsDown && window is { } topLevel && taskNode != null)
+                {
+                    topLevel.MouseUp(
+                        GetControlCenterPoint(topLevel, taskNode),
+                        MouseButton.Left,
+                        RawInputModifiers.None);
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_SelectedNodePlainClickWithoutDrag_CollapsesSelectionOnRelease()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+            var mouseIsDown = false;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                var root2 = WaitForTaskNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
+                var root3 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask3Id);
+
+                await ClickControlAsync(window, root2);
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Control);
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    MainWindowViewModelFixture.RootTask2Id,
+                    MainWindowViewModelFixture.RootTask3Id
+                });
+
+                var point = GetControlCenterPoint(window, root2);
+                window.MouseDown(point, MouseButton.Left, RawInputModifiers.None);
+                mouseIsDown = true;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    MainWindowViewModelFixture.RootTask2Id,
+                    MainWindowViewModelFixture.RootTask3Id
+                });
+
+                window.MouseUp(point, MouseButton.Left, RawInputModifiers.None);
+                mouseIsDown = false;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    MainWindowViewModelFixture.RootTask2Id
+                });
+            }
+            finally
+            {
+                if (mouseIsDown && window != null)
+                {
+                    window.MouseUp(new Point(0, 0), MouseButton.Left, RawInputModifiers.None);
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_SelectedNodeDrag_PreservesMultiSelectionAfterThreshold()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+            Control? taskNode = null;
+            var mouseIsDown = false;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                taskNode = WaitForTaskNode(graphControl!, MainWindowViewModelFixture.RootTask2Id);
+                var root3 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask3Id);
+
+                await ClickControlAsync(window, taskNode);
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Control);
+                var dragStartCountBefore = graphControl.RoadmapDragStartCount;
+
+                var startPoint = GetControlCenterPoint(window, taskNode);
+                var movePoint = new Point(startPoint.X + 24, startPoint.Y + 16);
+                window.MouseDown(startPoint, MouseButton.Left, RawInputModifiers.None);
+                mouseIsDown = true;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    MainWindowViewModelFixture.RootTask2Id,
+                    MainWindowViewModelFixture.RootTask3Id
+                });
+
+                window.MouseMove(movePoint, RawInputModifiers.LeftMouseButton);
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(WaitFor(() =>
+                    graphControl.RoadmapDragStartCount == dragStartCountBefore + 1)).IsTrue();
+
+                window.MouseUp(movePoint, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+                mouseIsDown = false;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    MainWindowViewModelFixture.RootTask2Id,
+                    MainWindowViewModelFixture.RootTask3Id
+                });
             }
             finally
             {
@@ -1718,6 +2377,85 @@ public class RoadmapGraphUiTests
                         GetControlCenterPoint(topLevel, taskNode),
                         MouseButton.Right,
                         RawInputModifiers.None);
+                    Dispatcher.UIThread.RunJobs();
+                }
+
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RoadmapGraph_RightDragOnEmptyCanvas_PansViewportWithSelection()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+            var mouseIsDown = false;
+            var releasePoint = default(Point);
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+                graphControl!.IsRoadmapViewportToolbarExpanded = false;
+                graphControl.IsRoadmapMinimapExpanded = false;
+                Dispatcher.UIThread.RunJobs();
+
+                var root2 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask2Id);
+                var root3 = WaitForTaskNode(graphControl, MainWindowViewModelFixture.RootTask3Id);
+                await ClickControlAsync(window, root2);
+                await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Control);
+
+                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                var locationProperty = editor.GetType().GetProperty("ViewportLocation")!;
+                var startLocation = (Point)locationProperty.GetValue(editor)!;
+                var startPoint = FindEmptyEditorPoint(window, editor, FindRoadmapNodeBorders(graphControl));
+                releasePoint = new Point(startPoint.X + 90, startPoint.Y + 44);
+
+                window.MouseDown(startPoint, MouseButton.Right, RawInputModifiers.None);
+                mouseIsDown = true;
+                Dispatcher.UIThread.RunJobs();
+
+                window.MouseMove(releasePoint, RawInputModifiers.RightMouseButton);
+                Dispatcher.UIThread.RunJobs();
+
+                var panned = WaitFor(() =>
+                {
+                    var currentLocation = (Point)locationProperty.GetValue(editor)!;
+                    return Math.Abs(currentLocation.X - startLocation.X) > 1 ||
+                           Math.Abs(currentLocation.Y - startLocation.Y) > 1;
+                });
+                await Assert.That(panned).IsTrue();
+
+                window.MouseUp(releasePoint, MouseButton.Right, RawInputModifiers.RightMouseButton);
+                mouseIsDown = false;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    MainWindowViewModelFixture.RootTask2Id,
+                    MainWindowViewModelFixture.RootTask3Id
+                });
+            }
+            finally
+            {
+                if (mouseIsDown && window is { } topLevel)
+                {
+                    topLevel.MouseUp(releasePoint, MouseButton.Right, RawInputModifiers.None);
                     Dispatcher.UIThread.RunJobs();
                 }
 
@@ -1928,6 +2666,89 @@ public class RoadmapGraphUiTests
     }
 
     [Test]
+    public async Task RoadmapGraph_SelectedNodesDragDrop_AppliesBatchOperation()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.Dispatch(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = false;
+                vm.GraphMode = true;
+                ((NotificationManagerWrapperMock)vm.ManagerWrapper).AskResult = true;
+
+                var firstSource = await vm.taskRepository!.Add();
+                firstSource.Title = "Roadmap batch DnD source A";
+                var secondSource = await vm.taskRepository.Add();
+                secondSource.Title = "Roadmap batch DnD source B";
+                var targetTask = await vm.taskRepository.Add();
+                targetTask.Title = "Roadmap batch DnD target";
+
+                var view = new MainControl { DataContext = vm };
+                window = CreateWindow(view);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                await Assert.That(graphControl).IsNotNull();
+
+                var firstReady = WaitFor(() => FindRoadmapNode(graphControl!, firstSource.Id) != null);
+                var secondReady = WaitFor(() => FindRoadmapNode(graphControl!, secondSource.Id) != null);
+                var targetReady = WaitFor(() => FindRoadmapNode(graphControl!, targetTask.Id) != null);
+                await Assert.That(firstReady).IsTrue();
+                await Assert.That(secondReady).IsTrue();
+                await Assert.That(targetReady).IsTrue();
+
+                var firstNode = WaitForTaskNode(graphControl!, firstSource.Id);
+                var secondNode = WaitForTaskNode(graphControl, secondSource.Id);
+                await ClickControlAsync(window, firstNode);
+                await ClickControlAsync(window, secondNode, modifiers: RawInputModifiers.Control);
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    firstSource.Id,
+                    secondSource.Id
+                });
+
+                var targetNode = WaitForTaskNode(graphControl, targetTask.Id);
+                using var dragData = GraphControl.CreateRoadmapDragTransfer([firstSource, secondSource]);
+                var dropArgs = new DragEventArgs(
+                    DragDrop.DropEvent,
+                    dragData,
+                    targetNode,
+                    new Avalonia.Point(targetNode.Bounds.Width / 2, targetNode.Bounds.Height / 2),
+                    KeyModifiers.Control);
+
+                await MainControl.Drop(view, dropArgs);
+                await TestHelpers.WaitThrottleTime();
+
+                var notificationManager = (NotificationManagerWrapperMock)vm.ManagerWrapper;
+                await Assert.That(dropArgs.Handled).IsTrue();
+                await Assert.That(dropArgs.DragEffects).IsEqualTo(DragDropEffects.Link);
+                await Assert.That(notificationManager.AskCount).IsEqualTo(1);
+                await Assert.That(firstSource.Blocks).Contains(targetTask.Id);
+                await Assert.That(secondSource.Blocks).Contains(targetTask.Id);
+                await Assert.That(targetTask.BlockedBy).Contains(firstSource.Id);
+                await Assert.That(targetTask.BlockedBy).Contains(secondSource.Id);
+                await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
+                {
+                    firstSource.Id,
+                    secondSource.Id
+                });
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
     public async Task RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode()
     {
         await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
@@ -1958,11 +2779,20 @@ public class RoadmapGraphUiTests
                 var graphText = WaitForTaskTitleTextBlock(
                     graphControl!,
                     MainWindowViewModelFixture.RootTask2Id);
+                var targetNode = FindRoadmapNode(graphControl, MainWindowViewModelFixture.RootTask2Id);
+
+                ApplyRoadmapClickSelectionForTest(
+                    graphControl,
+                    graphText,
+                    targetTask,
+                    KeyModifiers.None);
+                await Assert.That(targetNode?.IsSelected).IsTrue();
 
                 vm.Graph.Search.SearchText = targetTask.OnlyTextTitle;
                 var highlighted = WaitFor(() => targetTask.IsHighlighted);
 
                 await Assert.That(highlighted).IsTrue();
+                await Assert.That(targetNode?.IsSelected).IsTrue();
                 await Assert.That(graphText.FontWeight).IsEqualTo(FontWeight.Bold);
                 await Assert.That(graphText.Foreground is ISolidColorBrush brush && brush.Color == Color.Parse("#2F80ED"))
                     .IsTrue();
@@ -1971,6 +2801,7 @@ public class RoadmapGraphUiTests
                 var cleared = WaitFor(() => !targetTask.IsHighlighted);
 
                 await Assert.That(cleared).IsTrue();
+                await Assert.That(targetNode?.IsSelected).IsTrue();
             }
             finally
             {
@@ -2036,6 +2867,41 @@ public class RoadmapGraphUiTests
         Dispatcher.UIThread.RunJobs();
     }
 
+    private static void PressRoadmapNode(Control node, KeyModifiers modifiers, int clickCount)
+    {
+        var pointer = new Pointer(1, PointerType.Mouse, true);
+        var properties = new PointerPointProperties(
+            RawInputModifiers.LeftMouseButton,
+            PointerUpdateKind.LeftButtonPressed);
+        var point = new Point(node.Bounds.Width / 2, node.Bounds.Height / 2);
+
+        node.RaiseEvent(new PointerPressedEventArgs(
+            node,
+            pointer,
+            node,
+            point,
+            0,
+            properties,
+            modifiers,
+            clickCount));
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static async Task DragRoadmapRectangleAsync(
+        Window window,
+        Point start,
+        Point end,
+        RawInputModifiers modifiers)
+    {
+        window.MouseDown(start, MouseButton.Left, modifiers);
+        Dispatcher.UIThread.RunJobs();
+        window.MouseMove(end, modifiers | RawInputModifiers.LeftMouseButton);
+        Dispatcher.UIThread.RunJobs();
+        window.MouseUp(end, MouseButton.Left, modifiers | RawInputModifiers.LeftMouseButton);
+        Dispatcher.UIThread.RunJobs();
+        await Task.CompletedTask;
+    }
+
     private static Point GetControlCenterPoint(Visual relativeTo, Control control)
     {
         var point = control.TranslatePoint(
@@ -2048,6 +2914,189 @@ public class RoadmapGraphUiTests
         }
 
         return point.Value;
+    }
+
+    private static Rect GetControlBounds(Visual relativeTo, Control control)
+    {
+        var point = control.TranslatePoint(new Point(0, 0), relativeTo);
+        if (!point.HasValue)
+        {
+            throw new InvalidOperationException($"Cannot translate bounds for control {control.GetType().Name}.");
+        }
+
+        return new Rect(point.Value.X, point.Value.Y, control.Bounds.Width, control.Bounds.Height);
+    }
+
+    private static Rect GetTransformedControlBounds(Visual relativeTo, Control control)
+    {
+        var topLeft = control.TranslatePoint(new Point(0, 0), relativeTo);
+        var bottomRight = control.TranslatePoint(
+            new Point(control.Bounds.Width, control.Bounds.Height),
+            relativeTo);
+
+        if (!topLeft.HasValue || !bottomRight.HasValue)
+        {
+            throw new InvalidOperationException($"Cannot translate transformed bounds for control {control.GetType().Name}.");
+        }
+
+        return CreateNormalizedRect(topLeft.Value, bottomRight.Value);
+    }
+
+    private static IReadOnlyList<Border> FindRoadmapNodeBorders(Control root)
+    {
+        return root.GetVisualDescendants()
+            .OfType<Border>()
+            .Where(border => border.DataContext is RoadmapNode)
+            .ToArray();
+    }
+
+    private static Point FindEmptyEditorPoint(
+        Window window,
+        Control editor,
+        IReadOnlyList<Border> nodeBorders)
+    {
+        var editorBounds = GetControlBounds(window, editor);
+        var nodeBounds = nodeBorders
+            .Select(node => GetControlBounds(window, node))
+            .ToArray();
+        var candidates = new[]
+        {
+            new Point(editorBounds.X + 8, editorBounds.Y + 8),
+            new Point(editorBounds.Right - 8, editorBounds.Y + 8),
+            new Point(editorBounds.X + 8, editorBounds.Bottom - 8),
+            new Point(editorBounds.Right - 8, editorBounds.Bottom - 8),
+            new Point(editorBounds.X + editorBounds.Width / 2, editorBounds.Y + 8)
+        };
+
+        foreach (var candidate in candidates)
+        {
+            if (editorBounds.Contains(candidate) &&
+                nodeBounds.All(bounds => !bounds.Contains(candidate)))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException("Could not find an empty roadmap editor point for rectangle selection.");
+    }
+
+    private static Point FindRectangleEndPoint(
+        Window window,
+        Control editor,
+        Point start,
+        IReadOnlyList<Border> nodeBorders)
+    {
+        var editorBounds = GetControlBounds(window, editor);
+        var nodeBounds = nodeBorders.Select(node => GetControlBounds(window, node)).ToArray();
+        var union = UnionRects(nodeBounds);
+        var unionCenterX = union.X + union.Width / 2;
+        var unionCenterY = union.Y + union.Height / 2;
+        var endX = start.X <= unionCenterX
+            ? Math.Min(editorBounds.Right - 4, union.Right + 12)
+            : Math.Max(editorBounds.X + 4, union.X - 12);
+        var endY = start.Y <= unionCenterY
+            ? Math.Min(editorBounds.Bottom - 4, union.Bottom + 12)
+            : Math.Max(editorBounds.Y + 4, union.Y - 12);
+
+        return new Point(endX, endY);
+    }
+
+    private static Rect UnionRects(IReadOnlyList<Rect> rectangles)
+    {
+        if (rectangles.Count == 0)
+        {
+            throw new ArgumentException("At least one rectangle is required.", nameof(rectangles));
+        }
+
+        var minX = rectangles.Min(rectangle => rectangle.X);
+        var minY = rectangles.Min(rectangle => rectangle.Y);
+        var maxX = rectangles.Max(rectangle => rectangle.Right);
+        var maxY = rectangles.Max(rectangle => rectangle.Bottom);
+        return new Rect(minX, minY, maxX - minX, maxY - minY);
+    }
+
+    private static Rect CreateNormalizedRect(Point first, Point second)
+    {
+        var x = Math.Min(first.X, second.X);
+        var y = Math.Min(first.Y, second.Y);
+        return new Rect(
+            x,
+            y,
+            Math.Abs(first.X - second.X),
+            Math.Abs(first.Y - second.Y));
+    }
+
+    private static HashSet<string> GetRoadmapNodeIdsIntersectingWindowRect(
+        Window window,
+        Control root,
+        Rect rectangle)
+    {
+        return FindRoadmapNodeBorders(root)
+            .Where(border => RectanglesIntersect(GetControlBounds(window, border), rectangle))
+            .Select(border => ((RoadmapNode)border.DataContext!).Id)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static HashSet<string> GetRoadmapNodeIdsIntersectingTransformedWindowRect(
+        Window window,
+        Control root,
+        Rect rectangle)
+    {
+        return FindRoadmapNodeBorders(root)
+            .Where(border => RectanglesIntersect(GetTransformedControlBounds(window, border), rectangle))
+            .Select(border => ((RoadmapNode)border.DataContext!).Id)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static HashSet<string> GetSelectedRoadmapTaskIds(GraphControl graphControl)
+    {
+        return graphControl.RoadmapNodes
+            .Where(node => node.IsSelected)
+            .Select(node => node.Id)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static void ApplyRoadmapClickSelectionForTest(
+        GraphControl graphControl,
+        Control context,
+        TaskItemViewModel task,
+        KeyModifiers modifiers)
+    {
+        var method = typeof(GraphControl).GetMethod(
+            "ApplyRoadmapClickSelection",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        if (method == null)
+        {
+            throw new InvalidOperationException("GraphControl.ApplyRoadmapClickSelection was not found.");
+        }
+
+        method.Invoke(graphControl, new object?[] { context, task, modifiers });
+        Dispatcher.UIThread.RunJobs();
+    }
+
+    private static IReadOnlyList<RoadmapNode> GetRoadmapNodesIntersectingForTest(
+        GraphControl graphControl,
+        Rect rectangle)
+    {
+        var method = typeof(GraphControl).GetMethod(
+            "GetRoadmapNodesIntersecting",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        if (method == null)
+        {
+            throw new InvalidOperationException("GraphControl.GetRoadmapNodesIntersecting was not found.");
+        }
+
+        return (IReadOnlyList<RoadmapNode>)method.Invoke(graphControl, [rectangle])!;
+    }
+
+    private static bool RectanglesIntersect(Rect first, Rect second)
+    {
+        return first.X < second.Right &&
+               second.X < first.Right &&
+               first.Y < second.Bottom &&
+               second.Y < first.Bottom;
     }
 
     private static void PressRoadmapHotkey(Window window, string hotkey)

--- a/src/Unlimotion/Views/Graph/RoadmapNode.cs
+++ b/src/Unlimotion/Views/Graph/RoadmapNode.cs
@@ -15,6 +15,8 @@ public sealed class RoadmapNode : INotifyPropertyChanged
     private Point location;
     private double width = MinWidth;
     private double connectionWidth = MaxWidth;
+    private bool isSelected;
+    private bool isCurrent;
 
     public RoadmapNode(TaskItemViewModel taskItem)
     {
@@ -82,6 +84,36 @@ public sealed class RoadmapNode : INotifyPropertyChanged
     public Point RightAnchor => new(Location.X + Width, Location.Y + Height / 2);
 
     public Point ConnectionRightAnchor => new(Location.X + ConnectionWidth, Location.Y + Height / 2);
+
+    public bool IsSelected
+    {
+        get => isSelected;
+        set
+        {
+            if (isSelected == value)
+            {
+                return;
+            }
+
+            isSelected = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsCurrent
+    {
+        get => isCurrent;
+        set
+        {
+            if (isCurrent == value)
+            {
+                return;
+            }
+
+            isCurrent = value;
+            OnPropertyChanged();
+        }
+    }
 
     public bool SetMeasuredWidth(double measuredWidth)
     {

--- a/src/Unlimotion/Views/GraphControl.axaml
+++ b/src/Unlimotion/Views/GraphControl.axaml
@@ -39,6 +39,26 @@
         <Style Selector="TextBox.RoadmapInlineTaskTitleEditor.IsWanted">
             <Setter Property="FontWeight" Value="Bold" />
         </Style>
+        <Style Selector="Border.roadmapNode">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="2" />
+            <Setter Property="CornerRadius" Value="4" />
+        </Style>
+        <Style Selector="Border.roadmapNode.roadmapSelected">
+            <Setter Property="Background" Value="#182F80ED" />
+            <Setter Property="BorderBrush" Value="#7A2F80ED" />
+            <Setter Property="BorderThickness" Value="2" />
+        </Style>
+        <Style Selector="Border.roadmapNode.roadmapCurrent">
+            <Setter Property="BorderBrush" Value="#E08A3FFC" />
+            <Setter Property="BorderThickness" Value="2" />
+        </Style>
+        <Style Selector="Border.roadmapNode.roadmapSelected.roadmapCurrent">
+            <Setter Property="Background" Value="#243A9B4F" />
+            <Setter Property="BorderBrush" Value="#E08A3FFC" />
+            <Setter Property="BorderThickness" Value="2" />
+        </Style>
         <Style Selector="Button.roadmapViewportButton">
             <Setter Property="Width" Value="28" />
             <Setter Property="Height" Value="28" />
@@ -80,7 +100,7 @@
                         AutomationProperties.AutomationId="RoadmapResetFiltersButton" />
         </WrapPanel>
 
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="1" x:Name="RoadmapSurface">
             <nodify:NodifyEditor x:Name="RoadmapEditor"
                                  AutomationProperties.AutomationId="RoadmapZoomBorder"
                                  ItemsSource="{Binding RoadmapNodes, ElementName=Root}"
@@ -92,6 +112,7 @@
                                  MinViewportZoom="0.1"
                                  MaxViewportZoom="2"
                                  GridCellSize="1"
+                                 PointerPressed="RoadmapEditor_OnPointerPressed"
                                  DisableAutoPanning="True"
                                  DisplayConnectionsOnTop="False">
                 <nodify:NodifyEditor.Resources>
@@ -131,8 +152,10 @@
                         <Border MinWidth="{x:Static local:RoadmapNode.MinWidth}"
                                 MaxWidth="{x:Static local:RoadmapNode.MaxWidth}"
                                 MinHeight="{x:Static local:RoadmapNode.Height}"
-                                Padding="5,3"
-                                Background="Transparent"
+                                Classes="roadmapNode"
+                                Classes.roadmapSelected="{Binding IsSelected}"
+                                Classes.roadmapCurrent="{Binding IsCurrent}"
+                                Padding="4,2"
                                 DragDrop.AllowDrop="True"
                                 SizeChanged="RoadmapNode_OnSizeChanged"
                                 PointerPressed="InputElement_OnPointerPressed"
@@ -186,6 +209,18 @@
                     </ControlTheme>
                 </nodify:NodifyEditor.ItemContainerTheme>
             </nodify:NodifyEditor>
+
+            <Border HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Margin="{Binding RoadmapSelectionRectangleMargin, ElementName=Root}"
+                    Width="{Binding RoadmapSelectionRectangleWidth, ElementName=Root}"
+                    Height="{Binding RoadmapSelectionRectangleHeight, ElementName=Root}"
+                    Background="#332F80ED"
+                    BorderBrush="#B02F80ED"
+                    BorderThickness="1"
+                    IsHitTestVisible="False"
+                    IsVisible="{Binding IsRoadmapSelectionRectangleVisible, ElementName=Root}"
+                    AutomationProperties.AutomationId="RoadmapSelectionRectangle" />
 
             <Border HorizontalAlignment="Left"
                     VerticalAlignment="Top"

--- a/src/Unlimotion/Views/GraphControl.axaml.cs
+++ b/src/Unlimotion/Views/GraphControl.axaml.cs
@@ -32,16 +32,24 @@ namespace Unlimotion.Views
     public partial class GraphControl : UserControl
     {
         public const string CustomFormat = "application/xxx-unlimotion-task-item";
+        public const string CustomBatchFormat = "application/xxx-unlimotion-roadmap-task-items";
         internal static readonly DataFormat<string> CustomDataFormat =
             DataFormat.CreateStringPlatformFormat(CustomFormat);
+        internal static readonly DataFormat<string> CustomBatchDataFormat =
+            DataFormat.CreateStringPlatformFormat(CustomBatchFormat);
 
         private GraphViewModel? dc;
         private readonly DisposableList disposableList = new DisposableListRealization();
         private readonly SerialDisposable roadmapScopeSubscriptions = new();
         private readonly SerialDisposable roadmapFilterSubscriptions = new();
+        private readonly SerialDisposable roadmapCurrentTaskSubscription = new();
         private readonly DispatcherTimer graphUpdateTimer;
+        private readonly HashSet<string> selectedRoadmapTaskIds = new(StringComparer.Ordinal);
         private DateTime lastRoadmapPointerDoubleTapAt = DateTime.MinValue;
         private string? lastRoadmapPointerDoubleTapTaskId;
+        private string? lastRoadmapClickSelectionTaskId;
+        private KeyModifiers lastRoadmapClickSelectionModifiers;
+        private bool lastRoadmapClickSelectionSelectedCurrentTask;
         private ReadOnlyObservableCollection<TaskWrapperViewModel>? roadmapScopeSubscriptionRoots;
         private string? roadmapScopeSubscriptionSignature;
         private bool roadmapScopeSubscriptionsDirty = true;
@@ -50,6 +58,7 @@ namespace Unlimotion.Views
         private IRoadmapViewportAdapter? roadmapViewport;
         private PendingRoadmapDragContext? pendingRoadmapDrag;
         private PendingRoadmapPanContext? pendingRoadmapPan;
+        private PendingRoadmapSelectionContext? pendingRoadmapSelection;
         private TextBox? activeRoadmapInlineTitleEditor;
         private string? lastRoadmapInlineTitleClickTaskId;
         private DateTimeOffset? lastRoadmapInlineTitleClickAt;
@@ -84,6 +93,22 @@ namespace Unlimotion.Views
                 nameof(IsRoadmapMinimapExpanded),
                 true);
 
+        public static readonly StyledProperty<bool> IsRoadmapSelectionRectangleVisibleProperty =
+            AvaloniaProperty.Register<GraphControl, bool>(
+                nameof(IsRoadmapSelectionRectangleVisible));
+
+        public static readonly StyledProperty<Thickness> RoadmapSelectionRectangleMarginProperty =
+            AvaloniaProperty.Register<GraphControl, Thickness>(
+                nameof(RoadmapSelectionRectangleMargin));
+
+        public static readonly StyledProperty<double> RoadmapSelectionRectangleWidthProperty =
+            AvaloniaProperty.Register<GraphControl, double>(
+                nameof(RoadmapSelectionRectangleWidth));
+
+        public static readonly StyledProperty<double> RoadmapSelectionRectangleHeightProperty =
+            AvaloniaProperty.Register<GraphControl, double>(
+                nameof(RoadmapSelectionRectangleHeight));
+
         public GraphControl()
         {
             graphUpdateTimer = new DispatcherTimer
@@ -99,7 +124,9 @@ namespace Unlimotion.Views
                 CancelPendingRoadmapBuilds();
                 ClearPendingRoadmapDrag();
                 ClearPendingRoadmapPan();
+                ClearPendingRoadmapSelection();
                 ClearRoadmapInlineTitleEditState();
+                roadmapCurrentTaskSubscription.Disposable = Disposable.Empty;
             };
             InitializeComponent();
             AddHandler(DragDrop.DropEvent, MainControl.Drop);
@@ -165,6 +192,30 @@ namespace Unlimotion.Views
             set => SetValue(IsRoadmapMinimapExpandedProperty, value);
         }
 
+        public bool IsRoadmapSelectionRectangleVisible
+        {
+            get => GetValue(IsRoadmapSelectionRectangleVisibleProperty);
+            private set => SetValue(IsRoadmapSelectionRectangleVisibleProperty, value);
+        }
+
+        public Thickness RoadmapSelectionRectangleMargin
+        {
+            get => GetValue(RoadmapSelectionRectangleMarginProperty);
+            private set => SetValue(RoadmapSelectionRectangleMarginProperty, value);
+        }
+
+        public double RoadmapSelectionRectangleWidth
+        {
+            get => GetValue(RoadmapSelectionRectangleWidthProperty);
+            private set => SetValue(RoadmapSelectionRectangleWidthProperty, value);
+        }
+
+        public double RoadmapSelectionRectangleHeight
+        {
+            get => GetValue(RoadmapSelectionRectangleHeightProperty);
+            private set => SetValue(RoadmapSelectionRectangleHeightProperty, value);
+        }
+
         private IRoadmapViewportAdapter RoadmapViewport =>
             roadmapViewport ??= new NodifyRoadmapViewportAdapter(RoadmapEditor);
 
@@ -193,6 +244,9 @@ namespace Unlimotion.Views
             disposableList.Disposables.Clear();
             roadmapScopeSubscriptions.Disposable = Disposable.Empty;
             roadmapFilterSubscriptions.Disposable = Disposable.Empty;
+            roadmapCurrentTaskSubscription.Disposable = Disposable.Empty;
+            selectedRoadmapTaskIds.Clear();
+            ClearPendingRoadmapSelection();
             ResetRoadmapScopeSubscriptionCache();
             CancelScheduledGraphUpdate();
             CancelPendingRoadmapBuilds();
@@ -203,6 +257,8 @@ namespace Unlimotion.Views
             {
                 return;
             }
+
+            RegisterRoadmapCurrentTaskSubscription(dc.MainWindowViewModel);
 
             dc.WhenAnyValue(
                     m => m.OnlyUnlocked,
@@ -634,6 +690,9 @@ namespace Unlimotion.Views
             RemoveStaleRoadmapConnections(desiredConnectionKeys);
             SynchronizeRoadmapNodes(desiredNodes);
             SynchronizeRoadmapConnections(desiredConnections);
+            PruneRoadmapSelectionToVisibleNodes();
+            ApplyRoadmapSelectionState();
+            ApplyRoadmapCurrentState();
         }
 
         private void ClearRoadmapProjection()
@@ -645,6 +704,51 @@ namespace Unlimotion.Views
 
             RoadmapConnections.Clear();
             RoadmapNodes.Clear();
+        }
+
+        private void RegisterRoadmapCurrentTaskSubscription(MainWindowViewModel? owner)
+        {
+            if (owner == null)
+            {
+                roadmapCurrentTaskSubscription.Disposable = Disposable.Empty;
+                return;
+            }
+
+            roadmapCurrentTaskSubscription.Disposable = owner
+                .WhenAnyValue(m => m.CurrentTaskItem)
+                .ObserveOn(RxSchedulers.MainThreadScheduler)
+                .Subscribe(_ => ApplyRoadmapCurrentState());
+        }
+
+        private void PruneRoadmapSelectionToVisibleNodes()
+        {
+            if (selectedRoadmapTaskIds.Count == 0)
+            {
+                return;
+            }
+
+            var visibleIds = RoadmapNodes
+                .Select(node => node.Id)
+                .ToHashSet(StringComparer.Ordinal);
+
+            selectedRoadmapTaskIds.RemoveWhere(id => !visibleIds.Contains(id));
+        }
+
+        private void ApplyRoadmapSelectionState()
+        {
+            foreach (var node in RoadmapNodes)
+            {
+                node.IsSelected = selectedRoadmapTaskIds.Contains(node.Id);
+            }
+        }
+
+        private void ApplyRoadmapCurrentState()
+        {
+            var currentTaskId = dc?.MainWindowViewModel?.CurrentTaskItem?.Id;
+            foreach (var node in RoadmapNodes)
+            {
+                node.IsCurrent = string.Equals(node.Id, currentTaskId, StringComparison.Ordinal);
+            }
         }
 
         private void RemoveStaleRoadmapConnections(IReadOnlySet<string> desiredConnectionKeys)
@@ -1462,6 +1566,142 @@ namespace Unlimotion.Views
             activeRoadmapInlineTitleEditor = null;
         }
 
+        private void RoadmapEditor_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.Handled)
+            {
+                return;
+            }
+
+            var pointer = e.GetCurrentPoint(RoadmapSurface);
+            if (pointer.Properties.IsRightButtonPressed)
+            {
+                StartPendingRoadmapPan(RoadmapSurface, e);
+                return;
+            }
+
+            if (!pointer.Properties.IsLeftButtonPressed)
+            {
+                return;
+            }
+
+            if (TryGetRoadmapTaskItem(e.Source as Control, out _))
+            {
+                return;
+            }
+
+            ClearPendingRoadmapDrag();
+            ClearPendingRoadmapPan();
+            ClearPendingRoadmapSelection();
+
+            e.Pointer.Capture(RoadmapSurface);
+            pendingRoadmapSelection = new PendingRoadmapSelectionContext(
+                e.Pointer,
+                e.GetPosition(RoadmapSurface),
+                e.KeyModifiers);
+            e.Handled = true;
+        }
+
+        private void StartPendingRoadmapPan(Control captureControl, PointerPressedEventArgs e)
+        {
+            ClearPendingRoadmapDrag();
+            ClearPendingRoadmapPan();
+            ClearPendingRoadmapSelection();
+
+            e.Pointer.Capture(captureControl);
+            pendingRoadmapPan = new PendingRoadmapPanContext(
+                captureControl,
+                e.Pointer,
+                e.GetPosition(RoadmapViewport.Control),
+                RoadmapViewport.Location);
+            e.Handled = true;
+        }
+
+        private void ApplyRoadmapClickSelection(
+            Control? context,
+            TaskItemViewModel taskItem,
+            KeyModifiers modifiers)
+        {
+            var operation = GetRoadmapSelectionOperation(modifiers);
+            var wasSelected = selectedRoadmapTaskIds.Contains(taskItem.Id);
+            var shouldSelectCurrentTask = ShouldSelectRoadmapCurrentTask(operation, wasSelected);
+
+            switch (operation)
+            {
+                case RoadmapSelectionOperation.Replace:
+                    selectedRoadmapTaskIds.Clear();
+                    selectedRoadmapTaskIds.Add(taskItem.Id);
+                    break;
+                case RoadmapSelectionOperation.Toggle:
+                    if (!selectedRoadmapTaskIds.Remove(taskItem.Id))
+                    {
+                        selectedRoadmapTaskIds.Add(taskItem.Id);
+                    }
+
+                    break;
+                case RoadmapSelectionOperation.Add:
+                    selectedRoadmapTaskIds.Add(taskItem.Id);
+                    break;
+                case RoadmapSelectionOperation.Remove:
+                    selectedRoadmapTaskIds.Remove(taskItem.Id);
+                    break;
+            }
+
+            ApplyRoadmapSelectionState();
+            lastRoadmapClickSelectionTaskId = taskItem.Id;
+            lastRoadmapClickSelectionModifiers = modifiers;
+            lastRoadmapClickSelectionSelectedCurrentTask = shouldSelectCurrentTask;
+
+            if (shouldSelectCurrentTask)
+            {
+                SelectRoadmapTask(context, taskItem);
+            }
+        }
+
+        private bool ShouldSuppressDuplicateRoadmapClickSelection(
+            TaskItemViewModel taskItem,
+            KeyModifiers modifiers,
+            int clickCount)
+        {
+            return clickCount > 1 &&
+                   lastRoadmapClickSelectionTaskId == taskItem.Id &&
+                   lastRoadmapClickSelectionModifiers == modifiers;
+        }
+
+        private static RoadmapSelectionOperation GetRoadmapSelectionOperation(KeyModifiers modifiers)
+        {
+            if ((modifiers & KeyModifiers.Alt) != 0)
+            {
+                return RoadmapSelectionOperation.Remove;
+            }
+
+            if ((modifiers & KeyModifiers.Control) != 0)
+            {
+                return RoadmapSelectionOperation.Toggle;
+            }
+
+            if ((modifiers & KeyModifiers.Shift) != 0)
+            {
+                return RoadmapSelectionOperation.Add;
+            }
+
+            return RoadmapSelectionOperation.Replace;
+        }
+
+        private static bool ShouldSelectRoadmapCurrentTask(
+            RoadmapSelectionOperation operation,
+            bool wasSelected)
+        {
+            return operation switch
+            {
+                RoadmapSelectionOperation.Replace => true,
+                RoadmapSelectionOperation.Add => true,
+                RoadmapSelectionOperation.Toggle => !wasSelected,
+                RoadmapSelectionOperation.Remove => false,
+                _ => false
+            };
+        }
+
         private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
         {
             var pointer = e.GetCurrentPoint(this);
@@ -1471,14 +1711,7 @@ namespace Unlimotion.Views
             if (pointer.Properties.IsRightButtonPressed &&
                 TryGetRoadmapTaskItem(gestureControl, out _))
             {
-                ClearPendingRoadmapDrag();
-                e.Pointer.Capture(gestureControl ?? this);
-                pendingRoadmapPan = new PendingRoadmapPanContext(
-                    gestureControl ?? this,
-                    e.Pointer,
-                    e.GetPosition(RoadmapViewport.Control),
-                    RoadmapViewport.Location);
-                e.Handled = true;
+                StartPendingRoadmapPan(gestureControl ?? this, e);
                 return;
             }
 
@@ -1496,15 +1729,52 @@ namespace Unlimotion.Views
                 return;
             }
 
-            SelectRoadmapTask(gestureControl, taskItem);
             if (e.ClickCount > 1)
             {
-                ToggleRoadmapTaskDetails(gestureControl, taskItem);
+                var shouldSuppressClickSelection =
+                    ShouldSuppressDuplicateRoadmapClickSelection(taskItem, e.KeyModifiers, e.ClickCount);
+                var shouldSelectCurrentTask = shouldSuppressClickSelection
+                    ? lastRoadmapClickSelectionSelectedCurrentTask
+                    : ShouldSelectRoadmapCurrentTask(
+                        GetRoadmapSelectionOperation(e.KeyModifiers),
+                        selectedRoadmapTaskIds.Contains(taskItem.Id));
+
+                if (!shouldSuppressClickSelection)
+                {
+                    ApplyRoadmapClickSelection(gestureControl, taskItem, e.KeyModifiers);
+                }
+
+                ToggleRoadmapTaskDetails(gestureControl, taskItem, shouldSelectCurrentTask);
                 lastRoadmapPointerDoubleTapAt = DateTime.UtcNow;
                 lastRoadmapPointerDoubleTapTaskId = taskItem.Id;
                 ClearPendingRoadmapDrag();
                 e.Handled = true;
                 return;
+            }
+
+            if (HasRoadmapSelectionModifier(e.KeyModifiers))
+            {
+                if (!ShouldSuppressDuplicateRoadmapClickSelection(taskItem, e.KeyModifiers, e.ClickCount))
+                {
+                    ApplyRoadmapClickSelection(gestureControl, taskItem, e.KeyModifiers);
+                }
+
+                ClearPendingRoadmapDrag();
+                e.Handled = true;
+                return;
+            }
+
+            var selectedDragTasks = GetSelectedRoadmapDragTasks(taskItem);
+            var shouldDeferClickSelection = selectedDragTasks.Count > 1 &&
+                                            selectedRoadmapTaskIds.Contains(taskItem.Id);
+            if (shouldDeferClickSelection)
+            {
+                SelectRoadmapTask(gestureControl, taskItem);
+            }
+            else if (!ShouldSuppressDuplicateRoadmapClickSelection(taskItem, e.KeyModifiers, e.ClickCount))
+            {
+                ApplyRoadmapClickSelection(gestureControl, taskItem, e.KeyModifiers);
+                selectedDragTasks = [taskItem];
             }
 
             e.Pointer.Capture(gestureControl ?? this);
@@ -1513,12 +1783,19 @@ namespace Unlimotion.Views
                 e.Pointer,
                 taskItem,
                 e,
-                e.GetPosition(gestureControl ?? this));
+                e.GetPosition(gestureControl ?? this),
+                selectedDragTasks,
+                shouldDeferClickSelection);
         }
 
         private async void InputElement_OnPointerMoved(object? sender, PointerEventArgs e)
         {
             if (TryHandlePendingRoadmapPan(e))
+            {
+                return;
+            }
+
+            if (TryHandlePendingRoadmapSelection(e))
             {
                 return;
             }
@@ -1561,6 +1838,15 @@ namespace Unlimotion.Views
 
         private void InputElement_OnPointerReleased(object? sender, PointerReleasedEventArgs e)
         {
+            if (pendingRoadmapSelection != null &&
+                ReferenceEquals(e.Pointer, pendingRoadmapSelection.Pointer))
+            {
+                CommitPendingRoadmapSelection();
+                ClearPendingRoadmapSelection();
+                e.Handled = true;
+                return;
+            }
+
             if (pendingRoadmapPan != null &&
                 ReferenceEquals(e.Pointer, pendingRoadmapPan.Pointer))
             {
@@ -1573,6 +1859,15 @@ namespace Unlimotion.Views
                 !ReferenceEquals(e.Pointer, pendingRoadmapDrag.Pointer))
             {
                 return;
+            }
+
+            if (pendingRoadmapDrag?.ApplyClickSelectionOnRelease == true)
+            {
+                ApplyRoadmapClickSelection(
+                    pendingRoadmapDrag.Control,
+                    pendingRoadmapDrag.TaskItem,
+                    KeyModifiers.None);
+                e.Handled = true;
             }
 
             ClearPendingRoadmapDrag();
@@ -1603,6 +1898,166 @@ namespace Unlimotion.Views
             return true;
         }
 
+        private bool TryHandlePendingRoadmapSelection(PointerEventArgs e)
+        {
+            var pending = pendingRoadmapSelection;
+            if (pending == null || !ReferenceEquals(e.Pointer, pending.Pointer))
+            {
+                return false;
+            }
+
+            if (!e.GetCurrentPoint(RoadmapSurface).Properties.IsLeftButtonPressed)
+            {
+                ClearPendingRoadmapSelection();
+                return true;
+            }
+
+            var currentPoint = e.GetPosition(RoadmapSurface);
+            if (!pending.HasExceededThreshold &&
+                !HasExceededRoadmapDragThreshold(pending.StartPoint, currentPoint))
+            {
+                e.Handled = true;
+                return true;
+            }
+
+            pending.HasExceededThreshold = true;
+            pending.CurrentPoint = currentPoint;
+            UpdateRoadmapSelectionRectangle(pending.StartPoint, currentPoint);
+            e.Handled = true;
+            return true;
+        }
+
+        private void CommitPendingRoadmapSelection()
+        {
+            var pending = pendingRoadmapSelection;
+            if (pending == null || !pending.HasExceededThreshold)
+            {
+                return;
+            }
+
+            var rectangle = CreateNormalizedRect(pending.StartPoint, pending.CurrentPoint);
+            var hitNodes = GetRoadmapNodesIntersecting(rectangle);
+            ApplyRoadmapRectangleSelection(hitNodes, pending.Modifiers);
+        }
+
+        private void ApplyRoadmapRectangleSelection(
+            IReadOnlyList<RoadmapNode> nodes,
+            KeyModifiers modifiers)
+        {
+            var operation = GetRoadmapSelectionOperation(modifiers);
+
+            if (operation == RoadmapSelectionOperation.Replace)
+            {
+                selectedRoadmapTaskIds.Clear();
+            }
+
+            foreach (var node in nodes)
+            {
+                switch (operation)
+                {
+                    case RoadmapSelectionOperation.Replace:
+                    case RoadmapSelectionOperation.Add:
+                        selectedRoadmapTaskIds.Add(node.Id);
+                        break;
+                    case RoadmapSelectionOperation.Toggle:
+                        if (!selectedRoadmapTaskIds.Remove(node.Id))
+                        {
+                            selectedRoadmapTaskIds.Add(node.Id);
+                        }
+
+                        break;
+                    case RoadmapSelectionOperation.Remove:
+                        selectedRoadmapTaskIds.Remove(node.Id);
+                        break;
+                }
+            }
+
+            ApplyRoadmapSelectionState();
+        }
+
+        private IReadOnlyList<RoadmapNode> GetRoadmapNodesIntersecting(Rect rectangle)
+        {
+            var result = new List<RoadmapNode>();
+            var seenIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var border in RoadmapEditor
+                         .GetVisualDescendants()
+                         .OfType<Border>())
+            {
+                if (border.DataContext is not RoadmapNode node ||
+                    !seenIds.Add(node.Id) ||
+                    border.Bounds.Width <= 0 ||
+                    border.Bounds.Height <= 0)
+                {
+                    continue;
+                }
+
+                var nodeBounds = GetRoadmapNodeBoundsInSelectionCoordinates(border);
+                if (!nodeBounds.HasValue)
+                {
+                    continue;
+                }
+
+                if (RectanglesIntersect(rectangle, nodeBounds.Value))
+                {
+                    result.Add(node);
+                }
+            }
+
+            return result;
+        }
+
+        private Rect? GetRoadmapNodeBoundsInSelectionCoordinates(Control nodeControl)
+        {
+            var topLeft = nodeControl.TranslatePoint(new Point(0, 0), RoadmapSurface);
+            var bottomRight = nodeControl.TranslatePoint(
+                new Point(nodeControl.Bounds.Width, nodeControl.Bounds.Height),
+                RoadmapSurface);
+
+            if (!topLeft.HasValue || !bottomRight.HasValue)
+            {
+                return null;
+            }
+
+            return CreateNormalizedRect(topLeft.Value, bottomRight.Value);
+        }
+
+        private void UpdateRoadmapSelectionRectangle(Point startPoint, Point currentPoint)
+        {
+            var rectangle = CreateNormalizedRect(startPoint, currentPoint);
+            RoadmapSelectionRectangleMargin = new Thickness(rectangle.X, rectangle.Y, 0, 0);
+            RoadmapSelectionRectangleWidth = rectangle.Width;
+            RoadmapSelectionRectangleHeight = rectangle.Height;
+            IsRoadmapSelectionRectangleVisible = true;
+        }
+
+        private void ClearPendingRoadmapSelection()
+        {
+            pendingRoadmapSelection?.Pointer.Capture(null);
+            pendingRoadmapSelection = null;
+            IsRoadmapSelectionRectangleVisible = false;
+            RoadmapSelectionRectangleWidth = 0;
+            RoadmapSelectionRectangleHeight = 0;
+        }
+
+        private static Rect CreateNormalizedRect(Point first, Point second)
+        {
+            var x = Math.Min(first.X, second.X);
+            var y = Math.Min(first.Y, second.Y);
+            return new Rect(
+                x,
+                y,
+                Math.Abs(first.X - second.X),
+                Math.Abs(first.Y - second.Y));
+        }
+
+        private static bool RectanglesIntersect(Rect first, Rect second)
+        {
+            return first.X < second.Right &&
+                   second.X < first.Right &&
+                   first.Y < second.Bottom &&
+                   second.Y < first.Bottom;
+        }
+
         private static bool HasExceededRoadmapDragThreshold(Point startPoint, Point currentPoint)
         {
             return Math.Abs(currentPoint.X - startPoint.X) >= RoadmapDragThreshold ||
@@ -1611,7 +2066,7 @@ namespace Unlimotion.Views
 
         private static async Task StartRoadmapDragAsync(PendingRoadmapDragContext pending, PointerEventArgs e)
         {
-            var dragData = DragDataFormats.CreateTransfer(CustomDataFormat, pending.TaskItem);
+            var dragData = CreateRoadmapDragTransfer(pending.TaskItems);
 
             var graphControl = pending.Control.FindParent<GraphControl>();
             if (graphControl != null)
@@ -1630,6 +2085,60 @@ namespace Unlimotion.Views
             {
                 pending.Pointer.Capture(null);
             }
+        }
+
+        internal static InMemoryDragDataTransfer CreateRoadmapDragTransfer(
+            IReadOnlyList<TaskItemViewModel> taskItems)
+        {
+            var normalizedTasks = NormalizeRoadmapDragTasks(taskItems);
+            if (normalizedTasks.Count == 0)
+            {
+                return new InMemoryDragDataTransfer();
+            }
+
+            if (normalizedTasks.Count == 1)
+            {
+                return DragDataFormats.CreateTransfer(CustomDataFormat, normalizedTasks[0]);
+            }
+
+            var dragData = new InMemoryDragDataTransfer();
+            var item = new DataTransferItem();
+            item.Set(CustomBatchDataFormat, dragData.Track(new RoadmapTaskDragData(normalizedTasks)));
+            item.Set(CustomDataFormat, dragData.Track(normalizedTasks[0]));
+            dragData.Add(item);
+            return dragData;
+        }
+
+        private IReadOnlyList<TaskItemViewModel> GetSelectedRoadmapDragTasks(TaskItemViewModel fallbackTask)
+        {
+            if (selectedRoadmapTaskIds.Count <= 1 ||
+                !selectedRoadmapTaskIds.Contains(fallbackTask.Id))
+            {
+                return [fallbackTask];
+            }
+
+            var tasks = RoadmapNodes
+                .Where(node => selectedRoadmapTaskIds.Contains(node.Id))
+                .Select(node => node.TaskItem)
+                .ToArray();
+            return tasks.Length > 0 ? tasks : [fallbackTask];
+        }
+
+        private static IReadOnlyList<TaskItemViewModel> NormalizeRoadmapDragTasks(
+            IEnumerable<TaskItemViewModel>? taskItems)
+        {
+            return taskItems?
+                       .Where(static task => task != null && !string.IsNullOrWhiteSpace(task.Id))
+                       .GroupBy(static task => task.Id, StringComparer.Ordinal)
+                       .Select(static group => group.First())
+                       .ToList()
+                   ?? [];
+        }
+
+        private static bool HasRoadmapSelectionModifier(KeyModifiers modifiers)
+        {
+            var relevantModifiers = modifiers & (KeyModifiers.Control | KeyModifiers.Shift | KeyModifiers.Alt);
+            return relevantModifiers != KeyModifiers.None;
         }
 
         private void ClearPendingRoadmapDrag()
@@ -1658,6 +2167,7 @@ namespace Unlimotion.Views
                 return;
             }
 
+            ApplyRoadmapClickSelection(control, taskItem, KeyModifiers.None);
             ToggleRoadmapTaskDetails(control, taskItem);
             e.Handled = true;
         }
@@ -1668,9 +2178,14 @@ namespace Unlimotion.Views
                    DateTime.UtcNow - lastRoadmapPointerDoubleTapAt < TimeSpan.FromMilliseconds(500);
         }
 
-        private MainWindowViewModel? ToggleRoadmapTaskDetails(Control? context, TaskItemViewModel taskItem)
+        private MainWindowViewModel? ToggleRoadmapTaskDetails(
+            Control? context,
+            TaskItemViewModel taskItem,
+            bool selectTask = true)
         {
-            var owner = SelectRoadmapTask(context, taskItem);
+            var owner = selectTask
+                ? SelectRoadmapTask(context, taskItem)
+                : ResolveMainWindowViewModel(context);
             if (owner != null)
             {
                 owner.DetailsAreOpen = !owner.DetailsAreOpen;
@@ -1693,6 +2208,7 @@ namespace Unlimotion.Views
                 owner.SelectCurrentTask();
             }
 
+            ApplyRoadmapCurrentState();
             return owner;
         }
 
@@ -1729,7 +2245,9 @@ namespace Unlimotion.Views
             IPointer pointer,
             TaskItemViewModel taskItem,
             PointerPressedEventArgs pressEvent,
-            Point startPoint)
+            Point startPoint,
+            IReadOnlyList<TaskItemViewModel> taskItems,
+            bool applyClickSelectionOnRelease)
         {
             public Control Control { get; } = control;
 
@@ -1740,6 +2258,16 @@ namespace Unlimotion.Views
             public PointerPressedEventArgs PressEvent { get; } = pressEvent;
 
             public Point StartPoint { get; } = startPoint;
+
+            public IReadOnlyList<TaskItemViewModel> TaskItems { get; } = taskItems;
+
+            public bool ApplyClickSelectionOnRelease { get; } = applyClickSelectionOnRelease;
+        }
+
+        internal sealed class RoadmapTaskDragData(IReadOnlyList<TaskItemViewModel> taskItems)
+        {
+            public IReadOnlyList<TaskItemViewModel> TaskItems { get; } =
+                NormalizeRoadmapDragTasks(taskItems);
         }
 
         private sealed class PendingRoadmapPanContext(
@@ -1755,6 +2283,30 @@ namespace Unlimotion.Views
             public Point StartPoint { get; } = startPoint;
 
             public Point StartViewportLocation { get; } = startViewportLocation;
+        }
+
+        private sealed class PendingRoadmapSelectionContext(
+            IPointer pointer,
+            Point startPoint,
+            KeyModifiers modifiers)
+        {
+            public IPointer Pointer { get; } = pointer;
+
+            public Point StartPoint { get; } = startPoint;
+
+            public KeyModifiers Modifiers { get; } = modifiers;
+
+            public Point CurrentPoint { get; set; } = startPoint;
+
+            public bool HasExceededThreshold { get; set; }
+        }
+
+        private enum RoadmapSelectionOperation
+        {
+            Replace,
+            Toggle,
+            Add,
+            Remove
         }
 
         private bool Matches(TaskItemViewModel task, string normalizedQuery, bool isFuzzy)

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -896,6 +896,7 @@ namespace Unlimotion.Views
         {
             return data.Contains(CustomBatchDataFormat) ||
                    data.Contains(CustomDataFormat) ||
+                   data.Contains(GraphControl.CustomBatchDataFormat) ||
                    data.Contains(GraphControl.CustomDataFormat);
         }
 
@@ -968,6 +969,33 @@ namespace Unlimotion.Views
                 return items.Count > 0;
             }
 
+            if (DragDataFormats.TryGetValue<GraphControl.RoadmapTaskDragData>(
+                    e.DataTransfer,
+                    GraphControl.CustomBatchDataFormat,
+                    out var roadmapBatchData))
+            {
+                var normalizedTasks = NormalizeRoadmapTasksForBatch(roadmapBatchData.TaskItems);
+                var result = new List<DragSourceOperationItem>(normalizedTasks.Count);
+                foreach (var taskItem in normalizedTasks)
+                {
+                    TaskItemViewModel? sourceParent = null;
+                    if (operationKind == BatchDropOperationKind.MoveInto &&
+                        !TryResolveMoveSourceParent(taskItem, out sourceParent))
+                    {
+                        items = Array.Empty<DragSourceOperationItem>();
+                        errorMessage = L10n.Get("BatchMoveMissingParents");
+                        return false;
+                    }
+
+                    result.Add(new DragSourceOperationItem(
+                        taskItem,
+                        operationKind == BatchDropOperationKind.MoveInto ? sourceParent : null));
+                }
+
+                items = result;
+                return items.Count > 0;
+            }
+
             object? singleSource = null;
             if (!DragDataFormats.TryGetValue<object>(e.DataTransfer, CustomDataFormat, out singleSource))
             {
@@ -1018,17 +1046,11 @@ namespace Unlimotion.Views
                 case TaskItemViewModel taskItem:
                 {
                     TaskItemViewModel? sourceParent = null;
-                    if (operationKind == BatchDropOperationKind.MoveInto)
+                    if (operationKind == BatchDropOperationKind.MoveInto &&
+                        !TryResolveMoveSourceParent(taskItem, out sourceParent))
                     {
-                        if (taskItem.Parents.Count <= 1)
-                        {
-                            sourceParent = taskItem.ParentsTasks.FirstOrDefault();
-                        }
-                        else
-                        {
-                            errorMessage = L10n.Get("MoveMissingParent");
-                            return false;
-                        }
+                        errorMessage = L10n.Get("MoveMissingParent");
+                        return false;
                     }
 
                     item = new DragSourceOperationItem(taskItem, sourceParent);
@@ -1061,6 +1083,44 @@ namespace Unlimotion.Views
             }
 
             return false;
+        }
+
+        private static bool TryResolveMoveSourceParent(
+            TaskItemViewModel taskItem,
+            out TaskItemViewModel? sourceParent)
+        {
+            sourceParent = null;
+            if (taskItem.Parents.Count > 1)
+            {
+                return false;
+            }
+
+            sourceParent = taskItem.ParentsTasks.FirstOrDefault();
+            return true;
+        }
+
+        private static IReadOnlyList<TaskItemViewModel> NormalizeRoadmapTasksForBatch(
+            IEnumerable<TaskItemViewModel>? taskItems)
+        {
+            var distinctTasks = taskItems?
+                                    .Where(static task => task != null &&
+                                                          !string.IsNullOrWhiteSpace(task.Id))
+                                    .GroupBy(static task => task.Id, StringComparer.Ordinal)
+                                    .Select(static group => group.First())
+                                    .ToList()
+                                ?? [];
+            if (distinctTasks.Count <= 1)
+            {
+                return distinctTasks;
+            }
+
+            var selectedIds = distinctTasks
+                .Select(static task => task.Id)
+                .ToHashSet(StringComparer.Ordinal);
+
+            return distinctTasks
+                .Where(task => task.GetAllParents().All(parent => !selectedIds.Contains(parent.Id)))
+                .ToList();
         }
 
         private static bool CanApplyDrop(


### PR DESCRIPTION
## Summary
- add runtime roadmap selection/current visual state for task nodes
- support click and rectangle multi-selection with Ctrl/Shift/Alt semantics
- drag selected visible roadmap tasks as a batch and route them through the existing common drop engine
- preserve tree-tab batch drag/drop behavior while adding roadmap batch payload parsing
- prune selection for tasks hidden by roadmap filters while preserving selection through search highlighting
- fix right-button roadmap panning on empty canvas and selected-task scenarios
- keep roadmap node border thickness constant so selection/current frames do not resize nodes or shift inline content
- make roadmap rectangle hit-testing zoom-aware by comparing transformed node bounds in the same coordinate space as the selection overlay
- address review feedback: marquee hit-testing ignores minimap item borders, modifier double-clicks preserve single-click current-task semantics, and duplicate-selection suppression now relies on platform `ClickCount` instead of a local 500ms window
- rebase on current `origin/main` (`8e5d3c0`, includes #240) while preserving roadmap inline title rename behavior
- cover the UI behavior with Avalonia.Headless roadmap tests and update the QUEST spec journal

## Validation
- `dotnet build src\Unlimotion.Desktop\Unlimotion.Desktop.csproj -v:minimal -p:OutputPath=$env:TEMP\unlimotion-codex-desktop-build\ -p:UseSharedCompilation=false` (passes; existing warnings only)
- `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj -v:minimal -p:OutputPath=$env:TEMP\unlimotion-codex-test-build\ -p:UseSharedCompilation=false` (passes after sequential retry; existing warnings only)
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -p:OutputPath=$env:TEMP\unlimotion-codex-build\ -p:UseSharedCompilation=false -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_RectangleHitTesting_UsesZoomedNodeBounds"` (1/1, previous validation)
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -p:OutputPath=$env:TEMP\unlimotion-codex-build-2\ -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_RectangleSelection_UsesViewportZoom"` (1/1, previous validation)
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -p:OutputPath=$env:TEMP\unlimotion-codex-build\ -p:UseSharedCompilation=false -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_RectangleSelection_AppliesModifierSemanticsAndDoesNotChangeCurrentTask"` (1/1, previous validation)
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -p:OutputPath=$env:TEMP\unlimotion-codex-build\ -p:UseSharedCompilation=false -- --treenode-filter "/*/*/RoadmapGraphUiTests/*"` (47/47 after latest rebase)
- `dotnet run --no-build --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*"` (34/34, previous rebase validation)
- `git diff --check`

## Notes
- Normal local `bin\Debug` output is currently blocked by a running desktop/debug process, so the latest builds/tests use temp output paths.
- `dotnet build src\Unlimotion.sln -v:minimal -p:OutputPath=$env:TEMP\unlimotion-codex-sln-build\` is blocked by missing `wasm-tools` workload for `Unlimotion.Android` and `Unlimotion.iOS`.
- A full `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -p:OutputPath=$env:TEMP\unlimotion-codex-build\` attempt timed out after 20 minutes without diagnostic output; the leftover process was stopped after timeout.
- Parallel targeted test/build attempts can contend for shared `obj`; the final validation above uses sequential runs and/or `UseSharedCompilation=false`.