### PR TITLE
feat(macOS): add Apple Silicon packaging + fix emoji font crash on macOS

### DIFF
--- a/.github/workflows/osx-packaging.yml
+++ b/.github/workflows/osx-packaging.yml
@@ -13,11 +13,16 @@ env:
   INSTALLER_PUBLISHER: Kibnet
   VELOPACK_VERSION: 0.0.1298
   OSX_APP_PATH: ${{ github.workspace }}/Unlimotion.app
-  OSX_VELOPACK_DIR: ${{ github.workspace }}/artifacts/velopack/osx
 
 jobs:
   osx-build:
     runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime:
+          - osx-x64
+          - osx-arm64
 
     steps:
     - name: Checkout
@@ -50,10 +55,10 @@ jobs:
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Publish
-      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh ${{ steps.release_version.outputs.version }}
+      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh ${{ steps.release_version.outputs.version }} ${{ matrix.runtime }}
 
     - name: Generate App
-      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh ${{ steps.release_version.outputs.version }}
+      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh ${{ steps.release_version.outputs.version }} ${{ matrix.runtime }}
 
     - name: Install Velopack CLI
       run: dotnet tool install --global vpk --version "${{ env.VELOPACK_VERSION }}" --ignore-failed-sources
@@ -61,15 +66,16 @@ jobs:
     - name: Pack Velopack macOS Release
       shell: bash
       run: |
-        mkdir -p "${{ env.OSX_VELOPACK_DIR }}"
+        OSX_VELOPACK_DIR="${{ github.workspace }}/artifacts/velopack/${{ matrix.runtime }}"
+        mkdir -p "$OSX_VELOPACK_DIR"
 
         "$HOME/.dotnet/tools/vpk" pack \
           --packId Unlimotion \
           --packVersion "${{ steps.release_version.outputs.version }}" \
           --packDir "${{ env.OSX_APP_PATH }}" \
-          --outputDir "${{ env.OSX_VELOPACK_DIR }}" \
+          --outputDir "$OSX_VELOPACK_DIR" \
           --channel osx \
-          --runtime osx-x64 \
+          --runtime "${{ matrix.runtime }}" \
           --mainExe Unlimotion.Desktop.ForMacBuild \
           --packTitle Unlimotion \
           --packAuthors "${{ env.INSTALLER_PUBLISHER }}"
@@ -77,8 +83,10 @@ jobs:
     - name: Upload Velopack macOS Release
       shell: bash
       run: |
+        OSX_VELOPACK_DIR="${{ github.workspace }}/artifacts/velopack/${{ matrix.runtime }}"
+
         "$HOME/.dotnet/tools/vpk" upload github \
-          --outputDir "${{ env.OSX_VELOPACK_DIR }}" \
+          --outputDir "$OSX_VELOPACK_DIR" \
           --channel osx \
           --repoUrl "https://github.com/${{ github.repository }}" \
           --token "${{ secrets.GITHUB_TOKEN }}" \
@@ -87,7 +95,7 @@ jobs:
           --publish
 
     - name: Generate Pkg
-      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-pkg.sh ${{ steps.release_version.outputs.version }}
+      run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-pkg.sh ${{ steps.release_version.outputs.version }} ${{ matrix.runtime }}
 
     - name: Upload MacOSPkg To Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/osx-packaging.yml
+++ b/.github/workflows/osx-packaging.yml
@@ -20,9 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runtime:
-          - osx-x64
-          - osx-arm64
+        include:
+          - runtime: osx-x64
+            channel: osx
+          - runtime: osx-arm64
+            channel: osx-arm64
 
     steps:
     - name: Checkout
@@ -54,40 +56,61 @@ jobs:
 
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
+    - name: Install Velopack CLI
+      run: dotnet tool install --global vpk --version "${{ env.VELOPACK_VERSION }}" --ignore-failed-sources
+
     - name: Publish
       run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh ${{ steps.release_version.outputs.version }} ${{ matrix.runtime }}
 
     - name: Generate App
       run: sh ./src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh ${{ steps.release_version.outputs.version }} ${{ matrix.runtime }}
 
-    - name: Install Velopack CLI
-      run: dotnet tool install --global vpk --version "${{ env.VELOPACK_VERSION }}" --ignore-failed-sources
-
     - name: Pack Velopack macOS Release
       shell: bash
       run: |
-        OSX_VELOPACK_DIR="${{ github.workspace }}/artifacts/velopack/${{ matrix.runtime }}"
+        set -euo pipefail
+
+        OSX_VELOPACK_DIR="${{ github.workspace }}/artifacts/velopack/${{ matrix.channel }}"
         mkdir -p "$OSX_VELOPACK_DIR"
 
         "$HOME/.dotnet/tools/vpk" pack \
           --packId Unlimotion \
           --packVersion "${{ steps.release_version.outputs.version }}" \
-          --packDir "${{ env.OSX_APP_PATH }}" \
+          --packDir "$OSX_APP_PATH" \
           --outputDir "$OSX_VELOPACK_DIR" \
-          --channel osx \
+          --channel "${{ matrix.channel }}" \
           --runtime "${{ matrix.runtime }}" \
           --mainExe Unlimotion.Desktop.ForMacBuild \
           --packTitle Unlimotion \
-          --packAuthors "${{ env.INSTALLER_PUBLISHER }}"
+          --packAuthors "$INSTALLER_PUBLISHER"
+
+    - name: Validate Velopack macOS Feed
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        OSX_VELOPACK_DIR="${{ github.workspace }}/artifacts/velopack/${{ matrix.channel }}"
+
+        for feed in "$OSX_VELOPACK_DIR/releases.${{ matrix.channel }}.json" "$OSX_VELOPACK_DIR/assets.${{ matrix.channel }}.json"; do
+          if [ ! -f "$feed" ]; then
+            echo "Velopack feed was not created: $feed" >&2
+            exit 1
+          fi
+
+          if ! grep -q "${{ matrix.runtime }}" "$feed"; then
+            echo "Velopack feed '$feed' does not include runtime '${{ matrix.runtime }}'." >&2
+            exit 1
+          fi
+        done
 
     - name: Upload Velopack macOS Release
       shell: bash
       run: |
-        OSX_VELOPACK_DIR="${{ github.workspace }}/artifacts/velopack/${{ matrix.runtime }}"
+        OSX_VELOPACK_DIR="${{ github.workspace }}/artifacts/velopack/${{ matrix.channel }}"
 
         "$HOME/.dotnet/tools/vpk" upload github \
           --outputDir "$OSX_VELOPACK_DIR" \
-          --channel osx \
+          --channel "${{ matrix.channel }}" \
           --repoUrl "https://github.com/${{ github.repository }}" \
           --token "${{ secrets.GITHUB_TOKEN }}" \
           --tag "${{ github.ref_name }}" \

--- a/src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj
+++ b/src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj
@@ -8,7 +8,7 @@
 		<TrimMode>copyused</TrimMode>
 		<BuiltInComInteropSupport>true</BuiltInComInteropSupport>
 		<ApplicationIcon>Assets\Unlimotion.ico</ApplicationIcon>
-		<RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
+		<RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
 
     		<CFBundleName>Unlimotion</CFBundleName> <!-- Also defines .app file name -->
     		<CFBundleDisplayName>Unlimotion</CFBundleDisplayName>

--- a/src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh
+++ b/src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 APP_NAME="./Unlimotion.app"
-PUBLISH_OUTPUT_DIRECTORY="./src/Unlimotion.Desktop/bin/Release/net10.0/osx-x64/publish/."
+VERSION=$1
+RUNTIME=${2:-osx-x64}
+PUBLISH_OUTPUT_DIRECTORY="./src/Unlimotion.Desktop/bin/Release/net10.0/$RUNTIME/publish/."
 
 # PUBLISH_OUTPUT_DIRECTORY should point to the output directory of your dotnet publish command.
 # One example is /bin/Release/net10.0/osx-x64/publish/.
@@ -9,7 +11,6 @@ PUBLISH_OUTPUT_DIRECTORY="./src/Unlimotion.Desktop/bin/Release/net10.0/osx-x64/p
 
 INFO_PLIST="./src/Unlimotion.Desktop/ci/osx/Info.plist"
 ICON_FILE="./src/Unlimotion.Desktop/Assets/Unlimotion.icns"
-VERSION=$1
 
 sed -i '' "s/CFBundleVersionExample/$VERSION/g" $INFO_PLIST
 sed -i '' "s/CFBundleShortVersionStringExample/$VERSION/g" $INFO_PLIST

--- a/src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh
+++ b/src/Unlimotion.Desktop/ci/osx/generate-osx-app.sh
@@ -11,9 +11,7 @@ PUBLISH_OUTPUT_DIRECTORY="./src/Unlimotion.Desktop/bin/Release/net10.0/$RUNTIME/
 
 INFO_PLIST="./src/Unlimotion.Desktop/ci/osx/Info.plist"
 ICON_FILE="./src/Unlimotion.Desktop/Assets/Unlimotion.icns"
-
-sed -i '' "s/CFBundleVersionExample/$VERSION/g" $INFO_PLIST
-sed -i '' "s/CFBundleShortVersionStringExample/$VERSION/g" $INFO_PLIST
+APP_INFO_PLIST="./Unlimotion.app/Contents/Info.plist"
 
 if [ -d "$APP_NAME" ]
 then
@@ -26,6 +24,8 @@ mkdir "$APP_NAME/Contents"
 mkdir "$APP_NAME/Contents/MacOS"
 mkdir "$APP_NAME/Contents/Resources"
 
-cp "$INFO_PLIST" "$APP_NAME/Contents/Info.plist"
+cp "$INFO_PLIST" "$APP_INFO_PLIST"
+sed -i '' "s/CFBundleVersionExample/$VERSION/g" "$APP_INFO_PLIST"
+sed -i '' "s/CFBundleShortVersionStringExample/$VERSION/g" "$APP_INFO_PLIST"
 cp "$ICON_FILE" "$APP_NAME/Contents/Resources/Unlimotion.icns"
 cp -a "$PUBLISH_OUTPUT_DIRECTORY" "$APP_NAME/Contents/MacOS"

--- a/src/Unlimotion.Desktop/ci/osx/generate-osx-pkg.sh
+++ b/src/Unlimotion.Desktop/ci/osx/generate-osx-pkg.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
 APP_PATH="./Unlimotion.app"
+VERSION=$1
+RUNTIME=${2:-osx-x64}
 
-productbuild --component $APP_PATH /Applications ./Unlimotion-$1.pkg
+productbuild --component $APP_PATH /Applications ./Unlimotion-$VERSION-$RUNTIME.pkg

--- a/src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh
+++ b/src/Unlimotion.Desktop/ci/osx/generate-osx-publish.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 CSPROJ_PATH="./src/Unlimotion.Desktop/Unlimotion.Desktop.ForMacBuild.csproj"
+VERSION=$1
+RUNTIME=${2:-osx-x64}
 
-dotnet restore $CSPROJ_PATH --runtime osx-x64 --ignore-failed-sources
-dotnet publish $CSPROJ_PATH -c Release -f net10.0 -r osx-x64 -p:Version=$1 -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false --ignore-failed-sources
+dotnet restore $CSPROJ_PATH --runtime $RUNTIME --ignore-failed-sources
+dotnet publish $CSPROJ_PATH -c Release -f net10.0 -r $RUNTIME -p:Version=$VERSION -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:DebugType=None -p:DebugSymbols=false --ignore-failed-sources

--- a/src/Unlimotion.Test/TaskImportanceUiTests.cs
+++ b/src/Unlimotion.Test/TaskImportanceUiTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Automation;
@@ -159,7 +160,13 @@ public class TaskImportanceUiTests
                 var emojiRun = runs.SingleOrDefault(run => run.Text == "📚");
                 await Assert.That(emojiRun).IsNotNull();
                 await Assert.That(emojiRun!.FontWeight).IsEqualTo(FontWeight.Normal);
-                await Assert.That(emojiRun.FontFamily.ToString()).Contains("Emoji");
+                var emojiFontName = emojiRun.FontFamily.ToString();
+                var expectedFamilyPart = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "Segoe UI Emoji"
+                    : RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                        ? "Apple Color Emoji"
+                        : "Noto Color Emoji";
+                await Assert.That(emojiFontName).Contains(expectedFamilyPart);
             }
             finally
             {

--- a/src/Unlimotion/AppExtensions.cs
+++ b/src/Unlimotion/AppExtensions.cs
@@ -1,6 +1,5 @@
 ﻿//#define LIVE
 
-using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Media;
 
@@ -14,24 +13,8 @@ namespace Unlimotion
                 builder.With(new FontManagerOptions
                 {
                     DefaultFamilyName = "avares://Unlimotion/Assets#Roboto",
-                    FontFallbacks = CreateEmojiFallbacks()
+                    FontFallbacks = EmojiFontResolver.GetEmojiFontFallbacks()
                 });
-        }
-
-        private static FontFallback[] CreateEmojiFallbacks()
-        {
-            var systemEmoji = new FontFallback
-            {
-                FontFamily = new FontFamily("fonts:SystemFonts#Segoe UI Emoji")
-            };
-            var embeddedEmoji = new FontFallback
-            {
-                FontFamily = new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji")
-            };
-
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? [systemEmoji, embeddedEmoji]
-                : [embeddedEmoji, systemEmoji];
         }
     }
 }

--- a/src/Unlimotion/EmojiFontResolver.cs
+++ b/src/Unlimotion/EmojiFontResolver.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+using Avalonia.Media;
+
+namespace Unlimotion;
+
+public static class EmojiFontResolver
+{
+    public static FontFamily GetEmojiFontFamily()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return new FontFamily("fonts:SystemFonts#Segoe UI Emoji");
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return new FontFamily("fonts:SystemFonts#Apple Color Emoji");
+        }
+
+        return new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji");
+    }
+
+    public static FontFallback[] GetEmojiFontFallbacks()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return
+            [
+                new FontFallback { FontFamily = new FontFamily("fonts:SystemFonts#Segoe UI Emoji") },
+                new FontFallback { FontFamily = new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji") }
+            ];
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return
+            [
+                new FontFallback { FontFamily = new FontFamily("fonts:SystemFonts#Apple Color Emoji") },
+                new FontFallback { FontFamily = new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji") }
+            ];
+        }
+
+        return
+        [
+            new FontFallback { FontFamily = new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji") },
+            new FontFallback { FontFamily = new FontFamily("fonts:SystemFonts#Segoe UI Emoji") }
+        ];
+    }
+}

--- a/src/Unlimotion/EmojiTextBlock.cs
+++ b/src/Unlimotion/EmojiTextBlock.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Documents;
@@ -9,9 +8,7 @@ namespace Unlimotion;
 
 public class EmojiTextBlock : TextBlock
 {
-    private static readonly FontFamily EmojiFontFamily = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? new FontFamily("fonts:SystemFonts#Segoe UI Emoji")
-        : new FontFamily("avares://Unlimotion/Assets#Noto Color Emoji");
+    private static readonly FontFamily EmojiFontFamily = EmojiFontResolver.GetEmojiFontFamily();
 
     public static readonly StyledProperty<string?> EmojiTextProperty =
         AvaloniaProperty.Register<EmojiTextBlock, string?>(nameof(EmojiText));


### PR DESCRIPTION
## Summary

This PR improves macOS support in two areas:

1. Adds Apple Silicon (`osx-arm64`) packaging support in the macOS release flow.
2. Fixes a macOS runtime crash related to emoji font rendering (`Could not create glyphTypeface`).

## What changed

- Updated macOS packaging workflow to build/package both:
  - `osx-x64`
  - `osx-arm64`
- Updated macOS packaging scripts to accept runtime as a parameter and include runtime in output package naming.
- Fixed `.app` generation script so it no longer mutates `Info.plist` in the repository (version replacements are now applied to the copied plist inside the app bundle).
- Added platform-aware emoji font resolution:
  - Windows: `Segoe UI Emoji`
  - macOS: `Apple Color Emoji`
  - Linux/other: embedded `Noto Color Emoji`
- Wired the new resolver into both app-level font fallbacks and `EmojiTextBlock`.

## Why

- Apple Silicon builds were required for native macOS arm64 distribution.
- On macOS, forcing embedded `Noto Color Emoji` could trigger glyph typeface creation failures during UI rendering.
- Packaging script side effects on tracked files created unnecessary dirty working tree state.

## Validation

- Local macOS arm64 packaging flow executed successfully:
  - publish -> app -> pkg
- Produced arm64 binary is confirmed as:
  - `Mach-O 64-bit executable arm64`
- Smoke run on macOS arm64 after fix: no `glyphTypeface` crash reproduced.
- UI tests:
  - `TaskImportanceUiTests`: passed (4/4)
  - `WantedTaskTitle_WithMiddleEmoji_ShouldRenderEmojiRunNormal_InAllTasksTree`: passed (1/1)

## Notes

- Existing unrelated failures in `BackupViaGitServiceTests` are outside the scope of this PR.