### PR TITLE
feat(task-tree): persist expansion state

### DIFF
--- a/specs/2026-05-14-task-expansion-state-persistence.md
+++ b/specs/2026-05-14-task-expansion-state-persistence.md
@@ -1,0 +1,255 @@
+# Сохранение состояния разворачивания деревьев задач
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; `dotnet-desktop-client` + `ui-automation-testing`; context `testing-dotnet`.
+- Владелец: Codex / пользователь.
+- Масштаб: medium.
+- Целевая модель: gpt-5.5.
+- Целевой релиз / ветка: текущая рабочая ветка репозитория.
+- Ограничения: central QUEST SPEC-first; на фазе SPEC изменяется только этот файл; UI-изменение требует UI test coverage; состояние разворачивания должно храниться в отдельном json рядом с основным config-файлом.
+- Связанные ссылки: `C:\Users\Kibnet\.codex\agents\AGENTS.md`, `AGENTS.override.md`, `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.ViewModel/TaskWrapperViewModel.cs`, `src/Unlimotion.ViewModel/SettingsViewModel.cs`, `src/Unlimotion/Views/SettingsControl.axaml`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs`, `src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs`.
+
+## 1. Overview / Цель
+Добавить пользовательскую настройку, которая включает сохранение статусов разворачивания деревьев задач между перезапусками приложения. При включении настройки список развёрнутых задач должен записываться в отдельный json-файл рядом с основным конфигом, а при следующем запуске восстанавливаться.
+
+Outcome contract:
+- Success means: в Settings есть чекбокс; настройка сохраняется в основном конфиге; при включении списки развёрнутых task id по отдельным деревьям сохраняются в отдельный json рядом с config; после пересоздания ViewModel/перезапуска развёрнутые задачи восстанавливаются; существующее session-only восстановление при поиске не ломается.
+- Итоговый артефакт / output: изменения ViewModel, app wiring, XAML/resources и автоматические тесты.
+- Stop rules: остановиться перед реализацией до фразы пользователя `Спеку подтверждаю`; после EXEC остановиться только после targeted UI/ViewModel tests, `dotnet build`, полного `dotnet test` или явного отчёта о невозможности запуска.
+
+## 2. Текущее состояние (AS-IS)
+- `TaskWrapperViewModel` получает начальное `IsExpanded` через `TaskWrapperActions.GetExpansionState` и сообщает изменения через `SetExpansionState`.
+- `MainWindowViewModel.Connect()` создаёт отдельные in-memory словари `allTasksExpansionState`, `unlockedExpansionState`, `completedExpansionState`, `archivedExpansionState`, `lastCreatedExpansionState`, `lastUpdatedExpansionState`, `lastOpenedExpansionState`.
+- Локальная функция `TrackExpansionState(...)` привязывает эти словари к wrapper-ам. Это уже восстанавливает состояние после фильтрации/поиска внутри текущего `Connect()`, но не переживает новый запуск.
+- После выбора persisted-формата как списка развёрнутых задач эти in-memory словари тоже избыточны: для runtime cache достаточно `HashSet<string>` expanded ids на дерево.
+- `SettingsViewModel` пишет настройки через `WritableJsonConfiguration` в основной конфиг. В Settings UI уже есть чекбоксы для похожих bool-настроек (`IsFuzzySearch`, clipboard, auto update).
+- `App.Init(string configPath)` знает путь к конфигу, но `MainWindowViewModel` сейчас получает только `IConfiguration`, без явного пути к config.
+- UI-тесты есть в `src/Unlimotion.Test`: headless Avalonia тесты для Settings и tree commands.
+
+## 3. Проблема
+Пользователь вручную разворачивает нужные ветки дерева, но после перезапуска приложения состояние разворачивания сбрасывается, потому что текущая логика хранит его только в памяти.
+
+## 4. Цели дизайна
+- Разделение ответственности: настройка включения в `SettingsViewModel`; чтение/запись файла состояния в отдельном небольшом сервисе/классе; применение состояния в `MainWindowViewModel`.
+- Повторное использование: использовать существующие hooks `GetExpansionState`/`SetExpansionState`, не переписывать биндинги дерева.
+- Тестируемость: file-backed storage должен быть проверяем без UI; checkbox должен проверяться existing Avalonia.Headless pattern.
+- Консистентность: новая настройка должна выглядеть как существующие bool-настройки в Settings и иметь stable `AutomationId`.
+- Обратная совместимость: по умолчанию persistence выключен; без файла состояния приложение ведёт себя как сейчас.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не сохраняем selected item, scroll position, активную вкладку, search/filter/sort сверх уже существующих настроек.
+- Не переносим состояние разворачивания в файлы задач и не меняем формат задач.
+- Не меняем поведение команд expand/collapse, поиска и lazy projections кроме добавления optional persistence.
+- Не добавляем синхронизацию состояния разворачивания через Git backup/server storage.
+- Не создаём миграцию старых in-memory состояний, потому что они не persisted.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `SettingsViewModel.cs` -> новое свойство `PersistTaskTreeExpansionState`, чтение/запись bool в основной конфиг.
+- `SettingsControl.axaml` -> новый `CheckBox` с `AutomationId="PersistTaskTreeExpansionStateCheckBox"` в секции `Appearance`, рядом с `FuzzySearch`, потому что обе настройки управляют локальным UI-facing поведением.
+- `Strings.resx` / `Strings.ru.resx` -> тексты для чекбокса и при необходимости label/hint.
+- Новый класс во `Unlimotion.ViewModel` (например, `TaskTreeExpansionStateStore`) -> загрузка отдельного json-файла, накопление dirty changes и пакетная throttled-запись.
+- `App.axaml.cs` и test host/fixture -> передают путь к json-файлу, рассчитанный от config path.
+- `MainWindowViewModel.cs` -> заменяет per-tree expansion dictionaries на `HashSet<string>` expanded ids и использует store при создании sets и при `SetExpansionState`.
+
+### 6.2 Детальный дизайн
+- Config key: `TaskTreeExpansionState:Enabled`.
+- Файл состояния: `TaskTreeExpansionState.json` в той же директории, что и основной config. Пример: если config `C:\...\Settings.json`, state file `C:\...\TaskTreeExpansionState.json`.
+- Формат файла:
+  ```json
+  {
+    "Version": 1,
+    "Trees": {
+      "AllTasksTree": [ "<expanded-task-id>" ],
+      "UnlockedTree": [ "<expanded-task-id>" ]
+    }
+  }
+  ```
+- Сохраняются только развёрнутые task id. Свернутое состояние является default; при `IsExpanded=false` id удаляется из набора.
+- При включённой настройке `MainWindowViewModel.Connect()` загружает файл один раз в модель состояния и отдаёт каждому дереву свой набор expanded ids.
+- При изменении `TaskWrapperViewModel.IsExpanded` `SetExpansionState` добавляет id в набор при `true`, удаляет при `false`, и помечает состояние dirty, если `Settings.PersistTaskTreeExpansionState == true`.
+- При выключенной настройке in-memory наборы продолжают работать внутри текущего `Connect()`, но файл не читается и не пишется.
+- Runtime `GetExpansionState` для set-only cache возвращает `true`, если id есть в наборе, и `null`, если id отсутствует. Это сохраняет существующий fallback на `TaskWrapperViewModel.DefaultIsExpanded`: в обычном режиме default остаётся collapsed, а automation-сценарии с `DefaultIsExpanded=true` не ломаются. Точное хранение explicit collapsed в default-expanded automation режиме не входит в эту задачу.
+- Если json отсутствует, пустой или повреждён, состояние считается пустым; приложение не должно падать. Ошибку можно игнорировать либо показать toast только при write failure, если это уже соответствует pattern. Для минимального изменения предпочтительно не блокировать UI и не падать.
+- Запись MUST быть пакетной и throttled: серия изменений, включая `ExpandAll/CollapseAll`, не должна писать файл на каждую задачу отдельно. Store должен планировать запись после короткого quiet period (ориентир 500 ms) и сериализовать один snapshot всех sets.
+- Store должен поддерживать принудительный flush pending write при disposal/reset connection, чтобы не терять последнее изменение при закрытии окна или переподключении.
+- Фактическая запись должна быть атомарной overwrite-записью небольшого json с `WriteIndented`. Ошибки записи не должны падать через UI-поток; допустимо сохранить их как no-op/loggable failure без блокировки работы приложения.
+- Путь к файлу не должен попадать в основной конфиг как persisted value, чтобы не ломать portable config.
+
+## 7. Бизнес-правила / Алгоритмы
+- `PersistTaskTreeExpansionState == false`: поведение как сейчас, файл состояния не создаётся новыми expand/collapse действиями.
+- `PersistTaskTreeExpansionState == true`: каждое изменение `IsExpanded` для task id обновляет список развёрнутых задач конкретного дерева и планирует одну пакетную запись после throttle window.
+- State scope per tree: один и тот же task id может иметь разные состояния в `AllTasksTree`, `LastCreatedTree`, `UnlockedTree` и других projections.
+- Если id отсутствует в set, wrapper использует прежний fallback `DefaultIsExpanded`; в пользовательском runtime это даёт свернутое состояние по умолчанию.
+- Unknown tree names in json are ignored by текущие projections, но сохраняются при round-trip только если это не усложняет реализацию; допустимо перезаписать только known trees.
+- Пустые/whitespace task id не сохраняются. Дубликаты task id при чтении нормализуются в один id.
+- `ExpandAll/CollapseAll` над веткой или деревом должен приводить максимум к одной фактической записи после завершения burst, а не к записи на каждый wrapper.
+
+## 8. Точки интеграции и триггеры
+- Settings checkbox -> `SettingsViewModel.PersistTaskTreeExpansionState` -> основной config.
+- `MainWindowViewModel.Connect()` -> load state when enabled, wire per-tree expanded id sets.
+- `TaskWrapperViewModel.IsExpanded` setter -> existing `SetExpansionState` hook -> update set and schedule throttled batch write.
+- App startup/test host/fixture -> calculate state json path from known config path and provide it to ViewModel/store.
+
+## 9. Изменения модели данных / состояния
+- Новый config bool: настройка включения persistence.
+- Новый sidecar json-файл рядом с config: persisted lists of expanded task ids.
+- Данные задач и server model не меняются.
+- In-memory `HashSet<string>` остаются как runtime cache и источник для current session restore.
+
+## 10. Миграция / Rollout / Rollback
+- Первый запуск: config key отсутствует -> default `false`; sidecar файл не нужен.
+- Включение настройки: файл создаётся при первом изменении expand/collapse.
+- Отключение настройки: файл не удаляется автоматически; повторное включение может восстановить прежние состояния. Это безопаснее, чем silently deleting user state.
+- Повреждённый файл: игнорировать и продолжить с пустым состоянием; следующая успешная запись перезапишет корректным форматом.
+- Rollback: удалить новый config key и sidecar json; приложение вернётся к session-only состоянию.
+
+## 11. Тестирование и критерии приёмки
+Acceptance Criteria:
+- В Settings отображается чекбокс сохранения состояния разворачивания с устойчивым `AutomationId`.
+- Чекбокс меняет `SettingsViewModel.PersistTaskTreeExpansionState` и пишет bool в основной config.
+- При выключенной настройке разворачивание не создаёт sidecar json.
+- При включенной настройке разворачивание узла добавляет task id в sidecar json, а сворачивание удаляет task id из списка.
+- Массовое разворачивание/сворачивание пишет sidecar json пакетно после throttle window, а не на каждую задачу отдельно.
+- После пересоздания `MainWindowViewModel` с тем же config path и включённой настройкой состояние соответствующего дерева восстанавливается.
+- Существующий тест `TreeSearch_ClearSearch_RestoresExpansionState` остаётся зелёным.
+
+Какие тесты добавить/изменить:
+- `SettingsViewModelTests`: persist default/true для новой настройки.
+- `SettingsControlResponsiveUiTests`: headless UI test для нового checkbox и binding.
+- `MainWindowViewModelTests` или `MainControlTreeCommandsUiTests`: persistence через sidecar json для at least `AllTasksTree`; при низкой стоимости добавить parametrized coverage для нескольких tree names.
+- Тест на disabled mode: файл не создаётся при expand/collapse.
+- Тест store batching/throttling: несколько изменений подряд приводят к одной записи snapshot после throttle/flush, а не к записи на каждое изменение.
+- При необходимости unit-тест store на повреждённый json.
+
+Команды для проверки:
+- Targeted: `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --filter "FullyQualifiedName~SettingsViewModelTests|FullyQualifiedName~SettingsControlResponsiveUiTests|FullyQualifiedName~MainWindowViewModelTests|FullyQualifiedName~MainControlTreeCommandsUiTests"`
+- Build: `dotnet build src/Unlimotion.sln`
+- Full: `dotnet test src/Unlimotion.sln`
+
+Stop rules для validation loops:
+- Повторять targeted tests после каждой правки persistence logic или UI binding.
+- Full test запускать после targeted green.
+- Если full test невозможен из-за времени/окружения, зафиксировать targeted/build результат и точную причину.
+
+## 12. Риски и edge cases
+- Нет config path в некоторых тестовых/ручных конструкторах: использовать no-op store или optional path, чтобы не ломать существующие вызовы.
+- Throttled-запись может потерять последнее изменение при резком закрытии процесса без штатного dispose; mitigation: flush при disposal/reset connection и тест на принудительный flush.
+- Повреждённый json не должен ломать startup.
+- Lazy projections: set состояния для вкладки должен применяться при её первой активации, а не только во время первого `Connect()`.
+- Поиск временно фильтрует wrapper-ы; сохранённое состояние не должно перетирать пользовательский current-session state при очистке поиска.
+
+## 13. План выполнения
+1. Добавить model/store для sidecar expansion state с безопасной загрузкой, dirty tracking, throttled batch save и forced flush.
+2. Добавить настройку в `SettingsViewModel` и локализованные UI strings.
+3. Добавить checkbox в `SettingsControl.axaml` со stable `AutomationId`.
+4. Прокинуть путь sidecar json из app/test host/fixture, сохранив существующие call sites через optional/no-op path.
+5. Заменить локальные per-tree dictionaries в `MainWindowViewModel.Connect()` на runtime `HashSet<string>` expanded ids, инициализированные из store при включенной настройке.
+6. Добавить/обновить tests.
+7. Запустить targeted tests, build, full test.
+8. Выполнить post-EXEC review и исправить критичные находки.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов. Product choice принят в рамках запроса: sidecar filename `TaskTreeExpansionState.json`, setting default `false`, файл не удаляется при выключении.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client` + `ui-automation-testing`; context `testing-dotnet`.
+- Выполненные требования профиля: spec предусматривает сохранение UI-поведения без блокировки UI-потока, stable automation id, UI test coverage, targeted/full .NET checks.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.ViewModel/SettingsViewModel.cs` | Добавить bool-свойство настройки | Persist setting in config |
+| `src/Unlimotion.ViewModel/TaskTreeExpansionStateStore.cs` | Новый store sidecar json с throttled batch write и forced flush | Изолировать файловую persistence-логику и не писать на диск на каждую задачу |
+| `src/Unlimotion.ViewModel/MainWindowViewModel.cs` | Заменить expansion dictionaries на sets и подключить store | Восстановление/сохранение развёрнутых задач |
+| `src/Unlimotion/Views/SettingsControl.axaml` | Добавить checkbox | Пользовательское управление |
+| `src/Unlimotion.ViewModel/Resources/Strings.resx` | EN strings | Локализация UI |
+| `src/Unlimotion.ViewModel/Resources/Strings.ru.resx` | RU strings | Локализация UI |
+| `src/Unlimotion/App.axaml.cs` | Рассчитать sidecar path рядом с config | Runtime wiring |
+| `tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs` | Передать sidecar path в headless host | UI/integration тесты |
+| `src/Unlimotion.Test/MainWindowViewModelFixture.cs` | Передать sidecar path, cleanup | Repository test pattern |
+| `src/Unlimotion.Test/SettingsViewModelTests.cs` | Unit coverage setting | Config persistence |
+| `src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs` | UI checkbox coverage | UI requirement |
+| `src/Unlimotion.Test/MainWindowViewModelTests.cs` или `MainControlTreeCommandsUiTests.cs` | Persistence behavior coverage | Regression |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Expansion state | In-memory словари bool в текущем `Connect()` | In-memory sets + optional persisted sidecar json со списками expanded task ids per tree |
+| Settings UI | Нет настройки | Checkbox включает/выключает persistence |
+| Startup | Нет восстановления после перезапуска | При enabled загружает sidecar json |
+| Disabled mode | Session-only | Session-only сохранён |
+
+## 18. Альтернативы и компромиссы
+- Вариант: хранить состояния в основном config.
+- Плюсы: меньше файлов.
+- Минусы: пользователь явно попросил специальный json рядом с config; config будет часто меняться и разрастаться.
+- Почему выбранное решение лучше в контексте этой задачи: sidecar json отделяет runtime UI-state от пользовательских настроек и соответствует запросу.
+
+- Вариант: хранить состояние в файлах задач.
+- Плюсы: состояние рядом с task data.
+- Минусы: меняет domain data, может попасть в Git sync/server sync и загрязнить историю задач UI-state.
+- Почему выбранное решение лучше в контексте этой задачи: состояние разворачивания является локальным UI-state.
+
+- Вариант: хранить словарь task id -> bool.
+- Плюсы: напрямую соответствует текущему runtime-состоянию `IsExpanded`.
+- Минусы: `false` избыточен, потому что свернутое состояние является default; json становится шумнее.
+- Почему выбранное решение лучше в контексте этой задачи: список развёрнутых задач компактнее, проще для чтения и достаточно точно описывает persisted contract. При сворачивании task id удаляется из списка.
+
+- Вариант: писать json сразу на каждое изменение `IsExpanded`.
+- Плюсы: проще реализация, меньше риска потерять последнее изменение при аварийном завершении процесса.
+- Минусы: `ExpandAll/CollapseAll` создаёт запись на каждую задачу и может заметно грузить диск/UI.
+- Почему выбранное решение лучше в контексте этой задачи: throttled batch write сохраняет тот же итоговый snapshot, но резко снижает количество файловых операций; forced flush покрывает штатное закрытие/переподключение.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели и Non-Goals зафиксированы. |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, формат json, интеграции, ошибки, rollout описаны. |
+| C. Безопасность изменений | 11-13 | PASS | Есть тест-план, риски, phased implementation. |
+| D. Проверяемость | 14-16 | PASS | Acceptance Criteria, команды и таблица файлов есть. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Нет блокирующих вопросов, альтернативы и quality gate заполнены. |
+| F. Соответствие профилю | 20 | PASS | UI automation и .NET desktop требования учтены. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---|---|
+| 1. Ясность цели и границ | 5 | Запрос сведен к optional persistence expansion state. |
+| 2. Понимание текущего состояния | 5 | Зафиксированы текущие hooks и per-tree dictionaries, которые будут заменены на sets. |
+| 3. Конкретность целевого дизайна | 5 | Указаны config key, sidecar file, schema, wiring. |
+| 4. Безопасность (миграция, откат) | 5 | Default off, no task data migration, corrupt json handling. |
+| 5. Тестируемость | 5 | Указаны unit/UI/behavior tests и команды. |
+| 6. Готовность к автономной реализации | 5 | План не требует открытых решений пользователя. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Что исправлено: в spec явно добавлены disabled-mode acceptance, corrupt json behavior, lazy projection риск, stable `AutomationId`, запрет писать путь sidecar в основной config; после замечаний пользователя формат persistence упрощён со словаря bool до списков expanded task ids, runtime cache также переведён со словарей на sets; после ревью выбран конкретный config key/UI placement и исправлен контракт absent-id с `false` на `null`, чтобы сохранить `DefaultIsExpanded`; добавлено обязательное throttled batch сохранение с forced flush.
+- Что осталось на решение пользователя: только подтверждение перехода в EXEC.
+
+## Approval
+Ожидается фраза: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Контекст и проектирование | 0.86 | Нет блокирующих данных | Запросить подтверждение спеки | Да | Нет | Central QUEST требует SPEC-first и фразу подтверждения перед изменением кода | `specs/2026-05-14-task-expansion-state-persistence.md` |
+| SPEC | Уточнение дизайна | 0.9 | Нет блокирующих данных | Запросить подтверждение обновлённой спеки | Да | Да: пользователь предложил хранить список развёрнутых задач вместо словаря | Список expanded ids проще и достаточен, потому что collapsed является default | `specs/2026-05-14-task-expansion-state-persistence.md` |
+| SPEC | Уточнение runtime-модели | 0.88 | Нет блокирующих данных | Запросить подтверждение обновлённой спеки | Да | Да: пользователь предложил заменить in-memory словари на sets | Runtime sets совпадают с persisted контрактом и уменьшают лишнее состояние | `specs/2026-05-14-task-expansion-state-persistence.md` |
+| SPEC | Ревью спеки | 0.9 | Нет блокирующих данных | Запросить подтверждение обновлённой спеки | Да | Да: пользователь запросил ревью спеки | Убраны недоопределённые решения и сохранён fallback `DefaultIsExpanded` | `specs/2026-05-14-task-expansion-state-persistence.md` |
+| SPEC | Уточнение записи на диск | 0.9 | Нет блокирующих данных | Запросить подтверждение обновлённой спеки | Да | Да: пользователь потребовал throttling и batch save | Batch save предотвращает запись sidecar json на каждую задачу при массовых командах | `specs/2026-05-14-task-expansion-state-persistence.md` |
+| EXEC | Старт реализации | 0.88 | Нет блокирующих данных | Внести store, wiring, UI и тесты | Нет | Да: пользователь подтвердил спеки фразой `Спеку подтверждаю` | Переход в EXEC разрешён central QUEST-гейтом | `specs/2026-05-14-task-expansion-state-persistence.md` |
+| EXEC | Реализация store и UI wiring | 0.82 | Нужна компиляционная проверка | Добавить тесты и запустить targeted suite | Нет | Нет | Добавлен sidecar store с throttled batch write, подключён к деревьям, добавлена настройка Settings UI | `src/Unlimotion.ViewModel/TaskTreeExpansionStateStore.cs`, `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.ViewModel/SettingsViewModel.cs`, `src/Unlimotion/Views/SettingsControl.axaml`, resources, app/test host/fixture |
+| EXEC | Добавление тестов | 0.82 | Нужен запуск тестов | Запустить targeted tests | Нет | Нет | Добавлены проверки config setting, UI checkbox, throttled batch write, disabled sidecar и restore из sidecar | `src/Unlimotion.Test/SettingsViewModelTests.cs`, `src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs`, `src/Unlimotion.Test/MainWindowViewModelTests.cs` |
+| EXEC | Валидация | 0.78 | Полный solution build/full test заблокированы окружением/таймаутом | Выполнить post-EXEC review | Нет | Нет | Targeted тесты и build test project прошли; solution build упал на missing `wasm-tools`, полный `Unlimotion.Test` не завершился за 15 минут | test commands, `src/Unlimotion.Test/Unlimotion.Test.csproj` |
+| EXEC | Post-EXEC fix | 0.84 | Нужен повторный build после тестовой правки | Повторить build test project и завершить review | Нет | Нет | Добавлен недостающий тест forced flush при dispose для pending batch write; `SettingsViewModelTests` повторно прошёл 56/56 | `src/Unlimotion.Test/SettingsViewModelTests.cs` |
+| EXEC | Финальная проверка | 0.82 | Нет блокирующих данных | Завершить задачу | Нет | Нет | Повторный `dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj` прошёл; зависшие процессы полного прогона закрыты | `src/Unlimotion.Test/Unlimotion.Test.csproj` |
+| EXEC | Post-EXEC review | 0.84 | Нет блокирующих данных | Финальный отчёт пользователю | Нет | Нет | Проверены отклонения от спеки, UI coverage, batch/flush coverage и остаточные validation ограничения | изменённые файлы и результаты проверок |
+| EXEC | Исправления по review | 0.86 | Нет блокирующих данных | Финальный отчёт пользователю | Нет | Да: пользователь попросил внести изменения после review | Pending write теперь отменяется при выключении настройки, failed write не очищает dirty state, test fixture изолирует sidecar рядом с уникальным config | `src/Unlimotion.ViewModel/TaskTreeExpansionStateStore.cs`, `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.Test/MainWindowViewModelFixture.cs`, tests |

--- a/src/Unlimotion.Test/MainWindowViewModelFixture.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelFixture.cs
@@ -16,9 +16,12 @@ namespace Unlimotion.Test
         private readonly ThreadLocal<Guid> guid;
         private readonly IDisposable? configurationDisposable;
 
+        private readonly string fixtureDirectory;
         private readonly string uniqueConfigName;
         private bool isCleaned;
         public MainWindowViewModel MainWindowViewModelTest { get; private set; }
+        public string ConfigPath => Path.GetFullPath(uniqueConfigName);
+        public string? TaskTreeExpansionStatePath => TaskTreeExpansionStateStore.GetDefaultPath(ConfigPath);
         public readonly string DefaultTasksFolderPath;
         private readonly string defaultSnapshotsFolderPath;
         public string DefaultRootTaskPath;
@@ -57,16 +60,20 @@ namespace Unlimotion.Test
         public MainWindowViewModelFixture()
         {
             guid = new ThreadLocal<Guid> { Value = Guid.NewGuid() };
-            uniqueConfigName = $"TestSettings_{UniquiId}.json";
+            fixtureDirectory = Path.Combine(Environment.CurrentDirectory, $"MainWindowViewModelFixture_{UniquiId}");
+            Directory.CreateDirectory(fixtureDirectory);
+            uniqueConfigName = Path.Combine(fixtureDirectory, $"TestSettings_{UniquiId}.json");
             var defaultTasksFolderName = $"Tasks_{UniquiId}";
-            DefaultTasksFolderPath = Path.Combine(Environment.CurrentDirectory, defaultTasksFolderName);
+            DefaultTasksFolderPath = Path.Combine(fixtureDirectory, defaultTasksFolderName);
             defaultSnapshotsFolderPath = Path.Combine(Environment.CurrentDirectory, "Snapshots");
             DefaultRootTaskPath = Path.Combine(defaultSnapshotsFolderPath, RootTask1Id);
             Directory.CreateDirectory(DefaultTasksFolderPath);
             CopyTaskFromSnapshotsFolder();
             var fileInfo = new FileInfo(DefaultConfigName);
             var content = fileInfo.ReadAllText();
-            content = content.Replace("Tasks", defaultTasksFolderName);
+            content = content.Replace(
+                "\"Path\": \"Tasks\"",
+                $"\"Path\": \"{DefaultTasksFolderPath.Replace("\\", "\\\\")}\"");
             var configFile = File.Create(uniqueConfigName);
             configFile.Write(content);
             configFile.Close();
@@ -95,7 +102,8 @@ namespace Unlimotion.Test
                 notificationManagerMock,
                 configuration,
                 () => storageFactory.CurrentStorage,
-                settingsViewModel
+                settingsViewModel,
+                taskTreeExpansionStatePath: TaskTreeExpansionStatePath
             );
         }
 
@@ -144,7 +152,14 @@ namespace Unlimotion.Test
             {
                 Try(() => File.Delete(uniqueConfigName));
             }
+
+            if (!string.IsNullOrWhiteSpace(TaskTreeExpansionStatePath) && File.Exists(TaskTreeExpansionStatePath))
+            {
+                Try(() => File.Delete(TaskTreeExpansionStatePath));
+            }
+
             Try(() => Directory.Delete(DefaultTasksFolderPath, true));
+            Try(() => Directory.Delete(fixtureDirectory, true));
         }
     }
 }

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -10,7 +10,9 @@ using Avalonia.Headless;
 using Avalonia.Threading;
 using KellermanSoftware.CompareNetObjects;
 using Unlimotion.Domain;
+using Unlimotion.Services;
 using Unlimotion.ViewModel;
+using WritableJsonConfiguration;
 using L10n = Unlimotion.ViewModel.Localization.Localization;
 
 namespace Unlimotion.Test
@@ -148,6 +150,66 @@ namespace Unlimotion.Test
             return text?
                 .Replace("\r\n", "\n")
                 .Replace('\r', '\n');
+        }
+
+        private static IReadOnlyList<string> ReadExpandedTaskIds(string statePath, string treeName)
+        {
+            if (!File.Exists(statePath))
+            {
+                return [];
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllText(statePath));
+            if (!document.RootElement.TryGetProperty("Trees", out var trees) ||
+                !trees.TryGetProperty(treeName, out var treeState))
+            {
+                return [];
+            }
+
+            return treeState.EnumerateArray()
+                .Select(element => element.GetString())
+                .Where(id => !string.IsNullOrWhiteSpace(id))
+                .Cast<string>()
+                .ToList();
+        }
+
+        private static async Task<MainWindowViewModel> CreateReloadedViewModelAsync(
+            MainWindowViewModelFixture sourceFixture,
+            List<IDisposable> disposables)
+        {
+            var configuration = WritableJsonConfigurationFabric.Create(sourceFixture.ConfigPath, reloadOnChange: false);
+            if (configuration is IDisposable configurationDisposable)
+            {
+                disposables.Add(configurationDisposable);
+            }
+
+            var notificationManager = new NotificationManagerWrapperMock();
+            var storageFactory = new TaskStorageFactory(
+                configuration,
+                Unlimotion.AppModelMapping.ConfigureMapping(),
+                notificationManager);
+            storageFactory.CreateFileStorage(sourceFixture.DefaultTasksFolderPath);
+
+            if (storageFactory.CurrentStorage is IDisposable storageDisposable)
+            {
+                disposables.Add(storageDisposable);
+            }
+
+            var settings = new SettingsViewModel(configuration);
+            var viewModel = new MainWindowViewModel(
+                new AppNameDefinitionService(),
+                notificationManager,
+                configuration,
+                () => storageFactory.CurrentStorage,
+                settings,
+                taskTreeExpansionStatePath: sourceFixture.TaskTreeExpansionStatePath);
+            disposables.Add(viewModel);
+
+            await viewModel.Connect();
+            viewModel.AllTasksMode = true;
+            Dispatcher.UIThread.RunJobs();
+
+            return viewModel;
         }
 
         private static async Task<(TaskWrapperViewModel RootWrapper, TaskWrapperViewModel ChildWrapper, TaskWrapperViewModel GrandchildWrapper)>
@@ -2016,6 +2078,119 @@ namespace Unlimotion.Test
                 await Assert.That(rootWrapper.IsExpanded).IsTrue();
                 await Assert.That(childWrapper.IsExpanded).IsTrue();
                 await Assert.That(grandchildWrapper.IsExpanded).IsTrue();
+            });
+        }
+
+        [Test]
+        public async Task TaskTreeExpansionState_Disabled_DoesNotCreateSidecarFile()
+        {
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, _) =>
+            {
+                var statePath = projectionFixture.TaskTreeExpansionStatePath
+                    ?? throw new InvalidOperationException("Task tree expansion state path was not configured.");
+                if (File.Exists(statePath))
+                {
+                    File.Delete(statePath);
+                }
+
+                viewModel.Settings.PersistTaskTreeExpansionState = false;
+                var rootWrapper = viewModel.CurrentAllTasksItems.First();
+                rootWrapper.IsExpanded = true;
+
+                await Task.Delay(TaskTreeExpansionStateStore.DefaultSaveThrottle + TimeSpan.FromMilliseconds(200));
+
+                await Assert.That(File.Exists(statePath)).IsFalse();
+            });
+        }
+
+        [Test]
+        public async Task TaskTreeExpansionState_DisablingBeforeThrottleCancelsPendingSidecarWrite()
+        {
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, _) =>
+            {
+                var statePath = projectionFixture.TaskTreeExpansionStatePath
+                    ?? throw new InvalidOperationException("Task tree expansion state path was not configured.");
+                if (File.Exists(statePath))
+                {
+                    File.Delete(statePath);
+                }
+
+                viewModel.Settings.PersistTaskTreeExpansionState = true;
+                var rootWrapper = viewModel.CurrentAllTasksItems.First();
+                rootWrapper.IsExpanded = true;
+                viewModel.Settings.PersistTaskTreeExpansionState = false;
+
+                await Task.Delay(TaskTreeExpansionStateStore.DefaultSaveThrottle + TimeSpan.FromMilliseconds(200));
+
+                await Assert.That(File.Exists(statePath)).IsFalse();
+            });
+        }
+
+        [Test]
+        public async Task TaskTreeExpansionState_Enabled_PersistsAndRestoresExpandedIds()
+        {
+            await RunWithTreeProjectionAsync(async (projectionFixture, viewModel, repository) =>
+            {
+                var statePath = projectionFixture.TaskTreeExpansionStatePath
+                    ?? throw new InvalidOperationException("Task tree expansion state path was not configured.");
+                if (File.Exists(statePath))
+                {
+                    File.Delete(statePath);
+                }
+
+                viewModel.Settings.PersistTaskTreeExpansionState = true;
+                var (rootWrapper, childWrapper, _) =
+                    await CreateThreeLevelTreeCommandBranchAsync(viewModel, repository);
+
+                rootWrapper.IsExpanded = true;
+                childWrapper.IsExpanded = true;
+
+                var persisted = await TestHelpers.WaitUntilAsync(
+                    () =>
+                    {
+                        var ids = ReadExpandedTaskIds(statePath, "AllTasksTree");
+                        return ids.Contains(rootWrapper.TaskItem.Id) && ids.Contains(childWrapper.TaskItem.Id);
+                    },
+                    TimeSpan.FromSeconds(3));
+                await Assert.That(persisted).IsTrue();
+
+                childWrapper.IsExpanded = false;
+
+                var removed = await TestHelpers.WaitUntilAsync(
+                    () =>
+                    {
+                        var ids = ReadExpandedTaskIds(statePath, "AllTasksTree");
+                        return ids.Contains(rootWrapper.TaskItem.Id) && !ids.Contains(childWrapper.TaskItem.Id);
+                    },
+                    TimeSpan.FromSeconds(3));
+                await Assert.That(removed).IsTrue();
+
+                var disposables = new List<IDisposable>();
+                try
+                {
+                    var reloaded = await CreateReloadedViewModelAsync(projectionFixture, disposables);
+                    var reloadedRootTask = TestHelpers.GetTask(reloaded, rootWrapper.TaskItem.Id);
+                    var reloadedChildTask = TestHelpers.GetTask(reloaded, childWrapper.TaskItem.Id);
+
+                    var reloadedRootWrapper = reloaded.FindTaskWrapperViewModel(
+                        reloadedRootTask,
+                        reloaded.CurrentAllTasksItems);
+                    var reloadedChildWrapper = reloaded.FindTaskWrapperViewModel(
+                        reloadedChildTask,
+                        reloaded.CurrentAllTasksItems);
+
+                    await Assert.That(reloadedRootWrapper).IsNotNull();
+                    await Assert.That(reloadedChildWrapper).IsNotNull();
+                    await Assert.That(reloadedRootWrapper!.IsExpanded).IsTrue();
+                    await Assert.That(reloadedChildWrapper!.IsExpanded).IsFalse();
+                }
+                finally
+                {
+                    foreach (var disposable in disposables)
+                    {
+                        disposable.Dispose();
+                    }
+                }
             });
         }
 

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -66,6 +66,46 @@ public class SettingsControlResponsiveUiTests
     }
 
     [Test]
+    public async Task SettingsControl_TaskTreeExpansionStateCheckBox_PersistsSetting()
+    {
+        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            var fixture = new MainWindowViewModelFixture();
+            Window? window = null;
+
+            try
+            {
+                var settings = fixture.MainWindowViewModelTest.Settings;
+                var view = new SettingsControl
+                {
+                    DataContext = settings
+                };
+
+                window = CreateWindow(view, 720, 800);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var checkBox = FindControlByAutomationId<CheckBox>(
+                    view,
+                    "PersistTaskTreeExpansionStateCheckBox");
+
+                await Assert.That(checkBox.IsChecked).IsFalse();
+
+                await ClickControlAsync(window, checkBox);
+
+                await Assert.That(settings.PersistTaskTreeExpansionState).IsTrue();
+                await Assert.That(checkBox.IsChecked).IsTrue();
+            }
+            finally
+            {
+                window?.Close();
+                fixture.CleanTasks();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
     public async Task SettingsControl_UpdateSection_ShowsVersionAndDownloadsAvailableUpdate()
     {
         await using var session = HeadlessUnitTestSession.StartNew(typeof(App));

--- a/src/Unlimotion.Test/SettingsViewModelTests.cs
+++ b/src/Unlimotion.Test/SettingsViewModelTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using Microsoft.Extensions.Configuration;
 using Unlimotion.Services;
@@ -107,6 +108,145 @@ public class SettingsViewModelTests : IDisposable
         var reloaded = new SettingsViewModel(configuration);
         await Assert.That(reloaded.CopyTaskOutlineAsMarkdown).IsTrue();
         await Assert.That(reloaded.CopyTaskOutlineDescription).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task TaskTreeExpansionStateSettings_PersistChoice()
+    {
+        IConfigurationRoot configuration = CreateConfiguration();
+        var settings = new SettingsViewModel(configuration);
+
+        await Assert.That(settings.PersistTaskTreeExpansionState).IsFalse();
+
+        settings.PersistTaskTreeExpansionState = true;
+
+        await Assert.That(configuration
+                .GetSection("TaskTreeExpansionState")
+                .GetSection("Enabled")
+                .Get<bool>())
+            .IsTrue();
+
+        var reloaded = new SettingsViewModel(configuration);
+        await Assert.That(reloaded.PersistTaskTreeExpansionState).IsTrue();
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task TaskTreeExpansionStateStore_BatchesChangesIntoOneWrite()
+    {
+        var writes = new ConcurrentQueue<string>();
+        using var store = new TaskTreeExpansionStateStore(
+            "TaskTreeExpansionState.json",
+            loadPersistedState: true,
+            saveThrottle: TimeSpan.FromMilliseconds(50),
+            fileExists: _ => false,
+            readAllText: _ => string.Empty,
+            writeAllText: (_, content) => writes.Enqueue(content));
+
+        store.SetExpansionState("AllTasksTree", "root", true, persist: true);
+        store.SetExpansionState("AllTasksTree", "child", true, persist: true);
+        store.SetExpansionState("AllTasksTree", "grandchild", true, persist: true);
+
+        var written = await TestHelpers.WaitUntilAsync(
+            () => writes.Count == 1,
+            TimeSpan.FromSeconds(2));
+        await Assert.That(written).IsTrue();
+
+        await System.Threading.Tasks.Task.Delay(150);
+        await Assert.That(writes.Count).IsEqualTo(1);
+
+        var json = writes.Single();
+        using var document = JsonDocument.Parse(json);
+        var expandedIds = document.RootElement
+            .GetProperty("Trees")
+            .GetProperty("AllTasksTree")
+            .EnumerateArray()
+            .Select(element => element.GetString())
+            .ToList();
+
+        await Assert.That(expandedIds).Contains("root");
+        await Assert.That(expandedIds).Contains("child");
+        await Assert.That(expandedIds).Contains("grandchild");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task TaskTreeExpansionStateStore_DisposeFlushesPendingWrite()
+    {
+        var writes = new ConcurrentQueue<string>();
+        var store = new TaskTreeExpansionStateStore(
+            "TaskTreeExpansionState.json",
+            loadPersistedState: true,
+            saveThrottle: TimeSpan.FromHours(1),
+            fileExists: _ => false,
+            readAllText: _ => string.Empty,
+            writeAllText: (_, content) => writes.Enqueue(content));
+
+        store.SetExpansionState("AllTasksTree", "root", true, persist: true);
+        await Assert.That(writes.Count).IsEqualTo(0);
+
+        store.Dispose();
+
+        await Assert.That(writes.Count).IsEqualTo(1);
+        var json = writes.Single();
+        using var document = JsonDocument.Parse(json);
+        var expandedIds = document.RootElement
+            .GetProperty("Trees")
+            .GetProperty("AllTasksTree")
+            .EnumerateArray()
+            .Select(element => element.GetString())
+            .ToList();
+        await Assert.That(expandedIds).Contains("root");
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task TaskTreeExpansionStateStore_DisableCancelsPendingWrite()
+    {
+        var writes = new ConcurrentQueue<string>();
+        using var store = new TaskTreeExpansionStateStore(
+            "TaskTreeExpansionState.json",
+            loadPersistedState: true,
+            saveThrottle: TimeSpan.FromMilliseconds(50),
+            fileExists: _ => false,
+            readAllText: _ => string.Empty,
+            writeAllText: (_, content) => writes.Enqueue(content));
+
+        store.SetExpansionState("AllTasksTree", "root", true, persist: true);
+        store.SetPersistenceEnabled(false);
+
+        await System.Threading.Tasks.Task.Delay(150);
+        await Assert.That(writes.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async System.Threading.Tasks.Task TaskTreeExpansionStateStore_FailedWriteKeepsDirtyStateForNextFlush()
+    {
+        var writes = new ConcurrentQueue<string>();
+        var writeAttempts = 0;
+        using var store = new TaskTreeExpansionStateStore(
+            "TaskTreeExpansionState.json",
+            loadPersistedState: true,
+            saveThrottle: TimeSpan.FromHours(1),
+            fileExists: _ => false,
+            readAllText: _ => string.Empty,
+            writeAllText: (_, content) =>
+            {
+                writeAttempts++;
+                if (writeAttempts == 1)
+                {
+                    throw new IOException("Transient write failure.");
+                }
+
+                writes.Enqueue(content);
+            });
+
+        store.SetExpansionState("AllTasksTree", "root", true, persist: true);
+
+        store.Flush();
+        await Assert.That(writeAttempts).IsEqualTo(1);
+        await Assert.That(writes.Count).IsEqualTo(0);
+
+        store.Flush();
+        await Assert.That(writeAttempts).IsEqualTo(2);
+        await Assert.That(writes.Count).IsEqualTo(1);
     }
 
     [Test]

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -51,6 +51,7 @@ namespace Unlimotion.ViewModel
 
         public ITaskStorage? taskRepository;
         private readonly Func<ITaskStorage?>? _getTaskStorage;
+        private readonly string? _taskTreeExpansionStatePath;
 
         public MainWindowViewModel(
             IAppNameDefinitionService? appNameService,
@@ -58,13 +59,15 @@ namespace Unlimotion.ViewModel
             IConfiguration configuration,
             Func<ITaskStorage?>? getTaskStorage = null,
             SettingsViewModel? settings = null,
-            GraphViewModel? graph = null)
+            GraphViewModel? graph = null,
+            string? taskTreeExpansionStatePath = null)
         {
             Title = appNameService?.GetAppName() ?? "";
             connectionDisposableList.AddToDispose(this);
             ManagerWrapper = managerWrapper;
             _configuration = configuration;
             _getTaskStorage = getTaskStorage;
+            _taskTreeExpansionStatePath = taskTreeExpansionStatePath;
             Settings = settings ?? new SettingsViewModel(_configuration);
             Graph = graph ?? new GraphViewModel();
             CurrentAllTasksItems = EmptyTaskWrappers;
@@ -715,35 +718,26 @@ namespace Unlimotion.ViewModel
 
             #endregion Поиск
 
-            var allTasksExpansionState = new Dictionary<string, bool>();
-            var unlockedExpansionState = new Dictionary<string, bool>();
-            var completedExpansionState = new Dictionary<string, bool>();
-            var archivedExpansionState = new Dictionary<string, bool>();
-            var lastCreatedExpansionState = new Dictionary<string, bool>();
-            var lastUpdatedExpansionState = new Dictionary<string, bool>();
-            var lastOpenedExpansionState = new Dictionary<string, bool>();
+            var expansionStateStore = new TaskTreeExpansionStateStore(
+                _taskTreeExpansionStatePath,
+                Settings.PersistTaskTreeExpansionState);
+            expansionStateStore.AddToDispose(connectionDisposableList);
+            this.WhenAnyValue(m => m.Settings.PersistTaskTreeExpansionState)
+                .Subscribe(expansionStateStore.SetPersistenceEnabled)
+                .AddToDispose(connectionDisposableList);
 
-            static TaskWrapperActions TrackExpansionState(
+            TaskWrapperActions TrackExpansionState(
                 TaskWrapperActions actions,
-                IDictionary<string, bool> expansionState)
+                string treeName)
             {
-                actions.GetExpansionState = task =>
-                {
-                    if (string.IsNullOrWhiteSpace(task.Id))
-                    {
-                        return null;
-                    }
-
-                    return expansionState.TryGetValue(task.Id, out var isExpanded)
-                        ? isExpanded
-                        : null;
-                };
+                actions.GetExpansionState = task => expansionStateStore.GetExpansionState(treeName, task.Id);
                 actions.SetExpansionState = (task, isExpanded) =>
                 {
-                    if (!string.IsNullOrWhiteSpace(task.Id))
-                    {
-                        expansionState[task.Id] = isExpanded;
-                    }
+                    expansionStateStore.SetExpansionState(
+                        treeName,
+                        task.Id,
+                        isExpanded,
+                        Settings.PersistTaskTreeExpansionState);
                 };
 
                 return actions;
@@ -817,7 +811,7 @@ namespace Unlimotion.ViewModel
                         GetBreadScrumbs = BredScrumbsAlgorithms.WrapperParent,
                         SortComparer = sortObservable,
                         Filter = new() { taskFilter, emojiExcludeFilter },
-                    }, allTasksExpansionState);
+                    }, "AllTasksTree");
                     var wrapper = new TaskWrapperViewModel(null, item, actions);
                     return wrapper;
                 })
@@ -870,7 +864,7 @@ namespace Unlimotion.ViewModel
                             ChildSelector = m => m.ContainsTasks.ToObservableChangeSet(),
                             RemoveAction = RemoveTask,
                             GetBreadScrumbs = BredScrumbsAlgorithms.FirstTaskParent,
-                        }, unlockedExpansionState);
+                        }, "UnlockedTree");
                         var wrapper = new TaskWrapperViewModel(null, item, actions);
                         return wrapper;
                     })
@@ -983,7 +977,7 @@ namespace Unlimotion.ViewModel
                             ChildSelector = m => m.ContainsTasks.ToObservableChangeSet(),
                             RemoveAction = RemoveTask,
                             GetBreadScrumbs = BredScrumbsAlgorithms.FirstTaskParent,
-                        }, completedExpansionState);
+                        }, "CompletedTree");
                         var wrapper = new TaskWrapperViewModel(null, item, actions);
                         return wrapper;
                     })
@@ -1022,7 +1016,7 @@ namespace Unlimotion.ViewModel
                             ChildSelector = m => m.ContainsTasks.ToObservableChangeSet(),
                             RemoveAction = RemoveTask,
                             GetBreadScrumbs = BredScrumbsAlgorithms.FirstTaskParent,
-                        }, archivedExpansionState);
+                        }, "ArchivedTree");
                         var wrapper = new TaskWrapperViewModel(null, item, actions);
                         return wrapper;
                     })
@@ -1062,7 +1056,7 @@ namespace Unlimotion.ViewModel
                             ChildSelector = m => m.ContainsTasks.ToObservableChangeSet(),
                             RemoveAction = RemoveTask,
                             GetBreadScrumbs = BredScrumbsAlgorithms.FirstTaskParent,
-                        }, lastCreatedExpansionState);
+                        }, "LastCreatedTree");
                         var wrapper = new TaskWrapperViewModel(null, item, actions);
                         return wrapper;
                     })
@@ -1103,7 +1097,7 @@ namespace Unlimotion.ViewModel
                             ChildSelector = m => m.ContainsTasks.ToObservableChangeSet(),
                             RemoveAction = RemoveTask,
                             GetBreadScrumbs = BredScrumbsAlgorithms.FirstTaskParent,
-                        }, lastUpdatedExpansionState);
+                        }, "LastUpdatedTree");
                         var wrapper = new TaskWrapperViewModel(null, item, actions);
                         return wrapper;
                     })
@@ -1264,7 +1258,7 @@ namespace Unlimotion.ViewModel
                             ChildSelector = m => m.ContainsTasks.ToObservableChangeSet(),
                             RemoveAction = m => RemoveTask(m),
                             GetBreadScrumbs = BredScrumbsAlgorithms.FirstTaskParent,
-                        }, lastOpenedExpansionState);
+                        }, "LastOpenedTree");
                         var wrapper = new TaskWrapperViewModel(null, item.Item1, actions)
                         {
                             SpecialDateTime = DateTimeOffset.Now

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -121,6 +121,7 @@
   <data name="Friday" xml:space="preserve"><value>Friday</value></data>
   <data name="From" xml:space="preserve"><value>From</value></data>
   <data name="FuzzySearch" xml:space="preserve"><value>Smart search</value></data>
+  <data name="PersistTaskTreeExpansionState" xml:space="preserve"><value>Remember expanded task tree nodes</value></data>
   <data name="GitConflicts" xml:space="preserve"><value>Could not merge local tasks with the remote repository: Git conflicts were found.</value></data>
   <data name="ConflictAncestorVersion" xml:space="preserve"><value>Before change</value></data>
   <data name="ConflictCurrentVersion" xml:space="preserve"><value>Current version</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -121,6 +121,7 @@
   <data name="Friday" xml:space="preserve"><value>Пятница</value></data>
   <data name="From" xml:space="preserve"><value>С</value></data>
   <data name="FuzzySearch" xml:space="preserve"><value>Умный поиск</value></data>
+  <data name="PersistTaskTreeExpansionState" xml:space="preserve"><value>Запоминать развёрнутые узлы дерева задач</value></data>
   <data name="GitConflicts" xml:space="preserve"><value>Не удалось объединить локальные задачи с удаленным репозиторием: есть Git conflicts.</value></data>
   <data name="ConflictAncestorVersion" xml:space="preserve"><value>До изменения</value></data>
   <data name="ConflictCurrentVersion" xml:space="preserve"><value>Текущая версия</value></data>

--- a/src/Unlimotion.ViewModel/SettingsViewModel.cs
+++ b/src/Unlimotion.ViewModel/SettingsViewModel.cs
@@ -23,12 +23,15 @@ public class SettingsViewModel
     private const string TaskOutlineClipboardSectionName = "TaskOutlineClipboard";
     private const string TaskOutlineCopyAsMarkdownKey = "CopyAsMarkdown";
     private const string TaskOutlineCopyDescriptionKey = "CopyDescription";
+    private const string TaskTreeExpansionStateSectionName = "TaskTreeExpansionState";
+    private const string TaskTreeExpansionStateEnabledKey = "Enabled";
 
     private readonly IConfiguration _configuration;
     private readonly IConfiguration _taskStorageSettings;
     private readonly IConfiguration _gitSettings;
     private readonly IConfiguration _appearanceSettings;
     private readonly IConfiguration _taskOutlineClipboardSettings;
+    private readonly IConfiguration _taskTreeExpansionStateSettings;
     private readonly IConfiguration _updateSettings;
     private readonly IRemoteBackupService? _backupService;
     private readonly ILocalizationService _localization;
@@ -60,6 +63,7 @@ public class SettingsViewModel
     private string? _gitSshPublicKeyPath;
     private bool _copyTaskOutlineAsMarkdown;
     private bool _copyTaskOutlineDescription;
+    private bool _persistTaskTreeExpansionState;
     private bool _updateAutoCheckEnabled;
     private int _updateCheckIntervalValue;
     private ApplicationUpdateCheckIntervalUnit _updateCheckIntervalUnit;
@@ -77,6 +81,7 @@ public class SettingsViewModel
         _gitSettings = configuration.GetSection("Git");
         _appearanceSettings = configuration.GetSection(AppearanceSettings.SectionName);
         _taskOutlineClipboardSettings = configuration.GetSection(TaskOutlineClipboardSectionName);
+        _taskTreeExpansionStateSettings = configuration.GetSection(TaskTreeExpansionStateSectionName);
         _updateSettings = configuration.GetSection(ApplicationUpdateSettings.SectionName);
         _backupService = backupService;
         _localization = localizationService ?? LocalizationService.Current;
@@ -111,6 +116,9 @@ public class SettingsViewModel
         _gitSshPublicKeyPath = _gitSettings.GetSection(nameof(GitSettings.SshPublicKeyPath)).Get<string>();
         _copyTaskOutlineAsMarkdown = _taskOutlineClipboardSettings.GetSection(TaskOutlineCopyAsMarkdownKey).Get<bool>();
         _copyTaskOutlineDescription = _taskOutlineClipboardSettings.GetSection(TaskOutlineCopyDescriptionKey).Get<bool>();
+        _persistTaskTreeExpansionState = _taskTreeExpansionStateSettings
+            .GetSection(TaskTreeExpansionStateEnabledKey)
+            .Get<bool>();
         _updateAutoCheckEnabled = _updateSettings
             .GetSection(ApplicationUpdateSettings.AutoCheckEnabledKey)
             .Get<bool?>() ?? ApplicationUpdateSettings.DefaultAutoCheckEnabled;
@@ -335,6 +343,16 @@ public class SettingsViewModel
         {
             _copyTaskOutlineDescription = value;
             _taskOutlineClipboardSettings.GetSection(TaskOutlineCopyDescriptionKey).Set(value);
+        }
+    }
+
+    public bool PersistTaskTreeExpansionState
+    {
+        get => _persistTaskTreeExpansionState;
+        set
+        {
+            _persistTaskTreeExpansionState = value;
+            _taskTreeExpansionStateSettings.GetSection(TaskTreeExpansionStateEnabledKey).Set(value);
         }
     }
 

--- a/src/Unlimotion.ViewModel/TaskTreeExpansionStateStore.cs
+++ b/src/Unlimotion.ViewModel/TaskTreeExpansionStateStore.cs
@@ -1,0 +1,336 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+
+namespace Unlimotion.ViewModel;
+
+public sealed class TaskTreeExpansionStateStore : IDisposable
+{
+    public const string DefaultFileName = "TaskTreeExpansionState.json";
+    public static readonly TimeSpan DefaultSaveThrottle = TimeSpan.FromMilliseconds(500);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly object _gate = new();
+    private readonly string? _filePath;
+    private readonly TimeSpan _saveThrottle;
+    private readonly Func<string, bool> _fileExists;
+    private readonly Func<string, string> _readAllText;
+    private readonly Action<string, string> _writeAllText;
+    private readonly Timer _saveTimer;
+    private readonly Dictionary<string, HashSet<string>> _expandedTaskIdsByTree;
+    private bool _dirty;
+    private bool _disposed;
+    private bool _isPersistenceEnabled;
+    private int _saveVersion;
+
+    public TaskTreeExpansionStateStore(
+        string? filePath,
+        bool loadPersistedState,
+        TimeSpan? saveThrottle = null,
+        Func<string, bool>? fileExists = null,
+        Func<string, string>? readAllText = null,
+        Action<string, string>? writeAllText = null)
+    {
+        _filePath = string.IsNullOrWhiteSpace(filePath) ? null : filePath;
+        _saveThrottle = NormalizeThrottle(saveThrottle);
+        _fileExists = fileExists ?? File.Exists;
+        _readAllText = readAllText ?? File.ReadAllText;
+        _writeAllText = writeAllText ?? WriteAllTextAtomically;
+        _isPersistenceEnabled = loadPersistedState;
+        _expandedTaskIdsByTree = loadPersistedState ? LoadState() : new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        _saveTimer = new Timer(_ => Flush(), null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    public static string? GetDefaultPath(string? configPath)
+    {
+        if (string.IsNullOrWhiteSpace(configPath))
+        {
+            return null;
+        }
+
+        var fullConfigPath = Path.GetFullPath(configPath);
+        var configDirectory = Path.GetDirectoryName(fullConfigPath);
+        return string.IsNullOrWhiteSpace(configDirectory)
+            ? Path.Combine(Environment.CurrentDirectory, DefaultFileName)
+            : Path.Combine(configDirectory, DefaultFileName);
+    }
+
+    public bool? GetExpansionState(string treeName, string? taskId)
+    {
+        if (string.IsNullOrWhiteSpace(treeName) || string.IsNullOrWhiteSpace(taskId))
+        {
+            return null;
+        }
+
+        lock (_gate)
+        {
+            return _expandedTaskIdsByTree.TryGetValue(treeName, out var expandedTaskIds) &&
+                   expandedTaskIds.Contains(taskId)
+                ? true
+                : null;
+        }
+    }
+
+    public void SetExpansionState(string treeName, string? taskId, bool isExpanded, bool persist)
+    {
+        if (string.IsNullOrWhiteSpace(treeName) || string.IsNullOrWhiteSpace(taskId))
+        {
+            return;
+        }
+
+        lock (_gate)
+        {
+            var expandedTaskIds = GetOrCreateTreeState(treeName);
+            var changed = isExpanded
+                ? expandedTaskIds.Add(taskId)
+                : expandedTaskIds.Remove(taskId);
+
+            if (changed && persist)
+            {
+                ScheduleSaveLocked();
+            }
+        }
+    }
+
+    public void SetPersistenceEnabled(bool enabled)
+    {
+        lock (_gate)
+        {
+            if (_disposed || _isPersistenceEnabled == enabled)
+            {
+                return;
+            }
+
+            _isPersistenceEnabled = enabled;
+            if (!enabled)
+            {
+                CancelPendingSaveLocked();
+            }
+        }
+    }
+
+    public void Flush()
+    {
+        string? filePath;
+        string? json;
+        int saveVersion;
+
+        lock (_gate)
+        {
+            if (!_dirty || !_isPersistenceEnabled || string.IsNullOrWhiteSpace(_filePath))
+            {
+                return;
+            }
+
+            _saveTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            filePath = _filePath;
+            json = JsonSerializer.Serialize(CreateSnapshotLocked(), JsonOptions);
+            saveVersion = _saveVersion;
+        }
+
+        var writeSucceeded = false;
+        try
+        {
+            _writeAllText(filePath, json);
+            writeSucceeded = true;
+        }
+        catch
+        {
+            // Persistence of UI expansion state must never block the task workflow.
+        }
+
+        lock (_gate)
+        {
+            if (writeSucceeded)
+            {
+                if (saveVersion == _saveVersion)
+                {
+                    _dirty = false;
+                }
+
+                return;
+            }
+
+            if (_isPersistenceEnabled && !string.IsNullOrWhiteSpace(_filePath))
+            {
+                _dirty = true;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+        }
+
+        Flush();
+        _saveTimer.Dispose();
+    }
+
+    private void ScheduleSaveLocked()
+    {
+        if (_disposed || !_isPersistenceEnabled || string.IsNullOrWhiteSpace(_filePath))
+        {
+            return;
+        }
+
+        _dirty = true;
+        _saveVersion++;
+        _saveTimer.Change(_saveThrottle, Timeout.InfiniteTimeSpan);
+    }
+
+    private void CancelPendingSaveLocked()
+    {
+        _dirty = false;
+        _saveTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    private HashSet<string> GetOrCreateTreeState(string treeName)
+    {
+        if (_expandedTaskIdsByTree.TryGetValue(treeName, out var expandedTaskIds))
+        {
+            return expandedTaskIds;
+        }
+
+        expandedTaskIds = new HashSet<string>(StringComparer.Ordinal);
+        _expandedTaskIdsByTree[treeName] = expandedTaskIds;
+        return expandedTaskIds;
+    }
+
+    private PersistedExpansionState CreateSnapshotLocked()
+    {
+        return new PersistedExpansionState
+        {
+            Version = 1,
+            Trees = _expandedTaskIdsByTree
+                .Where(pair => !string.IsNullOrWhiteSpace(pair.Key))
+                .ToDictionary(
+                    pair => pair.Key,
+                    pair => pair.Value
+                        .Where(id => !string.IsNullOrWhiteSpace(id))
+                        .OrderBy(id => id, StringComparer.Ordinal)
+                        .ToList(),
+                    StringComparer.Ordinal)
+        };
+    }
+
+    private Dictionary<string, HashSet<string>> LoadState()
+    {
+        if (string.IsNullOrWhiteSpace(_filePath))
+        {
+            return new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        }
+
+        try
+        {
+            if (!_fileExists(_filePath))
+            {
+                return new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            }
+
+            var json = _readAllText(_filePath);
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+            }
+
+            var persistedState = JsonSerializer.Deserialize<PersistedExpansionState>(json, JsonOptions);
+            return NormalizeState(persistedState);
+        }
+        catch
+        {
+            return new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        }
+    }
+
+    private static Dictionary<string, HashSet<string>> NormalizeState(PersistedExpansionState? persistedState)
+    {
+        var result = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        if (persistedState?.Trees == null)
+        {
+            return result;
+        }
+
+        foreach (var (treeName, taskIds) in persistedState.Trees)
+        {
+            if (string.IsNullOrWhiteSpace(treeName))
+            {
+                continue;
+            }
+
+            result[treeName] = taskIds?
+                .Where(taskId => !string.IsNullOrWhiteSpace(taskId))
+                .ToHashSet(StringComparer.Ordinal) ?? new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        return result;
+    }
+
+    private static void WriteAllTextAtomically(string filePath, string content)
+    {
+        var fullPath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var tempPath = $"{fullPath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, content);
+            File.Move(tempPath, fullPath, true);
+        }
+        catch
+        {
+            TryDeleteTempFile(tempPath);
+            throw;
+        }
+    }
+
+    private static void TryDeleteTempFile(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+        catch
+        {
+            // Best-effort cleanup only; the caller handles the original write failure.
+        }
+    }
+
+    private static TimeSpan NormalizeThrottle(TimeSpan? saveThrottle)
+    {
+        if (saveThrottle == null || saveThrottle.Value < TimeSpan.Zero)
+        {
+            return DefaultSaveThrottle;
+        }
+
+        return saveThrottle.Value;
+    }
+
+    private sealed class PersistedExpansionState
+    {
+        public int Version { get; set; } = 1;
+
+        public Dictionary<string, List<string>> Trees { get; set; } = new(StringComparer.Ordinal);
+    }
+}

--- a/src/Unlimotion/App.axaml.cs
+++ b/src/Unlimotion/App.axaml.cs
@@ -63,6 +63,7 @@ public class App : Application
     private static IApplicationUpdateService? _applicationUpdateService;
     private static IAppNameDefinitionService? _appNameService;
     private static ITaskStorageFactory? _storageFactory;
+    private static string? _configPath;
     private static IScheduler? _scheduler;
     private static MainWindowViewModel? _mainWindowViewModel;
     private static EventHandler? _cultureChangedHandler;
@@ -157,7 +158,8 @@ public class App : Application
             _configuration!,
             () => _storageFactory?.CurrentStorage,
             settingsViewModel,
-            graphViewModel
+            graphViewModel,
+            TaskTreeExpansionStateStore.GetDefaultPath(_configPath)
         )
         {
             ToastNotificationManager = _toastNotificationManager
@@ -1562,7 +1564,8 @@ public class App : Application
         try
         {
             Log($"[App.Init] Starting with configPath: {configPath}");
-            
+            _configPath = configPath;
+
             // Create configuration
             _configuration = WritableJsonConfigurationFabric.Create(configPath);
             Log("[App.Init] Configuration created");

--- a/src/Unlimotion/Views/SettingsControl.axaml
+++ b/src/Unlimotion/Views/SettingsControl.axaml
@@ -120,6 +120,12 @@
                         <CheckBox IsChecked="{Binding IsFuzzySearch}"
                                   Content="{DynamicResource Enabled}" />
                     </StackPanel>
+
+                    <StackPanel Classes="FieldGroup">
+                        <CheckBox IsChecked="{Binding PersistTaskTreeExpansionState}"
+                                  Content="{DynamicResource PersistTaskTreeExpansionState}"
+                                  AutomationProperties.AutomationId="PersistTaskTreeExpansionStateCheckBox" />
+                    </StackPanel>
                 </StackPanel>
             </Border>
 

--- a/tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs
+++ b/tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs
@@ -188,7 +188,8 @@ public static class UnlimotionAppLaunchHost
             configuration,
             () => storageFactory.CurrentStorage,
             settingsViewModel,
-            new GraphViewModel());
+            new GraphViewModel(),
+            TaskTreeExpansionStateStore.GetDefaultPath(launchData.ConfigPath));
 
         TaskItemViewModel.NotificationManagerInstance = notificationManager;
         TaskItemViewModel.MainWindowInstance = vm;


### PR DESCRIPTION
## Summary
- Add optional persistence for expanded task tree nodes.
- Store expansion state in a sidecar JSON file next to the app config when the setting is enabled.

## Changes
- Added `TaskTreeExpansionStateStore` with per-tree expanded-id sets, throttled batch writes, forced flush on dispose, cancellation when persistence is disabled, and retry-friendly dirty handling after failed writes.
- Added Settings UI checkbox and localized resources for enabling expansion-state persistence.
- Wired the sidecar path from app/test launch config into `MainWindowViewModel` and tree projections.
- Added behavior, store, settings, and headless UI tests; isolated test fixture config directories so sidecar files do not collide across runs.

## Validation
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/SettingsViewModelTests/*"` passed 58/58.
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainWindowViewModelTests/TaskTreeExpansionState_DisablingBeforeThrottleCancelsPendingSidecarWrite"` passed 1/1.
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainWindowViewModelTests/TaskTreeExpansionState_Disabled_DoesNotCreateSidecarFile"` passed 1/1.
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainWindowViewModelTests/TaskTreeExpansionState_Enabled_PersistsAndRestoresExpandedIds"` passed 1/1.
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/SettingsControlResponsiveUiTests/SettingsControl_TaskTreeExpansionStateCheckBox_PersistsSetting"` passed 1/1.
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/TreeSearch_ClearSearch_RestoresExpansionState"` passed 7/7.
- `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj` passed.
- UI video evidence fallback: current Avalonia.Headless/TUnit runs did not produce video artifacts; next-best evidence is the generated TUnit HTML report at `src/Unlimotion.Test/bin/Debug/net10.0/TestResults/Unlimotion.Test-windows-net10.0-report.html`.

## Risks / Rollback
- Persistence is opt-in and defaults to disabled.
- Sidecar read/write errors are swallowed to avoid blocking task workflows.
- Rollback: disable `TaskTreeExpansionState:Enabled` or revert this PR; existing task data is not migrated or modified.

## Links
- Spec: `specs/2026-05-14-task-expansion-state-persistence.md`