### PR TITLE
fix(roadmap): prevent search from rebuilding map

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,81 @@
+name: Unlimotion Tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  DOTNET_NOLOGO: "1"
+
+jobs:
+  all-tests:
+    name: All tests
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.sha }}
+        submodules: recursive
+
+    - name: Setup .NET 10 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Cache NuGet Packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-${{ runner.os }}-sdk-${{ hashFiles('global.json') }}-projects-${{ hashFiles('src/Directory.Packages.props', 'src/nuget.config', 'src/**/*.csproj', 'tests/**/*.csproj') }}
+
+    - name: Prepare Local NuGet Feed Directory
+      shell: pwsh
+      run: New-Item -ItemType Directory -Force artifacts/nuget-local | Out-Null
+
+    - name: Restore Test Projects
+      shell: pwsh
+      run: |
+        $projects = @(
+          "src/Unlimotion.Test/Unlimotion.Test.csproj",
+          "tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj"
+        )
+
+        foreach ($project in $projects) {
+          dotnet restore $project
+        }
+
+    - name: Run Unlimotion Tests
+      shell: pwsh
+      run: >
+        dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj
+        -c Debug
+        --no-restore
+        -p:UseSharedCompilation=false
+        --
+        --maximum-parallel-tests 1
+        --output Detailed
+
+    - name: Run Headless UI Tests
+      shell: pwsh
+      run: >
+        dotnet test tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj
+        -c Debug
+        --no-restore
+        -p:UseSharedCompilation=false
+        --
+        --maximum-parallel-tests 1
+        --output Detailed

--- a/specs/2026-06-02-pr-all-tests-check.md
+++ b/specs/2026-06-02-pr-all-tests-check.md
@@ -1,0 +1,271 @@
+# PR all-tests check
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; `dotnet-desktop-client`, context `testing-dotnet`
+- Владелец: Codex
+- Масштаб: small
+- Целевая модель: gpt-5.5
+- Целевой релиз / ветка: `fix/roadmap-search-no-rebuild`
+- Ограничения: central `QUEST` SPEC-first gate; локальный `AGENTS.override.md`; PR delivery policy; TUnit/Microsoft.Testing.Platform runner из `global.json`
+- Связанные ссылки: PR #247; existing spec `specs/2026-06-02-roadmap-search-no-rebuild.md`
+
+Если секция не применима, указано `Не применимо` с причиной.
+
+## 1. Overview / Цель
+Добавить в GitHub PR checks отдельный обязательный по workflow результат, который прогоняет полный набор CI-safe тестовых проектов репозитория.
+
+Outcome contract:
+- Success means: на `pull_request` в `main` запускается отдельный check с полным последовательным прогоном CI-safe runnable TUnit test projects.
+- Итоговый артефакт / output: новый GitHub Actions workflow для тестов, обновленный PR, validation evidence локально и/или из GitHub Actions.
+- Stop rules: остановиться после создания workflow, локальной YAML/diff проверки, push в PR и проверки, что новый GitHub check стартует; если full CI test run падает из-за environment-only ограничения, зафиксировать точную причину и next-best evidence.
+
+## 2. Текущее состояние (AS-IS)
+- `.github/workflows/android-packaging.yml` запускается на PR, но выполняет Android packaging build, а не `dotnet test`.
+- `.github/workflows/codeql-analysis.yml` запускает CodeQL analysis без build/test.
+- `.github/workflows/static.yml` не запускается на PR.
+- Release packaging workflows не покрывают PR test gate.
+- `global.json` задает `Microsoft.Testing.Platform`.
+- Обычные CI-safe runnable test projects:
+  - `src/Unlimotion.Test/Unlimotion.Test.csproj` использует `TUnit`.
+  - `tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj` имеет `IsTestProject=true` и `TUnit`.
+- Desktop automation project:
+  - `tests/Unlimotion.UiTests.FlaUI/Unlimotion.UiTests.FlaUI.csproj` имеет `IsTestProject=true`, `TUnit` и Windows target, но требует реального desktop automation session; для обязательного PR gate на GitHub-hosted runner это high-risk/flaky без отдельной стабилизации.
+- Вспомогательные/необычные проекты не являются PR all-tests target:
+  - `tests/Unlimotion.UiTests.Authoring` содержит shared authoring code, `IsTestProject=false`.
+  - `tests/Unlimotion.AppAutomation.TestHost` является test host/helper.
+  - `tests/Unlimotion.ReadmeMedia` является генератором README media, `IsTestProject=false`.
+  - `tests/Unlimotion.Performance` является performance/tooling project, не обычный PR test suite.
+
+## 3. Проблема
+Текущий PR может пройти checks без полного прогона тестов, поэтому regression UI/unit tests не являются обязательным GitHub evidence перед merge.
+
+## 4. Цели дизайна
+- Разделение ответственности: test workflow отдельно от packaging и CodeQL.
+- Повторное использование: использовать существующие `.csproj` и TUnit runner, не добавлять новый test harness.
+- Тестируемость: последовательный `dotnet test` для всех CI-safe runnable test projects.
+- Консистентность: setup .NET через `global.json`, как Android workflow.
+- Обратная совместимость: не менять код приложения, тесты или release workflows.
+
+## 5. Non-Goals
+- Не менять branch protection / required status checks в настройках GitHub, потому что это не хранится в PR diff.
+- Не включать media generation, performance tooling или FlaUI desktop automation в обычный обязательный PR test gate.
+- Не доказывать пригодность GitHub-hosted Windows runner для FlaUI в рамках этой правки.
+- Не менять существующий Android packaging workflow.
+- Не переписывать тесты и не исправлять flaky tests в рамках этой спеки, кроме объективно нужной CI invocation правки.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `.github/workflows/tests.yml` -> отдельный PR/push/manual workflow `Unlimotion Tests`.
+- `All tests` job -> Windows runner, restore и последовательный `dotnet test` для двух CI-safe runnable TUnit projects.
+- FlaUI остается вне обязательного PR gate; при необходимости его можно добавить отдельным non-blocking/manual workflow после отдельной стабилизации.
+
+### 6.2 Детальный дизайн
+- Trigger: `pull_request` и `push` в `main`, плюс `workflow_dispatch`.
+- Runner: `windows-latest`, чтобы сохранить совместимость с Windows-sensitive tests в `Unlimotion.Test` и desktop stack.
+- Checkout: `actions/checkout@v4`, `submodules: recursive` для консистентности с repo checkout requirements.
+- .NET: `actions/setup-dotnet@v4` с `global-json-file: global.json`.
+- Cache: NuGet cache по `global.json`, `src/Directory.Packages.props`, `src/nuget.config`, `src/**/*.csproj`, `tests/**/*.csproj`.
+- Execution:
+  - restore выбранных test projects;
+  - последовательно выполнить:
+    - `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug --no-restore -- --maximum-parallel-tests 1 --output Detailed`
+    - `dotnet test tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj -c Debug --no-restore -- --maximum-parallel-tests 1 --output Detailed`
+  - job-level `timeout-minutes: 30`, чтобы UI-heavy tests не зависали бесконечно.
+- Visual planning artifact: Не применимо, потому что изменение касается CI workflow и не меняет UI layout/state/flow.
+- UI test video evidence: Не применимо как `до/после` UI artifact; workflow сам выполняет UI tests, evidence будет Actions log и локальная команда проверки, если окружение позволит.
+- Обработка ошибок: любой non-zero exit code должен валить job и PR check.
+- Производительность: последовательный запуск снижает риск shared UI state conflicts; `concurrency` отменяет устаревшие runs одного PR/ref.
+
+## 7. Бизнес-правила / Алгоритмы
+- "All tests" для обязательного PR gate означает все CI-safe runnable TUnit test projects, а не helper/tooling/performance/media/FlaUI desktop automation projects.
+- Если в будущем появится новый test project, workflow должен быть обновлен в том же PR, где он добавлен.
+
+## 8. Точки интеграции и триггеры
+- GitHub Actions запускает workflow на `pull_request` к `main`, `push` в `main`, `workflow_dispatch`.
+- PR #247 получает новый check после push ветки.
+
+## 9. Изменения модели данных / состояния
+Не применимо: persisted/runtime state не меняется.
+
+## 10. Миграция / Rollout / Rollback
+- Rollout: commit в текущую PR ветку.
+- Rollback: удалить `.github/workflows/tests.yml` или revert commit.
+- Совместимость: существующие workflow остаются без изменений.
+
+## 11. Тестирование и критерии приёмки
+Acceptance Criteria:
+- В репозитории есть отдельный workflow, запускающийся на PR.
+- Workflow явно прогоняет `src/Unlimotion.Test` и `Unlimotion.UiTests.Headless`.
+- Workflow не включает FlaUI в обязательный PR gate без отдельного стабилизированного runner/evidence.
+- Workflow использует TUnit/MTP аргументы без VSTest `--filter`.
+- PR #247 показывает новый GitHub check после push.
+- Existing roadmap targeted UI test остается зеленым или уже подтвержден предыдущим commit evidence; эта правка не меняет UI behavior.
+
+Какие тесты добавить/изменить:
+- Новые product tests не нужны: меняется CI orchestration, не приложение.
+- Добавляется workflow-level test execution.
+
+Команды для проверки:
+- `git diff --check`
+- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug --no-restore -- --maximum-parallel-tests 1 --output Detailed`
+- `dotnet test tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj -c Debug --no-restore -- --maximum-parallel-tests 1 --output Detailed`
+- `gh pr checks 247 --watch` или equivalent GitHub Actions inspection after push.
+
+Stop rules для validation:
+- Если локальные full tests не завершаются из-за времени/окружения, указать точный failed command и проверить через GitHub Actions after push.
+- Если позже потребуется FlaUI в CI, сначала завести отдельный non-blocking/manual check и собрать evidence стабильности.
+
+## 12. Риски и edge cases
+- FlaUI на GitHub-hosted Windows может быть environment-sensitive, поэтому исключен из обязательного PR gate.
+- Полный набор UI tests может быть долгим.
+- Branch protection может не сделать новый check required автоматически; это repository setting вне PR diff.
+- Excluding `ReadmeMedia` может выглядеть как неполный "all"; mitigated by explicit `IsTestProject=false`/tooling classification.
+
+## 13. План выполнения
+1. Добавить `.github/workflows/tests.yml` с обязательным прогоном `Unlimotion.Test` и `Unlimotion.UiTests.Headless`.
+2. Выполнить `git diff --check`.
+3. Запустить доступные локальные test commands последовательно или зафиксировать объективный blocker.
+4. Выполнить post-EXEC review.
+5. Commit, push, обновить PR body validation.
+6. Проверить новый GitHub check в PR.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов. Branch protection required-check selection может потребовать отдельной настройки вне PR.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client`, context `testing-dotnet`
+- Выполненные требования профиля:
+  - Используется `dotnet test`.
+  - Учитывается TUnit/Microsoft.Testing.Platform.
+  - UI behavior не меняется, поэтому новые UI assertions не требуются; workflow прогоняет существующие UI tests.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `.github/workflows/tests.yml` | Новый PR/push/manual workflow с полным тестовым прогоном | Сделать test evidence частью PR checks |
+| `specs/2026-06-02-pr-all-tests-check.md` | Рабочая спецификация и audit trail | Соблюсти QUEST gate |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| PR checks | Android build + CodeQL, без отдельного full tests check | Отдельный `Unlimotion Tests / All tests` check |
+| Test execution | Локально/ручной запуск, не гарантирован в PR | GitHub Actions запускает CI-safe runnable TUnit test projects |
+| FlaUI coverage | Не часть PR checks | Остается вне mandatory PR gate до отдельной стабилизации |
+
+## 18. Альтернативы и компромиссы
+- Вариант: добавить test step в `android-packaging.yml`.
+  - Плюсы: меньше файлов.
+  - Минусы: смешивает packaging и tests, Linux runner не подходит для FlaUI.
+- Вариант: matrix по test projects.
+  - Плюсы: быстрее.
+  - Минусы: выше риск shared UI state/resource conflicts, сложнее читать failure flow.
+- Вариант: включить FlaUI в обязательный PR gate.
+  - Плюсы: шире UI automation coverage.
+  - Минусы: desktop automation на GitHub-hosted runner может быть flaky и блокировать merge не из-за продуктовой регрессии.
+- Выбранное решение лучше: отдельный Windows workflow явно отражает PR test gate и последовательно запускает стабильный unit/headless набор; FlaUI остается для отдельного optional workflow после стабилизации.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели и Non-Goals заданы |
+| B. Качество дизайна | 6-10 | PASS | Workflow boundaries, runner, commands, FlaUI exclusion, rollback и state impact описаны |
+| C. Безопасность изменений | 11-13 | PASS | Риски CI/FlaUI/branch protection зафиксированы, rollback прост |
+| D. Проверяемость | 14-16 | PASS | Есть acceptance criteria, commands и planned changed files |
+| E. Готовность к автономной реализации | 17-19 | PASS | План и tradeoffs есть, блокирующих вопросов нет |
+| F. Соответствие профилю | 20 | PASS | Учтен .NET/TUnit runner и desktop/UI test context |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Цель ограничена CI PR test check |
+| 2. Понимание текущего состояния | 5 | Перечислены текущие workflows, test projects и FlaUI CI риск |
+| 3. Конкретность целевого дизайна | 5 | Задан файл, runner, triggers и команды |
+| 4. Безопасность (миграция, откат) | 5 | Rollout/rollback прост, app behavior не меняется |
+| 5. Тестируемость | 5 | Есть local и GitHub validation commands |
+| 6. Готовность к автономной реализации | 5 | Нет блокирующих вопросов |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Scope reviewed: `specs/2026-06-02-pr-all-tests-check.md`; instruction stack `model-behavior-baseline`, `quest-governance`, `quest-mode`, `collaboration-baseline`, `testing-baseline`, `testing-dotnet`, `dotnet-desktop-client`, `github-delivery-policy`; selected profile `dotnet-desktop-client`; open questions none; planned changed files `.github/workflows/tests.yml`, this spec.
+- Decision: можно запрашивать подтверждение.
+- Review passes:
+  - Scope/Evidence pass: просмотрены current workflow list, `android-packaging.yml`, `codeql-analysis.yml`, `static.yml`, test csproj files, `global.json`, `update-readme-media.ps1`.
+  - Contract pass: spec добавляет PR test gate без изменения app behavior, исключает FlaUI из mandatory gate по CI-stability risk и не включает branch protection settings вне PR diff.
+  - Adversarial risk pass: проверены counterexamples: FlaUI needs interactive desktop automation session, helper projects with TUnit.Core are not runnable tests, media generator is not normal PR test suite, branch protection cannot be guaranteed by repo diff.
+  - Re-review after fixes / Fix and re-review: после вопроса пользователя FlaUI удален из обязательного PR gate; acceptance, commands, risks and alternatives пересмотрены.
+  - Stop decision: PASS with explicit residual branch protection note.
+- Evidence inspected: `.github/workflows/android-packaging.yml`, `.github/workflows/codeql-analysis.yml`, `.github/workflows/static.yml`, `src/Unlimotion.Test/Unlimotion.Test.csproj`, `tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj`, `tests/Unlimotion.UiTests.FlaUI/Unlimotion.UiTests.FlaUI.csproj`, `tests/Unlimotion.ReadmeMedia/Unlimotion.ReadmeMedia.csproj`, `global.json`, `scripts/update-readme-media.ps1`.
+- Depth checklist:
+  - Scope drift / unrelated changes: scope limited to CI workflow and spec.
+  - Acceptance criteria: check file, test project list, PR check evidence.
+  - Validation evidence: local diff/test commands and GitHub Actions inspection planned.
+  - Unsupported claims: branch protection not claimed.
+  - Regression / edge case: CI/FlaUI/environment risks documented.
+  - Comments/docs/changelog: no comments/docs changes needed beyond spec.
+  - Hidden contract change: CI cost increases, app behavior unchanged.
+  - Manual-review challenge: likely question is whether `FlaUI`/`ReadmeMedia`/`Performance` are excluded; spec explains why.
+- No-findings justification: workflow design is narrow, reversible and based on inspected repo evidence plus user feedback on FlaUI.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | operations | New check may not be branch-protection required until selected in GitHub settings | Report as outside PR diff after implementation | accepted-risk |
+| LOW | coverage | FlaUI is excluded from mandatory PR gate, so visible desktop automation is not merge-blocking | Keep unit/headless mandatory now; consider optional/manual FlaUI workflow later | accepted-risk |
+
+- Fixed before continuing: FlaUI removed from mandatory PR gate design after user challenge.
+- Checks rerun: SPEC linter/rubric updated in this file.
+- Needs human: yes, `Спеку подтверждаю`.
+- Residual risks / follow-ups: branch protection required-check selection outside PR diff.
+
+### Post-EXEC Review
+- Статус: PASS
+- Scope reviewed: approved spec, `git status --short`, `git diff --stat`, relevant diff for `.github/workflows/tests.yml`, local restore/test evidence, docs/changelog impact.
+- Decision: можно commit/push; GitHub Actions evidence проверить после push и отразить в PR body.
+- Review passes:
+  - Scope/Evidence pass: проверены два changed files, local restore, `Unlimotion.Test` full run, targeted rerun одного failed test, headless project run, whitespace check.
+  - Contract pass: workflow запускается на PR/push/manual, гоняет `src/Unlimotion.Test` и `tests/Unlimotion.UiTests.Headless`, не включает FlaUI, использует TUnit/MTP args.
+  - Adversarial risk pass: проверены risks: missing local NuGet feed dir, infinite UI test hang, flaky full-suite baseline, branch protection outside PR diff, accidental FlaUI inclusion.
+  - Re-review after fixes / Fix and re-review: добавлен `timeout-minutes: 30` после review risk по зависанию; diff и spec пересмотрены.
+  - Stop decision: PASS с residual risk, что локальный full `Unlimotion.Test` сейчас flaky/failing и новый PR check может стать красным, что соответствует цели выявлять broken baseline.
+- Evidence inspected: `.github/workflows/tests.yml`, `specs/2026-06-02-pr-all-tests-check.md`, local command outputs.
+- Depth checklist:
+  - Scope drift / unrelated changes: only workflow and spec files changed.
+  - Acceptance criteria: repo workflow exists; includes two CI-safe projects; excludes FlaUI; GitHub PR check pending after push.
+  - Validation evidence: restore passed; headless project passed 25/25; `Unlimotion.Test` full failed twice with different single-test failures after 421/422 passed; targeted rerun of one failed test passed 1/1; `git diff --check` passed.
+  - Unsupported claims: no claim that branch protection is updated or local full suite is green.
+  - Regression / edge case: CI now exposes existing full-suite instability instead of hiding it.
+  - Comments/docs/changelog: no changelog needed; spec updated.
+  - Hidden contract change: PR CI cost increases and may block on current suite failures; this is intended by the request to run all tests.
+  - Manual-review challenge: likely finding is that "all tests" excludes FlaUI; spec documents why FlaUI is outside mandatory gate.
+- No-findings justification: implementation matches approved spec; residual risks are explicitly reported.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | validation | Local `Unlimotion.Test` full run failed twice on different tests after 421/422 passed, while a targeted rerun of one failure passed | Push strict workflow and inspect clean GitHub runner; report if PR check turns red | accepted-risk |
+| LOW | operations | Branch protection may not automatically require the new check | Report as repository setting outside PR diff | accepted-risk |
+
+- Fixed before final report: added job timeout.
+- Checks rerun: `git diff --check`; local restore for both test projects; `dotnet test tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj ...` passed.
+- Validation evidence: restore passed; headless 25/25 passed; local `Unlimotion.Test` full runs failed 421/422 twice on different tests; targeted failed-test rerun passed 1/1.
+- Unrelated changes: none observed in `git status --short`.
+- Needs human: none before push.
+- Residual risks / follow-ups: inspect GitHub check after push; repository settings may need selecting the new check as required.
+
+## Approval
+Получено подтверждение пользователя: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Context gathering | 0.87 | Нет | Создать спецификацию | Нет | Нет | Найдены текущие PR workflows и runnable TUnit test projects | `.github/workflows/*`, test `.csproj`, `global.json` |
+| SPEC | Spec creation and review | 0.91 | Подтверждение пользователя | Запросить `Спеку подтверждаю` | Да | Да, ожидается решение человека | Требуется SPEC-gate перед изменением CI infrastructure | `specs/2026-06-02-pr-all-tests-check.md` |
+| SPEC | User feedback on FlaUI | 0.93 | Подтверждение пользователя | Запросить `Спеку подтверждаю` | Да | Да, пользователь оспорил FlaUI в mandatory gate | FlaUI исключен из обязательного PR check как CI-flaky/high-risk без отдельной стабилизации | `specs/2026-06-02-pr-all-tests-check.md` |
+| EXEC | Workflow implementation | 0.88 | Локальная и GitHub validation pending | Запустить проверки | Нет | Да, пользователь подтвердил spec | Добавлен отдельный PR workflow для CI-safe TUnit/headless tests без FlaUI | `.github/workflows/tests.yml`, `specs/2026-06-02-pr-all-tests-check.md` |
+| EXEC | Local validation | 0.78 | GitHub clean runner result pending | Выполнить post-EXEC review и push | Нет | Нет | Restore прошел; headless project passed 25/25; full `Unlimotion.Test` выявил existing flaky failures 421/422 на разных тестах в двух прогонах | local `dotnet restore`, `dotnet test`, `.github/workflows/tests.yml` |

--- a/specs/2026-06-02-roadmap-search-no-rebuild.md
+++ b/specs/2026-06-02-roadmap-search-no-rebuild.md
@@ -1,0 +1,289 @@
+# Roadmap search must not rebuild the map
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; `dotnet-desktop-client` + `ui-automation-testing`
+- Владелец: Codex
+- Масштаб: small
+- Целевая модель: gpt-5.5
+- Целевой релиз / ветка: текущий worktree `HEAD (no branch)`
+- Ограничения: до подтверждения менять только этот spec; после подтверждения не менять публичный API и не трогать unrelated files
+- Связанные ссылки: Не применимо; локальный bugfix без внешнего issue
+
+## 1. Overview / Цель
+Поиск на вкладке roadmap должен только обновлять выделение подходящих задач (`IsHighlighted`) и не должен менять набор задач, из которого строится карта.
+
+Outcome contract:
+- Success means: изменения `Search.SearchText` и `Search.IsFuzzySearch` на открытой карте не увеличивают `RoadmapGraphUpdateCount` и `RoadmapGraphBackgroundBuildStartCount` после стабилизации initial build, но matching node корректно подсвечивается по текущему exact/fuzzy режиму.
+- Итоговый артефакт / output: правка ViewModel wiring, подписки `GraphControl` на search state и regression UI test.
+- Stop rules: остановиться, если тест покажет, что текущий search нужен для состава roadmap roots по отдельному продуктовому контракту; иначе довести до targeted UI test, build и full test command либо явно зафиксировать объективный blocker.
+
+## 2. Текущее состояние (AS-IS)
+- `MainWindowViewModel` создает `searchTopFilter` для обычных списков задач.
+- `emojiRootFilter` дополнительно подписан на `Search.SearchText` и при непустом поиске меняет root predicate: без активных emoji-фильтров возвращает `true` для всех задач.
+- `ActivateRoadmapProjection()` использует `emojiRootFilter` для `Graph.Tasks`; из-за этого search может менять `Graph.Tasks`, а `GraphControl` видит collection change и пересобирает карту.
+- `GraphControl` уже имеет отдельный путь для поиска: подписка на `dc.Search.SearchText` вызывает `UpdateHighlights()`, где меняется только `TaskItemViewModel.IsHighlighted`.
+- `UpdateHighlights()` уже читает `Search.IsFuzzySearch`, но `GraphControl` не подписан на изменение этого флага; поэтому переключение fuzzy mode может не обновить подсветку до следующего изменения search text или другого refresh-trigger.
+- `src/Unlimotion.Test/RoadmapGraphUiTests.cs` уже содержит `RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode()` и счетчики rebuild/update.
+
+## 3. Проблема
+Одна корневая проблема: roadmap смешивает search state с разными механизмами обновления: `Search.SearchText` может менять root collection через ViewModel filter, а `Search.IsFuzzySearch` не является полноценным refresh-trigger для highlight-only state.
+
+## 4. Цели дизайна
+- Разделение ответственности: filters формируют набор задач карты; search только подсвечивает.
+- Повторное использование: сохранить существующий `emojiRootFilter` для обычного дерева, где search может влиять на отображаемые roots.
+- Тестируемость: закрепить поведение через существующий Avalonia.Headless UI test с build counters.
+- Консистентность: не менять UX подсветки, selection и styling.
+- Обратная совместимость: не менять persisted state, public API, automation ids и поведение non-roadmap вкладок.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не меняем алгоритм `RoadmapGraphBuilder`.
+- Не меняем визуальный стиль подсветки.
+- Не меняем search behavior для обычных task tabs.
+- Не добавляем новые filters/settings.
+- Не создаем новые automation ids или публичные API.
+- Не коммитим video artifacts; если runner не пишет видео, фиксируем fallback evidence.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `src/Unlimotion.ViewModel/MainWindowViewModel.cs` -> разделить root filtering для обычных task trees и roadmap.
+- `src/Unlimotion/Views/GraphControl.axaml.cs` -> пересчитывать highlights при изменении `Search.SearchText` или `Search.IsFuzzySearch`, не вызывая `UpdateGraph()`.
+- `src/Unlimotion.Test/RoadmapGraphUiTests.cs` -> добавить regression assertion, что search highlight не вызывает rebuild.
+
+### 6.2 Детальный дизайн
+- В `MainWindowViewModel` оставить текущий `emojiRootFilter` для `CurrentAllTasksItems`.
+- Для roadmap projection добавить отдельный observable predicate, например `roadmapRootFilter`, который не подписан на `Search.SearchText` и сохраняет root selection по emoji filters как в empty-search ветке текущего `emojiRootFilter`.
+- В `ActivateRoadmapProjection()` заменить `.Filter(emojiRootFilter)` на `.Filter(roadmapRootFilter)` только для `Graph.Tasks`.
+- `Graph.UnlockedTasks` остается без search filter, как сейчас.
+- `GraphControl.UpdateHighlights()` остается источником search-driven UI state.
+- Подписку `GraphControl` на search state расширить с `Search.SearchText` до пары `Search.SearchText` + `Search.IsFuzzySearch`, чтобы переключение fuzzy mode пересчитывало highlight без rebuild.
+- Инвариант no-rebuild относится к search text changes и matching-mode state (`Search.IsFuzzySearch`) как к состоянию поиска. Regression assertion покрывает оба триггера.
+- Visual planning artifact: Не применимо как отдельный render; layout и flow не меняются. Fallback state схема:
+  - до search: roadmap topology stable, nodes not highlighted unless previous query remains;
+  - after search text: same nodes/connections/viewport, matching nodes get highlighted style;
+  - after clear: same topology, highlight cleared.
+- UI test video evidence: fallback during EXEC, потому что выбранный быстрый regression path - Avalonia.Headless unit UI test; если runner не сохраняет видео, evidence будет test output + counters.
+- Обработка ошибок: не добавляется; существующие subscriptions и throttling остаются.
+- Производительность: search больше не должен запускать expensive background roadmap build.
+
+## 7. Бизнес-правила / Алгоритмы
+- Search query:
+  - не меняет `Graph.Tasks` / `Graph.UnlockedTasks`;
+  - не вызывает `ScheduleUpdateGraph()` через collection changes;
+  - вызывает только highlight recalculation.
+- `Search.IsFuzzySearch`:
+  - не должен подключаться к roadmap root/topology filters;
+  - должен пересчитывать `IsHighlighted` для уже открытой карты без изменения `Graph.Tasks` / `Graph.UnlockedTasks`;
+  - не должен вызывать `ScheduleUpdateGraph()` или background build.
+- Emoji include/exclude filters:
+  - продолжают менять набор задач roadmap;
+  - продолжают вызывать rebuild.
+- Title/description/emoji changes:
+  - сохраняют существующее поведение highlight refresh и conditional rebuild.
+
+## 8. Точки интеграции и триггеры
+- `MainWindowViewModel.ActivateRoadmapProjection()` обязан использовать search-independent root filter.
+- `GraphControl.GraphControl_DataContextChanged()` подписывает `Search.SearchText` и `Search.IsFuzzySearch` на `UpdateHighlights()`.
+- Пересчет карты остается за `ScheduleUpdateGraph()` и collection/property triggers, которые реально меняют roadmap topology.
+
+## 9. Изменения модели данных / состояния
+- Новых полей persisted state нет.
+- Новых calculated fields нет.
+- Влияния на хранилище нет.
+
+## 10. Миграция / Rollout / Rollback
+- Первый запуск: поведение применяется сразу, миграции нет.
+- Совместимость: файлы задач, настройки и UI selectors не меняются.
+- Rollback: вернуть roadmap projection на прежний `emojiRootFilter` и удалить regression assertion.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  - на открытой roadmap вкладке ввод search text подсвечивает matching node;
+  - selected node остается selected;
+  - `RoadmapGraphUpdateCount` не увеличивается после ввода search text;
+  - `RoadmapGraphBackgroundBuildStartCount` не увеличивается после ввода search text;
+  - очистка search снимает highlight и тоже не запускает rebuild;
+  - переключение `Search.IsFuzzySearch` обновляет highlight для fuzzy-only query и не запускает rebuild;
+  - счетчики фиксируются только после `WaitForStableRoadmapUpdates()` или эквивалентной стабилизации initial roadmap build;
+  - отрицательная проверка ждет окно больше debounce/rebuild throttle после set, fuzzy toggle and clear, чтобы поймать поздний rebuild;
+  - emoji filter changes still rebuild roadmap.
+- Какие тесты добавить/изменить:
+  - расширить `RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode()` или добавить соседний test в `RoadmapGraphUiTests`.
+- Characterization tests / contract checks:
+  - сначала добавить assertion и запустить targeted test на текущем коде, ожидая fail из-за rebuild.
+- Детали regression assertion:
+  - открыть roadmap tab и дождаться stable roadmap build;
+  - сохранить `RoadmapGraphUpdateCount`, `RoadmapGraphBackgroundBuildStartCount`, node count/connection count и selected node reference;
+  - установить `vm.Graph.Search.SearchText = targetTask.OnlyTextTitle`;
+  - дождаться `targetTask.IsHighlighted == true`;
+  - выполнить negative wait, подтверждающий отсутствие increment в обоих build counters;
+  - для fuzzy режима задать deterministic title, например `"Roadmap fuzzy match target"`, установить typo query вроде `"fuzxy"` при `IsFuzzySearch = false`, проверить отсутствие highlight, затем `IsFuzzySearch = true`, дождаться highlight и выполнить negative wait по counters;
+  - очистить search, дождаться `IsHighlighted == false` и повторить negative wait;
+  - дополнительно проверить, что selected node reference и topology counts не изменились.
+- Visual acceptance:
+  - в headless UI test проверить bold/blue highlighted state и stable selection; screenshot/video не обязателен при отсутствии runner video support.
+- UI video evidence:
+  - fallback: `dotnet run`/`dotnet test` output targeted UI test; video не применимо, если Avalonia.Headless test harness не пишет видео artifacts.
+- Команды для проверки:
+  - `dotnet run --project src/Unlimotion.Test/Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode"`
+  - `dotnet build src/Unlimotion.sln`
+  - `dotnet test src/Unlimotion.sln`
+- Stop rules для validation:
+  - если targeted test не воспроизводит rebuild, сначала найти актуальный воспроизводимый UI test path, не править вслепую;
+  - если full test command блокируется окружением, зафиксировать точную ошибку и выполнить next-best targeted suite.
+
+## 12. Риски и edge cases
+- Риск: ordinary task tree search мог случайно полагаться на общий `emojiRootFilter`; mitigation: не менять его, добавить новый roadmap-only filter.
+- Риск: search toggle could still trigger rebuild via another subscription; mitigation: assert both update and background build counters.
+- Риск: clearing search может иметь отдельный path; mitigation: assert no rebuild on set and clear.
+- Риск: active emoji filters should still rebuild; mitigation: existing `RoadmapGraph_FilterChange_RebuildsOpenView()` remains as guard.
+- Риск: fuzzy-mode assertion could accidentally match exact search; mitigation: use a deterministic typo query that `source.Contains(term)` cannot satisfy but `FuzzyMatcher.IsFuzzyMatch` should match.
+
+## 13. План выполнения
+1. Добавить failing regression assertions around search in `RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode()`, including stable initial counters, fuzzy toggle refresh and negative wait windows.
+2. Запустить targeted test и подтвердить fail на текущем поведении.
+3. Ввести roadmap-only root filter в `MainWindowViewModel` и подключить его в `ActivateRoadmapProjection()`.
+4. Повторить targeted UI test.
+5. Запустить `dotnet build src/Unlimotion.sln`.
+6. Запустить `dotnet test src/Unlimotion.sln` или зафиксировать объективный blocker и next-best coverage.
+7. Выполнить post-EXEC review-loop и исправить однозначные findings.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов. Требуется только approval gate по правилам QUEST.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client`, `ui-automation-testing`, context `testing-dotnet`
+- Выполненные требования профиля:
+  - UI behavior покрывается Avalonia.Headless UI test.
+  - Automation selectors не меняются.
+  - План включает targeted UI test, build и full test command.
+  - Video evidence имеет объективный fallback для headless runner.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.ViewModel/MainWindowViewModel.cs` | Добавить roadmap-only root filter без search dependency и использовать его для `Graph.Tasks` | Search не должен менять task set карты |
+| `src/Unlimotion/Views/GraphControl.axaml.cs` | Подписать highlight refresh на `Search.SearchText` и `Search.IsFuzzySearch` | Fuzzy toggle должен менять подсветку без rebuild |
+| `src/Unlimotion.Test/RoadmapGraphUiTests.cs` | Добавить regression assertion по counters и highlight | Зафиксировать UI contract и предотвратить повторную регрессию |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Roadmap search | Может менять `Graph.Tasks` через `emojiRootFilter` и запускать rebuild | Меняет только `IsHighlighted` |
+| Roadmap fuzzy search | `UpdateHighlights()` учитывает `IsFuzzySearch`, но fuzzy toggle не является самостоятельным trigger | Fuzzy toggle пересчитывает `IsHighlighted` без rebuild |
+| Roadmap topology | Может зависеть от search text | Зависит от task relations и active roadmap filters, но не от search text |
+| UI test | Проверяет highlight/clear | Проверяет exact highlight/clear, fuzzy toggle refresh, stable selection/topology and absence of rebuild after set/toggle/clear |
+
+## 18. Альтернативы и компромиссы
+- Вариант: игнорировать search changes внутри `GraphControl`.
+- Плюсы: минимальная локальная правка в control.
+- Минусы: `Graph.Tasks` все равно меняется от search, что ломает contract модели и может влиять на другие consumers.
+- Почему выбранное решение лучше: root cause находится в ViewModel projection wiring; roadmap должен получать search-independent collection, а `GraphControl` уже имеет правильный highlight-only механизм.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели и Non-Goals заданы |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, integration triggers, perf и rollback описаны |
+| C. Безопасность изменений | 11-13 | PASS | Нет данных/миграций; план rollback и границы изменения есть |
+| D. Проверяемость | 14-16 | PASS | Acceptance criteria cover exact search, fuzzy toggle, no-rebuild counters and validation commands |
+| E. Готовность к автономной реализации | 17-19 | PASS | План и alternatives есть; blockers отсутствуют |
+| F. Соответствие профилю | 20 | PASS | UI test coverage и validation requirements учтены |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Search должен быть highlight-only для roadmap |
+| 2. Понимание текущего состояния | 5 | Указаны `emojiRootFilter`, `Graph.Tasks`, `UpdateHighlights()` и счетчики |
+| 3. Конкретность целевого дизайна | 5 | Определены roadmap-only root filter и search-state subscription в `GraphControl` |
+| 4. Безопасность (миграция, откат) | 5 | Нет persistence changes; rollback простой |
+| 5. Тестируемость | 5 | Есть targeted Avalonia.Headless UI test для exact/fuzzy/no-rebuild и full validation commands |
+| 6. Готовность к автономной реализации | 5 | Нет открытых вопросов, scope small |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Scope reviewed: `specs/2026-06-02-roadmap-search-no-rebuild.md`; central stack `model-behavior-baseline`, `quest-governance`, `quest-mode`, `collaboration-baseline`, `testing-baseline`, `testing-dotnet`, `dotnet-desktop-client`, `ui-automation-testing`; локальный `AGENTS.override.md`; planned files `MainWindowViewModel.cs`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`; current evidence from `MainWindowViewModel` search/emoji filters, `GraphControl` rebuild/highlight subscriptions, existing `RoadmapGraphUiTests`; open questions none.
+- Decision: можно запрашивать подтверждение.
+- Review passes:
+  - Scope/Evidence pass: просмотрены текущие subscriptions в `MainWindowViewModel`, rebuild/highlight path в `GraphControl`, existing UI tests and counters.
+  - Contract pass: spec сохраняет Non-Goals, не меняет public API, включает exact/fuzzy UI test coverage, stabilization requirement and validation commands.
+  - Adversarial risk pass: counterexamples checked: late rebuild after debounce, clear-search rebuild, fuzzy-mode stale highlight, accidental exact-match fuzzy assertion, accidental topology change; mitigations are explicit in test design and scope.
+  - Re-review after fixes / Fix and re-review: iteration 1 found MEDIUM test-design/scope gaps; iteration 2 left fuzzy as LOW follow-up; user widened scope; iteration 3 patched fuzzy into the main contract and re-reviewed changed sections.
+  - Stop decision: PASS, после исправлений остались только LOW evidence residuals.
+- Evidence inspected: `GraphControl` currently subscribes only to `Search.SearchText`, while `UpdateHighlights()` reads `Search.IsFuzzySearch`; `ActivateRoadmapProjection()` uses `emojiRootFilter`; existing test `RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode()` validates highlight state; existing helpers `WaitForStableRoadmapUpdates()` and `WaitForRoadmapUpdateAsync()` support stronger negative assertions.
+- Depth checklist:
+  - Scope drift / unrelated changes: только spec на SPEC phase.
+  - Acceptance criteria: покрывают exact highlight, fuzzy toggle refresh, selection, topology stability, stable initial counters and no rebuild after set/toggle/clear.
+  - Validation evidence: planned targeted UI test, build, full test.
+  - Unsupported claims: no unsupported runtime claim; implementation not started.
+  - Regression / edge case: clear search, late rebuild window, fuzzy-only typo query and active emoji filter cases учтены.
+  - Comments/docs/changelog: не требуется.
+  - Hidden contract change: non-roadmap search behavior explicitly preserved.
+  - Manual-review challenge: reviewer would likely check whether root cause is ViewModel filter, not GraphControl; spec addresses that and requires delayed no-rebuild proof.
+- No-findings justification: no BLOCKER/HIGH/MEDIUM findings remain after iteration 3.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | evidence | Video artifacts are not planned for headless unit UI path | Use explicit fallback evidence with test command output | accepted-risk |
+
+- Fixed before continuing: MEDIUM test-design gap fixed by adding stabilization and negative wait requirements; fuzzy refresh moved from LOW follow-up into main scope and test contract.
+- Checks rerun: SPEC linter/rubric self-check and third review pass over changed sections.
+- Needs human: phrase `Спеку подтверждаю`.
+- Residual risks / follow-ups: full `dotnet test src/Unlimotion.sln` may be slow or environment-sensitive; report exact blocker if it cannot run.
+
+### Post-EXEC Review
+- Статус: PASS
+- Scope reviewed: `MainWindowViewModel` roadmap projection, `GraphControl` search highlight subscription, `RoadmapGraphUiTests` regression.
+- Decision: можно завершать; validation limitation по full solution build зафиксирован как accepted-risk с объективной причиной и next-best evidence.
+- Review passes:
+  - Scope/Evidence pass: Изменения ограничены тремя planned code/test files и spec; ordinary tree `emojiRootFilter` не изменен.
+  - Contract pass: Roadmap `Graph.Tasks` теперь использует search-independent root filter; `SearchText` и `IsFuzzySearch` вызывают только `UpdateHighlights()`.
+  - Adversarial risk pass: Проверены exact search, fuzzy-only query, clear search, selected node/reference stability and no rebuild counters.
+  - Re-review after fixes / Fix and re-review: Дополнительных code fixes после validation не потребовалось; spec review metadata и Approval section исправлены и повторно проверены.
+  - Stop decision: Stop after targeted UI test + project build + diff check; full solution build ограничен окружением.
+- Evidence inspected: diff измененных файлов; `dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj --no-restore`; `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-build --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode"`; `git diff --check`; failed/timeout full solution build attempts.
+- Depth checklist:
+  - Scope drift / unrelated changes: Нет.
+  - Acceptance criteria: Покрыты no-rebuild для exact search, fuzzy toggle и clear; highlight меняется по текущему exact/fuzzy режиму.
+  - Validation evidence: Targeted UI test passed 1/1; test project build passed; diff check passed.
+  - Unsupported claims: Full solution build не заявляется как passed.
+  - Regression / edge case: Covered negative wait windows after search text changes and fuzzy mode toggle.
+  - Comments/docs/changelog: Production comments не добавлялись; spec journal обновлен.
+  - Hidden contract change: Ordinary task tree search/filter path сохранен на старом `emojiRootFilter`.
+  - Manual-review challenge: Основной остаточный риск - full solution build path по Android/mobile projects не завершен в текущем окружении.
+- No-findings justification: Нет BLOCKER/HIGH/MEDIUM findings после review; оставшиеся риски validation-only и environment-only.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | validation | Full solution build did not complete in current environment: `--no-restore` failed on missing `project.assets.json`, restore/build attempt timed out after 10 minutes while spawning Android/mobile build paths | Report limitation; rely on narrower passed build/test for this scoped change | accepted-risk |
+| LOW | evidence | No video artifact for Avalonia.Headless UI path | Use command output and rebuild counters as fallback evidence | accepted-risk |
+
+- Fixed before final report: Added roadmap-only root filter, fuzzy highlight subscription, regression assertions; corrected post-EXEC status/decision format and stale Approval section.
+- Checks rerun: `dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj --no-restore`; targeted `dotnet test` with TUnit treenode filter; `git diff --check`.
+- Validation evidence: test project build passed with existing warnings; targeted UI regression passed 1/1; diff check returned 0.
+- Unrelated changes: Нет.
+- Needs human: Нет.
+- Residual risks / follow-ups: Full solution build may need a restored/mobile-ready environment; no video artifact for headless UI path.
+
+## Approval
+Получено подтверждение пользователя: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Context gathering | 0.85 | Нет | Создать рабочий spec | Нет | Нет | Найдены центральные правила, UI testing override и вероятный root cause | `AGENTS.override.md`, central instructions, `MainWindowViewModel.cs`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| SPEC | Spec authoring | 0.90 | Подтверждение пользователя | Запросить approval gate | Да | Да, ожидается фраза `Спеку подтверждаю` | QUEST mode запрещает менять код до подтверждения | `specs/2026-06-02-roadmap-search-no-rebuild.md` |
+| SPEC | Iterative spec review | 0.92 | Нет для SPEC review; EXEC approval still needed | Запросить approval gate | Да | Да, ожидается фраза `Спеку подтверждаю` | Итерация 1 нашла MEDIUM gaps в test design/scope; после patch итерация 2 оставила только LOW findings | `specs/2026-06-02-roadmap-search-no-rebuild.md` |
+| SPEC | Scope update for fuzzy search | 0.93 | Нет для SPEC; EXEC approval still needed | Запросить approval gate | Да | Да, пользователь попросил включить `Search.IsFuzzySearch`; ожидается `Спеку подтверждаю` для EXEC | `Search.IsFuzzySearch` теперь входит в основной контракт: refresh highlight без rebuild; review iteration 3 оставила только LOW evidence finding | `specs/2026-06-02-roadmap-search-no-rebuild.md` |
+| EXEC | Implementation | 0.90 | Нет | Запустить targeted validation | Нет | Да, пользователь подтвердил spec фразой `Спеку подтверждаю` | Добавлен `roadmapRootFilter` без зависимости от search, `GraphControl` подписан на `SearchText` + `IsFuzzySearch`, regression расширен no-rebuild assertions | `MainWindowViewModel.cs`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs` |
+| EXEC | Validation | 0.86 | Full solution build не завершился: `--no-restore` missing assets, restore/build timeout на solution/mobile path | Выполнить post-EXEC review | Нет | Нет | Relevant UI regression passed 1/1, test project build passed, diff check passed; фоновые build/test хвосты остановлены по конкретным PID | build/test command output, process cleanup checks |
+| EXEC | Post-EXEC review | 0.88 | Нет блокирующих данных | Финальный отчет пользователю | Нет | Нет | Review не выявил blocker/high/medium findings; residual risks ограничены full solution build environment и отсутствием video artifact для headless UI | измененные файлы и validation evidence |
+| EXEC | Review format audit | 0.95 | Нет | Финальный отчет пользователю | Нет | Нет | Статус и decision post-EXEC review приведены к каноническим значениям `PASS` и `можно завершать`; code diff не менялся | `specs/2026-06-02-roadmap-search-no-rebuild.md` |
+| EXEC | Approval section audit | 0.95 | Нет | Финальный отчет пользователю | Нет | Нет | Убрана stale-формулировка, будто подтверждение спеки еще ожидается; re-review section обновлена после spec-only fix | `specs/2026-06-02-roadmap-search-no-rebuild.md` |

--- a/specs/2026-06-02-roadmap-search-no-rebuild.md
+++ b/specs/2026-06-02-roadmap-search-no-rebuild.md
@@ -272,6 +272,32 @@ Outcome contract:
 - Needs human: Нет.
 - Residual risks / follow-ups: Full solution build may need a restored/mobile-ready environment; no video artifact for headless UI path.
 
+### Post-EXEC Review Addendum: PR build warnings
+- Статус: PASS
+- Scope reviewed: PR #247 `android-build` log annotations for `src/Unlimotion.ViewModel/MainWindowViewModel.cs`; local `MainWindowViewModel.cs` diff.
+- Decision: можно завершать after warning cleanup.
+- Review passes:
+  - Scope/Evidence pass: Found two `CS0618` annotations at `MainWindowViewModel.cs(820,13)` and `(866,17)` for obsolete `ObservableCacheEx.Sort(...)`.
+  - Contract pass: Replaced only the two top-level `Sort(...).Bind(...)` chains with `SortAndBind(...)`; roadmap search behavior remains unchanged.
+  - Adversarial risk pass: Checked that warning source was existing top-level sorted bindings shifted into PR annotations by this diff, not `roadmapRootFilter` itself.
+  - Re-review after fixes / Fix and re-review: `Unlimotion.ViewModel.csproj` rebuild confirmed zero warnings/errors after the fix.
+  - Stop decision: PASS with unchanged residual limitation around broader test project build availability.
+- Evidence inspected: GitHub PR #247 `android-build` log; local `dotnet build src/Unlimotion.ViewModel/Unlimotion.ViewModel.csproj --no-restore -v:minimal`.
+- Depth checklist:
+  - Scope drift / unrelated changes: One file fix in `MainWindowViewModel.cs` plus this spec addendum.
+  - Acceptance criteria: PR `MainWindowViewModel.cs` CS0618 warnings removed locally.
+  - Validation evidence: ViewModel project build passed with `Предупреждений: 0`, `Ошибок: 0`.
+  - Unsupported claims: No claim that full test project rebuild completed after this warning-only fix.
+  - Regression / edge case: Top-level current/unlocked bindings still use the same observable comparers.
+  - Comments/docs/changelog: No production comments added.
+  - Hidden contract change: No API, persistence, search or roadmap topology contract changes.
+  - Manual-review challenge: Broader UI sort behavior is indirectly covered by existing tests but not rerun after this warning-only fix because concurrent build/test processes were active in the worktree.
+- No-findings justification: No BLOCKER/HIGH/MEDIUM findings; the warning cleanup is mechanically aligned with the compiler recommendation.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | validation | Test project rebuild was not completed after the warning-only fix because another `Unlimotion.Test` build was already running in the same worktree and the attempted build timed out | Report limitation; rely on focused `Unlimotion.ViewModel.csproj` build for this compiler warning fix | accepted-risk |
+
 ## Approval
 Получено подтверждение пользователя: "Спеку подтверждаю"
 
@@ -287,3 +313,4 @@ Outcome contract:
 | EXEC | Post-EXEC review | 0.88 | Нет блокирующих данных | Финальный отчет пользователю | Нет | Нет | Review не выявил blocker/high/medium findings; residual risks ограничены full solution build environment и отсутствием video artifact для headless UI | измененные файлы и validation evidence |
 | EXEC | Review format audit | 0.95 | Нет | Финальный отчет пользователю | Нет | Нет | Статус и decision post-EXEC review приведены к каноническим значениям `PASS` и `можно завершать`; code diff не менялся | `specs/2026-06-02-roadmap-search-no-rebuild.md` |
 | EXEC | Approval section audit | 0.95 | Нет | Финальный отчет пользователю | Нет | Нет | Убрана stale-формулировка, будто подтверждение спеки еще ожидается; re-review section обновлена после spec-only fix | `specs/2026-06-02-roadmap-search-no-rebuild.md` |
+| EXEC | PR build warning cleanup | 0.90 | Test project rebuild после warning-only fix не завершился из-за параллельного build процесса в worktree | Закоммитить и запушить warning fix в PR | Нет | Да, пользователь попросил посмотреть PR build warnings | Две CS0618 аннотации в `MainWindowViewModel.cs` исправлены через `SortAndBind`; focused ViewModel build прошел с 0 warnings/0 errors | `MainWindowViewModel.cs`, PR #247 build log, `specs/2026-06-02-roadmap-search-no-rebuild.md` |

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -2770,6 +2770,8 @@ public class RoadmapGraphUiTests
                 var targetTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
                 await Assert.That(targetTask).IsNotNull();
                 targetTask!.Wanted = false;
+                targetTask.Title = "Roadmap fuzzy match target";
+                vm.Graph.Search.IsFuzzySearch = false;
 
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
@@ -2791,19 +2793,66 @@ public class RoadmapGraphUiTests
                     KeyModifiers.None);
                 await Assert.That(targetNode?.IsSelected).IsTrue();
 
+                WaitForStableRoadmapUpdates(graphControl);
+                var updateCountBeforeSearch = graphControl.RoadmapGraphUpdateCount;
+                var buildStartCountBeforeSearch = graphControl.RoadmapGraphBackgroundBuildStartCount;
+                var nodeCountBeforeSearch = graphControl.RoadmapNodes.Count;
+                var connectionCountBeforeSearch = graphControl.RoadmapConnections.Count;
+
                 vm.Graph.Search.SearchText = targetTask.OnlyTextTitle;
                 var highlighted = WaitFor(() => targetTask.IsHighlighted);
 
                 await Assert.That(highlighted).IsTrue();
+                await AssertNoRoadmapRebuildAsync(
+                    graphControl,
+                    updateCountBeforeSearch,
+                    buildStartCountBeforeSearch,
+                    nodeCountBeforeSearch,
+                    connectionCountBeforeSearch);
                 await Assert.That(targetNode?.IsSelected).IsTrue();
+                await Assert.That(ReferenceEquals(targetNode, FindRoadmapNode(
+                    graphControl,
+                    MainWindowViewModelFixture.RootTask2Id))).IsTrue();
                 await Assert.That(graphText.FontWeight).IsEqualTo(FontWeight.Bold);
                 await Assert.That(graphText.Foreground is ISolidColorBrush brush && brush.Color == Color.Parse("#2F80ED"))
                     .IsTrue();
 
+                var updateCountBeforeFuzzy = graphControl.RoadmapGraphUpdateCount;
+                var buildStartCountBeforeFuzzy = graphControl.RoadmapGraphBackgroundBuildStartCount;
+                vm.Graph.Search.SearchText = "fuzxy";
+                var exactCleared = WaitFor(() => !targetTask.IsHighlighted);
+                await Assert.That(exactCleared).IsTrue();
+                await AssertNoRoadmapRebuildAsync(
+                    graphControl,
+                    updateCountBeforeFuzzy,
+                    buildStartCountBeforeFuzzy,
+                    nodeCountBeforeSearch,
+                    connectionCountBeforeSearch);
+
+                updateCountBeforeFuzzy = graphControl.RoadmapGraphUpdateCount;
+                buildStartCountBeforeFuzzy = graphControl.RoadmapGraphBackgroundBuildStartCount;
+                vm.Graph.Search.IsFuzzySearch = true;
+                var fuzzyHighlighted = WaitFor(() => targetTask.IsHighlighted);
+                await Assert.That(fuzzyHighlighted).IsTrue();
+                await AssertNoRoadmapRebuildAsync(
+                    graphControl,
+                    updateCountBeforeFuzzy,
+                    buildStartCountBeforeFuzzy,
+                    nodeCountBeforeSearch,
+                    connectionCountBeforeSearch);
+
+                var updateCountBeforeClear = graphControl.RoadmapGraphUpdateCount;
+                var buildStartCountBeforeClear = graphControl.RoadmapGraphBackgroundBuildStartCount;
                 vm.Graph.Search.SearchText = "";
                 var cleared = WaitFor(() => !targetTask.IsHighlighted);
 
                 await Assert.That(cleared).IsTrue();
+                await AssertNoRoadmapRebuildAsync(
+                    graphControl,
+                    updateCountBeforeClear,
+                    buildStartCountBeforeClear,
+                    nodeCountBeforeSearch,
+                    connectionCountBeforeSearch);
                 await Assert.That(targetNode?.IsSelected).IsTrue();
             }
             finally
@@ -2812,6 +2861,25 @@ public class RoadmapGraphUiTests
                 fixture.CleanTasks();
             }
         }, CancellationToken.None);
+
+        static async Task AssertNoRoadmapRebuildAsync(
+            GraphControl graphControl,
+            int updateCountBefore,
+            int buildStartCountBefore,
+            int nodeCountBefore,
+            int connectionCountBefore)
+        {
+            var rebuilt = await WaitForRoadmapUpdateAsync(
+                graphControl,
+                updateCountBefore,
+                1200);
+
+            await Assert.That(rebuilt).IsFalse();
+            await Assert.That(graphControl.RoadmapGraphUpdateCount).IsEqualTo(updateCountBefore);
+            await Assert.That(graphControl.RoadmapGraphBackgroundBuildStartCount).IsEqualTo(buildStartCountBefore);
+            await Assert.That(graphControl.RoadmapNodes.Count).IsEqualTo(nodeCountBefore);
+            await Assert.That(graphControl.RoadmapConnections.Count).IsEqualTo(connectionCountBefore);
+        }
     }
 
     private static Window CreateWindow(Control content)

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -791,6 +791,32 @@ namespace Unlimotion.ViewModel
                     return (Func<TaskItemViewModel, bool>)Predicate;
                 });
 
+            var roadmapRootFilter = _emojiFilters.ToObservableChangeSet()
+                .AutoRefreshOnObservable(filter => filter.WhenAnyValue(e => e.ShowTasks))
+                .ToCollection()
+                .Select(filter =>
+                {
+                    bool Predicate(TaskItemViewModel task)
+                    {
+                        if (filter.All(e => !e.ShowTasks))
+                        {
+                            return task.Parents.Count == 0;
+                        }
+
+                        foreach (var item in filter.Where(e => e.ShowTasks))
+                        {
+                            if (task.Id == item.Source?.Id)
+                            {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    }
+
+                    return (Func<TaskItemViewModel, bool>)Predicate;
+                });
+
             taskRepository.Tasks
                 .Connect()
                 .AutoRefreshOnObservable(m => m.Parents.ToObservableChangeSet())
@@ -1147,7 +1173,7 @@ namespace Unlimotion.ViewModel
                         m => m.IsCompleted,
                         m => m.UnlockedDateTime, (c, d, u) => c.Value && (d.Value == false)))
                     .Filter(taskFilter)
-                    .Filter(emojiRootFilter)
+                    .Filter(roadmapRootFilter)
                     .Filter(emojiExcludeFilter)
                     .Transform(item =>
                     {

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -841,9 +841,7 @@ namespace Unlimotion.ViewModel
                     var wrapper = new TaskWrapperViewModel(null, item, actions);
                     return wrapper;
                 })
-                .Sort(sortObservable)
-                .TreatMovesAsRemoveAdd()
-                .Bind(out _currentItems)
+                .SortAndBind(out _currentItems, sortObservable)
                 .Subscribe(/*set => ExpandParentNodesForTask(CurrentTaskItem)*/)
                 .AddToDispose(connectionDisposableList);
 
@@ -894,8 +892,7 @@ namespace Unlimotion.ViewModel
                         var wrapper = new TaskWrapperViewModel(null, item, actions);
                         return wrapper;
                     })
-                    .Sort(sortObservableForUnlocked)
-                    .Bind(out _unlockedItems)
+                    .SortAndBind(out _unlockedItems, sortObservableForUnlocked)
                     .Subscribe()
                     .AddToDispose(connectionDisposableList);
 

--- a/src/Unlimotion/Views/GraphControl.axaml.cs
+++ b/src/Unlimotion/Views/GraphControl.axaml.cs
@@ -298,9 +298,9 @@ namespace Unlimotion.Views
                 .Subscribe(_ => ScheduleUpdateGraph())
                 .AddToDispose(disposableList);
 
-            dc.WhenAnyValue(m => m.Search.SearchText)
+            dc.WhenAnyValue(m => m.Search.SearchText, m => m.Search.IsFuzzySearch)
                 .Throttle(TimeSpan.FromMilliseconds(SearchDefinition.DefaultThrottleMs))
-                .Select(t => (t ?? "").Trim())
+                .Select(search => ((search.Item1 ?? "").Trim(), search.Item2))
                 .DistinctUntilChanged()
                 .ObserveOn(RxSchedulers.MainThreadScheduler)
                 .Subscribe(_ => UpdateHighlights())


### PR DESCRIPTION
## Summary
- Prevent roadmap search text and fuzzy mode changes from rebuilding the roadmap graph.
- Keep search as highlight-only state for the already rendered roadmap topology.
- Remove the PR build annotations in `MainWindowViewModel.cs` by replacing obsolete DynamicData `Sort(...).Bind(...)` usage with `SortAndBind(...)`.
- Add a PR test workflow that runs CI-safe TUnit and headless UI suites on pull requests.

## Changes
- Add a roadmap-only root filter that ignores `Search.SearchText` while preserving emoji-root behavior for roadmap topology.
- Refresh roadmap highlights when either `Search.SearchText` or `Search.IsFuzzySearch` changes, without calling `UpdateGraph()`.
- Extend the existing Avalonia.Headless roadmap search UI regression to assert exact search, fuzzy-only search, clear search, selected node stability, and no rebuild counter changes.
- Replace the two top-level `MainWindowViewModel` sorted binding chains that produced `CS0618` PR build warnings.
- Add `Unlimotion Tests / All tests` GitHub Actions workflow for `src/Unlimotion.Test` and `tests/Unlimotion.UiTests.Headless`; FlaUI stays outside the mandatory PR gate.
- Add the approved QUEST specs and post-EXEC review evidence.

## Validation
- `dotnet build src/Unlimotion.ViewModel/Unlimotion.ViewModel.csproj --no-restore -v:minimal` passed with `0` warnings and `0` errors after the warning cleanup.
- `dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj --no-restore` passed before the warning cleanup with existing repository warnings.
- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj --no-build --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode"` passed `1/1`.
- `dotnet restore` passed for `src/Unlimotion.Test/Unlimotion.Test.csproj` and `tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj`.
- `dotnet test tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --output Detailed` passed `25/25` locally.
- Local full `Unlimotion.Test` was attempted twice and exposed existing local instability: both runs reached `421/422` passed and failed on different tests; the targeted rerun of one failed test passed `1/1`.
- GitHub Actions `Unlimotion Tests / All tests` passed on the clean runner in `4m42s`: https://github.com/Kibnet/Unlimotion/actions/runs/26847518121/job/79170890321
- `git diff --check` passed.
- UI automation evidence fallback: the roadmap path uses Avalonia.Headless unit UI tests, so no before/after video artifact was produced; the targeted test output plus roadmap rebuild/highlight counters are the next-best evidence.

## Risks / Rollback
- Full `dotnet build src/Unlimotion.sln` was not completed in this worktree: `--no-restore` hit missing `project.assets.json` for unrecovered projects, and restore/build timed out on the solution/mobile path.
- The test project rebuild after the warning-only cleanup was not completed because another `Unlimotion.Test` build was already running in the same worktree and the attempted build timed out; the focused ViewModel build verifies the compiler warning fix.
- The new `All tests` check now blocks on the CI-safe test baseline; selecting it as a required branch-protection check may still require repository settings outside this PR diff.
- Rollback: revert this PR to restore the previous roadmap root filter, sorted binding behavior, and PR check set.

## Links
- Spec: `specs/2026-06-02-roadmap-search-no-rebuild.md`
- Spec: `specs/2026-06-02-pr-all-tests-check.md`