### PR TITLE
refactor(client): isolate task source runtime

### DIFF
--- a/specs/2026-06-16-client-multi-source-refactor.md
+++ b/specs/2026-06-16-client-multi-source-refactor.md
@@ -1,0 +1,996 @@
+# Рефакторинг клиентского состояния для нескольких источников задач
+
+## 0. Метаданные
+- Тип (профиль): `delivery-task` + `.NET desktop client` + `refactor-architecture` + `refactoring-policy`
+- Владелец: Product Owner / активный пользователь
+- Масштаб: large
+- Целевая модель: gpt-5.5
+- Целевой релиз / ветка: Не задано
+- Ограничения:
+  - Фаза `SPEC`: до подтверждения менять только этот файл.
+  - Переход в `EXEC` только после фразы пользователя `Спеку подтверждаю`.
+  - Локальный `AGENTS.override.md` требует UI tests, если этап реализации меняет UI behavior, visual user flows или UI-facing state.
+  - Рефакторинг не должен менять наблюдаемое поведение текущего одного источника задач.
+  - Публичные persisted-данные должны мигрироваться назад-совместимо с существующим `TaskStorage`.
+- Связанные ссылки:
+  - `src/Unlimotion/App.axaml.cs`
+  - `src/Unlimotion.Desktop/Program.cs`
+  - `src/Unlimotion.Android/MainActivity.cs`
+  - `src/Unlimotion.Browser/Program.cs`
+  - `tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs`
+  - `src/Unlimotion/Services/ITaskStorageFactory.cs`
+  - `src/Unlimotion/Services/TaskStorageFactory.cs`
+  - `src/Unlimotion/UnifiedTaskStorage.cs`
+  - `src/Unlimotion/FileStorage.cs`
+  - `src/Unlimotion/ServerStorage.cs`
+  - `src/Unlimotion/Services/BackupViaGitService.cs`
+  - `src/Unlimotion.ViewModel/TaskStorageSettings.cs`
+  - `src/Unlimotion.ViewModel/MainWindowViewModel.cs`
+  - `src/Unlimotion.ViewModel/TaskItemViewModel.cs`
+  - `src/Unlimotion.ViewModel/SettingsViewModel.cs`
+  - `src/Unlimotion.ViewModel/Localization/LocalizationService.cs`
+  - `src/Unlimotion/Views/MainControl.axaml.cs`
+  - `src/Unlimotion/Views/GraphControl.axaml.cs`
+  - `src/Unlimotion.Test/MainWindowViewModelFixture.cs`
+
+Если секция не применима, явно указано `Не применимо`.
+
+## 1. Overview / Цель
+Подготовить клиентскую часть Unlimotion к поддержке нескольких источников задач за счет удаления process-wide mutable singleton/static state из пути создания, выбора, чтения и изменения задач.
+
+Outcome contract:
+- Success means:
+  - Клиентский composition root перестает хранить основные сервисы, текущую VM и текущий storage в static fields.
+  - Контракт `ITaskStorageFactory.CurrentStorage` заменен на source-aware runtime/manager, который может держать один или несколько источников без глобального `CurrentStorage`.
+  - `MainWindowViewModel`, `TaskItemViewModel`, `GraphControl` и `MainControl` получают зависимости через instance context/data context, а не через `TaskItemViewModel.*Instance` и `MainControl.DialogsInstance`.
+  - Текущий single-source сценарий остается полностью совместимым: существующий `TaskStorage` в `Settings.json` мигрируется в новый формат или читается как legacy fallback.
+  - Pure static helpers, extension methods, Avalonia dependency properties и immutable constants не объявляются проблемой сами по себе и не переписываются без пользы.
+  - Будущий feature-этап сможет добавить UI управления несколькими источниками без переписывания storage/viewmodel foundation.
+- Итоговый артефакт / output:
+  - Спецификация, затем после утверждения: кодовый рефакторинг, tests и краткий migration/rollback отчет.
+- Stop rules:
+  - Остановиться до EXEC, пока пользователь не подтвердит spec.
+  - Не продолжать этап refactor, если characterization tests фиксируют изменение текущего single-source поведения.
+  - Не завершать EXEC без `dotnet build`, релевантных targeted tests и полного тестового прогона проекта или явного отчета, почему полный прогон недоступен.
+
+## 2. Текущее состояние (AS-IS)
+- `App.axaml.cs` является одновременно Avalonia `Application`, composition root, storage orchestrator, settings command binder, migration runner, backup scheduler owner и update service owner.
+- В `App.axaml.cs` есть static mutable fields: `_configuration`, `_mapper`, `_dialogs`, `_toastNotificationManager`, `_notificationManager`, `_backupService`, `_applicationUpdateService`, `_appNameService`, `_storageFactory`, `_configPath`, `_scheduler`, `_mainWindowViewModel`, `_cultureChangedHandler`, `_startupUpdateSettings`, `_startupUpdateCheckPending`.
+- `App.Init(configPath)` глобально создает configuration, localization, mapper, dialogs, storage factory, backup service, initial storage и scheduler hooks.
+- `TaskStorageFactory` держит один `CurrentStorage`, один `CurrentWatcher`, static `DefaultStoragePath` и static `PrepareFileStoragePathAsync`.
+- `ITaskStorageFactory` выражает ровно один текущий storage:
+  - `ITaskStorage? CurrentStorage`
+  - `IDatabaseWatcher? CurrentWatcher`
+  - `CreateFileStorage`, `CreateServerStorage`, `SwitchStorage`
+- `MainWindowViewModel` получает `Func<ITaskStorage?> getTaskStorage`, сохраняет результат в публичное поле `taskRepository` и строит все tabs, graph, filters, relation editor и commands от одного `taskRepository.Tasks.Connect()`.
+- `TaskItemViewModel` хранит static fallbacks `NotificationManagerInstance` и `MainWindowInstance`. `NotificationManagerInstance` читается для toast/confirm flows, а `MainWindowInstance` используется как fallback в `GraphControl`.
+- `MainControl` держит static `DialogsInstance` и напрямую создает `FileStorage` в `MoveToPath`.
+- `GraphControl.ResolveMainWindowViewModel` падает назад на `TaskItemViewModel.MainWindowInstance`.
+- `LocalizationService.Current` является глобальным mutable singleton. Он не является источником задач, но создает тестовую и composition-сцепку через глобальную культуру.
+- `BackupViaGitService.GetAbsolutePath` static и `TaskStorageFactory.DefaultStoragePath` static задаются из Desktop, Android, Browser и TestHost entry point-ов.
+- `FileStorage` при пустом path берет `TaskStorageFactory.DefaultStoragePath`.
+- `ServerStorage` читает login/password и tokens из глобальных секций `TaskStorage` и `ClientSettings`, поэтому несколько server-source с разными учетками сейчас неразличимы.
+- `TaskStorageSettings` хранит один набор: `Path`, `URL`, `Login`, `Password`, `IsServerMode`, `IsFuzzySearch`.
+- `SettingsViewModel` редактирует один локальный путь или один server URL и переключает один режим.
+- Browser и AppAutomation TestHost частично обходят `App.Init`, но все равно пишут в те же static dependencies.
+
+AS-IS dependency sketch:
+
+```mermaid
+flowchart TD
+    Program["Desktop/Android/Browser/TestHost entry point"] --> StaticApp["App static fields"]
+    StaticApp --> Factory["TaskStorageFactory CurrentStorage"]
+    Factory --> OneStorage["UnifiedTaskStorage"]
+    OneStorage --> Cache["SourceCache<TaskItemViewModel,string>"]
+    StaticApp --> MainVm["MainWindowViewModel taskRepository"]
+    MainVm --> Cache
+    StaticApp --> TaskVmStatics["TaskItemViewModel static instances"]
+    GraphControl["GraphControl"] --> TaskVmStatics
+    MainControl["MainControl"] --> StaticDialogs["MainControl.DialogsInstance"]
+    ServerStorage["ServerStorage"] --> GlobalTaskStorageSettings["TaskStorage settings"]
+```
+
+## 3. Проблема
+Корневая проблема: путь работы с задачами завязан на единственный process-wide mutable "текущий storage" и static service fallbacks, поэтому приложение не может одновременно держать несколько независимых источников задач, маршрутизировать команды в правильный источник и тестировать такие сценарии без скрытого пересечения состояния.
+
+## 4. Цели дизайна
+- Разделение ответственности:
+  - startup/composition отдельно от Avalonia `Application`;
+  - source registry/manager отдельно от concrete storage implementations;
+  - task command routing отдельно от UI controls;
+  - platform path/dialog/update services отдельно от domain/viewmodel.
+- Повторное использование:
+  - один composition API для Desktop, Android, Browser и AppAutomation TestHost;
+  - существующие `FileStorage`, `ServerStorage`, `UnifiedTaskStorage` переиспользуются как source runtimes.
+- Тестируемость:
+  - несколько source runtime можно создать в одном test process без static resets;
+  - `TaskItemViewModel` можно тестировать с injected context.
+- Консистентность:
+  - все task lists, graph, relation picker и current task используют один source-aware read model.
+- Обратная совместимость:
+  - legacy `TaskStorage` продолжает читаться;
+  - текущий single-source UX не меняется в этом refactor.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не добавляем полноценный UI управления несколькими источниками задач в этой спецификации.
+- Не меняем серверный API и server-side storage model.
+- Не меняем формат файлов отдельных задач.
+- Не переписываем pure helper static classes, extension methods, immutable constants, Avalonia styled/direct properties и stateless algorithms только ради отсутствия слова `static`.
+- Не меняем semantics связей задач между источниками. На этом этапе связи остаются внутри одного source.
+- Не переносим Git backup на multi-source модель полностью. В этом refactor он остается привязан к active local source, а multi-source backup проектируется как follow-up.
+- Не вводим DI container, если локальная composition object/factory решает задачу с меньшим diff.
+
+## 6. Предлагаемое решение (TO-BE)
+
+### 6.1 Распределение ответственности
+- `UnlimotionClientRuntime`:
+  - instance-scoped composition root;
+  - держит configuration, localization, mapper, dialogs, notification, update service, source manager, backup service, scheduler;
+  - создается entry point-ом и передается в `App` instance.
+- `AppClientOptions`:
+  - config path, default storage path, platform path resolver, optional update service, optional folder access preparer.
+- `ITaskSourceManager`:
+  - source-aware replacement for `ITaskStorageFactory.CurrentStorage`;
+  - exposes `IReadOnlyList<TaskSourceRuntime> Sources`, `TaskSourceRuntime? ActiveSource`, `IObservable`/events for source changes;
+  - creates, connects, disconnects and switches active source by id.
+- `TaskSourceDescriptor`:
+  - persisted source identity: `Id`, `DisplayName`, `Kind`, `IsEnabled`, `IsActive`, `FilePath`, `ServerUrl`;
+  - for server sources references source-scoped auth/token settings by the same `Id`.
+- `TaskSourceServerSettings`:
+  - source-scoped server auth state: `SourceId`, `Login`, `Password`, `AccessToken`, `RefreshToken`, `ExpireTime`;
+  - preserves current plaintext password behavior; encrypted storage is a separate security feature.
+- `TaskSourceRuntime`:
+  - runtime pair: descriptor + `ITaskStorage` + optional watcher + source-specific services.
+- `ITaskStorageFactory`:
+  - replaced by stateless `ITaskStorageBuilder`;
+  - no `CurrentStorage`, no static default path.
+- `TaskItemViewModelContext`:
+  - injected notification manager, localization, scheduler/options and task owner callbacks;
+  - replaces `TaskItemViewModel.NotificationManagerInstance` and `TaskItemViewModel.MainWindowInstance`.
+- `TaskViewModelFactory`:
+  - creates `TaskItemViewModel(model, storage, context, isInitializedProvider)`;
+  - passed into `UnifiedTaskStorage` through constructor/runtime creation.
+- `MainWindowViewModel`:
+  - depends on `ITaskSourceManager`;
+  - for this refactor still binds to active source only, but no longer asks a global factory for `CurrentStorage`;
+  - exposes source context needed by controls through DataContext.
+- `MainControl`:
+  - gets dialogs through view model command/service, not static `DialogsInstance`;
+  - `MoveToPath` delegates to source/task service instead of directly newing `FileStorage`.
+- `GraphControl`:
+  - resolves owner from DataContext/visual tree only; no fallback to `TaskItemViewModel.MainWindowInstance`.
+- `SettingsViewModel`:
+  - keeps legacy single-source properties for current UI;
+  - internally can read/write active source descriptor through adapter, preserving existing bindings.
+
+### 6.2 Детальный дизайн
+
+TO-BE dependency sketch:
+
+```mermaid
+flowchart TD
+    Entry["Desktop/Android/Browser/TestHost entry point"] --> Options["AppClientOptions"]
+    Options --> Runtime["UnlimotionClientRuntime instance"]
+    Runtime --> SourceManager["ITaskSourceManager"]
+    SourceManager --> Builder["ITaskStorageBuilder"]
+    SourceManager --> SourceA["TaskSourceRuntime A"]
+    SourceManager --> SourceB["TaskSourceRuntime B"]
+    SourceA --> StorageA["UnifiedTaskStorage A"]
+    SourceB --> StorageB["UnifiedTaskStorage B"]
+    Runtime --> MainVm["MainWindowViewModel"]
+    MainVm --> SourceManager
+    MainVm --> StorageA
+    Runtime --> TaskContext["TaskItemViewModelContext"]
+    StorageA --> TaskFactory["TaskViewModelFactory"]
+    TaskFactory --> TaskContext
+    MainControl["MainControl"] --> MainVm
+    GraphControl["GraphControl"] --> MainVm
+```
+
+Refactor stages:
+
+1. Characterization safety net:
+   - capture current single-source startup/connect behavior;
+   - capture static fallback behavior for notification, graph owner resolution and settings storage path;
+   - add tests that fail if storage commands write to a different source than the task belongs to.
+2. Introduce source descriptors without behavior change:
+   - add `TaskSourceKind`, `TaskSourceDescriptor`, `TaskSourcesSettings`;
+   - add legacy adapter that maps existing `TaskStorage` to one descriptor with stable id like `default`;
+   - no UI change.
+3. Replace `TaskStorageFactory.CurrentStorage`:
+   - add `ITaskSourceManager`;
+   - make active source runtime explicit;
+   - introduce stateless `ITaskStorageBuilder`;
+   - keep `SwitchStorage` compatibility as wrapper only inside source manager during migration, then remove direct callers.
+4. Remove static path/service fallbacks:
+   - replace `TaskStorageFactory.DefaultStoragePath` with `AppClientOptions.DefaultTaskStoragePath`;
+   - replace `PrepareFileStoragePathAsync` with injected platform service;
+   - replace `BackupViaGitService.GetAbsolutePath` with injected path resolver.
+5. Remove TaskItem/View static dependencies:
+   - introduce `TaskItemViewModelContext` and pass it through `UnifiedTaskStorage`;
+   - remove `TaskItemViewModel.NotificationManagerInstance`;
+   - remove `TaskItemViewModel.MainWindowInstance`;
+   - move graph/task selection owner resolution to DataContext.
+6. Move App static composition into runtime:
+   - convert `App.Init` static workflow into runtime factory;
+   - keep only thin platform bridge methods if platform APIs require static entry, and make them delegate to current `App` instance rather than owning services.
+7. Prepare multi-source read model:
+   - keep active-source-only UI in this spec;
+   - add source identity and ownership to active-source subscriptions now;
+   - do not add `AllEnabledTasks` aggregation in this refactor;
+   - add source id to task context, not necessarily to persisted `TaskItem`.
+
+Output/evidence rules:
+- Each stage must be reviewable as a small diff.
+- Any stage that touches UI bindings or controls must include relevant Avalonia Headless/AppAutomation tests.
+- Any stage that touches persisted settings must include migration tests.
+
+Visual planning artifact:
+- `Не применимо` for this refactor spec: target behavior is architectural and intentionally preserves current visible UI. Fallback state flow is the dependency diagrams above. If EXEC expands into visible source selector/settings UI, a separate visual planning artifact must be added before that UI change.
+
+UI test video evidence:
+- `Не применимо` for this refactor-only spec because no UI automation feature flow or visual change is planned. If EXEC changes Settings UI or task source selection UI, video/screenshot evidence becomes required by the GitHub delivery policy and local UI override.
+- Fallback evidence for UI-facing plumbing changes: targeted Avalonia Headless/AppAutomation suites around startup, main control command wiring and task card/status rendering must be listed in the EXEC review and PR validation instead of video artifacts.
+
+Границы сохранения поведения:
+- Existing `Settings.json` with only `TaskStorage` loads exactly one active source.
+- Existing local file tasks are not rewritten unless existing migrations already do so.
+- Current tabs, filters, graph, relation picker, task commands and backup controls continue to work for the active source.
+
+Обработка ошибок:
+- Source connection errors must be source-scoped.
+- A failed inactive source must not break active source UI.
+- Legacy migration failures must fall back to current `TaskStorage` behavior or show existing storage error, not silently start with an empty source list.
+
+Производительность:
+- No intentional performance tradeoff.
+- Multi-source aggregation is not enabled in this spec, so startup cost should remain near current single-source cost.
+
+## 7. Бизнес-правила / Алгоритмы
+- Source identity:
+  - each source has stable `Id`;
+  - legacy single source uses `default`;
+  - task command routing uses the source runtime that created/owns the `TaskItemViewModel`.
+- Active source:
+  - current UI operates on one active source during this refactor;
+  - changing active source disconnects or detaches subscriptions from the previous source before binding the new one.
+- Relations:
+  - relation editor candidates are from the same source as the current task in this refactor.
+  - cross-source relations are explicitly unsupported until a product spec defines semantics.
+- Settings migration:
+  - if `TaskSources` section is absent and `TaskStorage` exists, create/read one descriptor from `TaskStorage`;
+  - legacy `TaskStorage.Login`, `TaskStorage.Password` and `ClientSettings` map to `TaskSources.ServerSettings[default]` for server mode;
+  - keep writing legacy `TaskStorage` fields until UI/settings compatibility is intentionally changed.
+- Server auth:
+  - `ServerStorage` must stop reading login/password/tokens from global `TaskStorage` and `ClientSettings`;
+  - `ServerStorage` receives source-specific server settings and token persistence callbacks from `TaskSourceRuntime`;
+  - only the legacy active `default` server source is mirrored back to `TaskStorage`/`ClientSettings` for rollback compatibility.
+- Static classification:
+  - blocking static: mutable process-wide service/state/default used by task source flow;
+  - non-blocking static: pure helper, extension method, immutable resource/cache, Avalonia property registration, local test helper.
+
+## 8. Точки интеграции и триггеры
+- Startup:
+  - Desktop `Program.Main`
+  - Android `MainActivity.ConfigureCoreAppServices`
+  - Browser `Program.BuildAvaloniaApp`
+  - AppAutomation `UnlimotionAppLaunchHost.CreateHeadlessViewModel`
+- Storage/source changes:
+  - current `SettingsViewModel.ConnectCommand`
+  - current `TaskStorageFactory.SwitchStorage`
+  - `MainWindowViewModel.Connect`
+- Task VM creation:
+  - `UnifiedTaskStorage.BuildInitialTaskViewsAsync`
+  - `UnifiedTaskStorage.Add`, `AddChild`, `Update`, `Clone`, cache update paths
+- UI owner/context:
+  - `GraphControl.ResolveMainWindowViewModel`
+  - `MainControl` commands currently using `DialogsInstance`
+- Backup:
+  - `BackupViaGitService` current path and current storage access
+  - scheduler job factory setup in app runtime
+
+## 9. Изменения модели данных / состояния
+- New persisted section, proposed:
+
+```json
+{
+  "TaskSources": {
+    "ActiveSourceId": "default",
+    "Sources": [
+      {
+        "Id": "default",
+        "DisplayName": "Local tasks",
+        "Kind": "File",
+        "Path": "Tasks",
+        "IsEnabled": true
+      },
+      {
+        "Id": "work-server",
+        "DisplayName": "Work server",
+        "Kind": "Server",
+        "Url": "https://tasks.example.com",
+        "IsEnabled": false
+      }
+    ],
+    "ServerSettings": [
+      {
+        "SourceId": "work-server",
+        "Login": "",
+        "Password": "",
+        "AccessToken": "",
+        "RefreshToken": "",
+        "ExpireTime": ""
+      }
+    ]
+  }
+}
+```
+
+- `TaskStorage` remains supported as legacy/current UI section during this refactor.
+- `ClientSettings` remains supported as legacy token section for the `default` server source only.
+- Source-scoped server credentials intentionally preserve current storage semantics, including plaintext password; encryption is outside this refactor.
+- No persisted change to `TaskItem`.
+- Runtime-only state:
+  - active source runtime;
+  - source-specific watcher;
+  - source-specific notification/error state;
+  - source id in `TaskItemViewModelContext`.
+
+## 10. Миграция / Rollout / Rollback
+- Rollout:
+  1. Add new contracts and tests while keeping old behavior.
+  2. Route existing single source through `ITaskSourceManager`.
+  3. Remove static fallbacks in small steps.
+  4. Keep old `TaskStorage` read/write compatibility.
+- First launch after update:
+  - If `TaskSources` missing, derive active source from `TaskStorage`.
+  - If legacy server mode is active, derive `TaskSources.ServerSettings[default]` from `TaskStorage.Login`, `TaskStorage.Password` and `ClientSettings` tokens.
+  - If both exist, `TaskSources.ActiveSourceId` wins, but legacy `TaskStorage` and `ClientSettings` are kept in sync for the active `default` source only.
+- Rollback:
+  - Because individual task files are unchanged, rollback to old app can still use `TaskStorage`.
+  - If rollback app ignores `TaskSources`, it should still see the synced legacy active source.
+- Compatibility checks:
+  - old config with local path;
+  - old config with server mode;
+  - empty config;
+  - platform-specific default paths.
+
+## 11. Тестирование и критерии приёмки
+Acceptance Criteria:
+- AC1: existing single-source local startup loads the same tasks and current UI bindings as before.
+- AC2: existing single-source server settings still create/connect a server storage with the same login/password behavior.
+- AC3: two source runtimes can be created in one process without sharing `CurrentStorage`, default path, notification manager or task owner.
+- AC4: `TaskItemViewModel` commands route writes to the storage that owns the task.
+- AC5: `GraphControl` can resolve `MainWindowViewModel` without `TaskItemViewModel.MainWindowInstance`.
+- AC6: `MainControl` no longer needs static `DialogsInstance`.
+- AC7: legacy `TaskStorage` config is migrated/read into a default source descriptor and remains compatible.
+- AC8: pure static helpers are left alone unless they hold mutable source/composition state.
+- AC9: no visible UI change is introduced by this refactor.
+- AC10: two server source descriptors can hold different login/password/token state without sharing global `ClientSettings`.
+
+Какие тесты добавить/изменить:
+- Unit/characterization:
+  - `TaskSourceSettingsMigrationTests`
+  - `TaskSourceManagerTests`
+  - `TaskItemViewModelContextTests`
+  - `MainWindowViewModelSourceBindingTests`
+- Existing targeted suites likely affected:
+  - `MainWindowViewModelTests`
+  - `SettingsViewModelTests`
+  - `SingleViewStartupUiTests`
+  - `MainScreenLoadingUiTests`
+  - `RoadmapGraphUiTests` for owner resolution fallback removal
+  - `MainControlTreeCommandsUiTests` or the nearest `MainControl*UiTests` suite when moving `MainControl` command wiring
+- UI tests:
+  - required for the `GraphControl` fallback removal stage: run targeted `RoadmapGraphUiTests`;
+  - required for the `MainControl.DialogsInstance` removal stage: run targeted `MainControlTreeCommandsUiTests` or another suite that covers affected command wiring;
+  - if a stage changes only constructor/composition code and no UI control/binding/event handler, record that UI tests are not applicable for that stage and run existing startup/headless smoke tests as next-best evidence.
+
+Characterization tests / contract checks:
+- Existing fixture loads snapshot tasks through active source.
+- Switching active source detaches previous subscriptions and does not mutate previous storage.
+- A task created in source A is saved to source A even when source B exists.
+- Legacy `TaskStorage.Path` -> `TaskSources.Sources[default].Path`.
+- Legacy `TaskStorage.IsServerMode` -> `TaskSources.Sources[default].Kind`.
+- Legacy `TaskStorage.Login/Password` and `ClientSettings` -> `TaskSources.ServerSettings[default]`.
+- Distinct server sources persist distinct tokens and do not overwrite each other.
+
+Visual acceptance:
+- No UI layout/state change expected.
+- If any UI binding changes, verify Settings, main task tabs and Roadmap render unchanged in headless/AppAutomation tests.
+
+UI video evidence:
+- Not required for architecture-only refactor.
+- Required if a later stage adds source selector UI.
+- For this EXEC, no screenshot/video artifact is expected unless a visible UI flow changes; next-best evidence is targeted UI/headless tests covering the touched command wiring and startup/render paths.
+
+Базовые замеры до/после для performance tradeoff:
+- Не применимо: no planned performance tradeoff.
+
+Команды для проверки:
+
+```powershell
+dotnet build src/Unlimotion.Desktop/Unlimotion.Desktop.csproj --no-restore /nodeReuse:false
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --no-restore -- --treenode-filter "/*/*/TaskSource*/*"
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --no-restore -- --treenode-filter "/*/*/MainWindowViewModelTests/*"
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --no-restore -- --treenode-filter "/*/*/SingleViewStartupUiTests/*"
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --no-restore -- --treenode-filter "/*/*/MainScreenLoadingUiTests/*"
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --no-restore -- --treenode-filter "/*/*/RoadmapGraphUiTests/*"
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --no-restore -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*"
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --no-restore
+```
+
+Stop rules для validation loops:
+- If targeted source/context tests fail, stop and fix before broad tests.
+- If full `Unlimotion.Test` run hangs due known environment issue, rerun affected targeted suites and report full-run blocker with evidence.
+- Do not use VSTest `--filter`; this repo uses TUnit/Microsoft.Testing.Platform tree filters.
+
+## 12. Риски и edge cases
+- Risk: hidden static remains in platform startup and masks cross-source bugs.
+  - Mitigation: `rg` static audit before final EXEC review and explicit allowlist for non-blocking statics.
+- Risk: settings migration accidentally changes user's active storage path.
+  - Mitigation: migration tests for local/server/empty config and synced legacy section.
+- Risk: `ServerStorage` still reads credentials from global `TaskStorage`.
+  - Mitigation: introduce source-specific settings access before enabling multiple server sources.
+- Risk: Git backup semantics are source-specific and currently assume one local repository.
+  - Mitigation: keep backup bound to active local source and mark multi-source backup as follow-up.
+- Risk: `TaskItemViewModel` context injection creates large constructor churn.
+  - Mitigation: use a small context object and factory, not long parameter lists.
+- Risk: removing static fallback breaks Roadmap interactions in visual tree edge cases.
+  - Mitigation: targeted `RoadmapGraphUiTests` around task selection/details opening.
+
+## 13. План выполнения
+Порядок является инвариантом: следующий этап начинается только после targeted-проверок предыдущего этапа.
+
+| Этап | Deliverable | Основные файлы | Required tests/evidence | Rollback point | Stop condition |
+| --- | --- | --- | --- | --- | --- |
+| 1. Characterization | Тесты текущего single-source поведения и static audit allowlist | `src/Unlimotion.Test/*` | targeted new characterization tests; `git diff --check` | удалить новые тесты без product-code diff | тест не воспроизводит текущий контракт |
+| 2. Source settings | `TaskSourceDescriptor`, `TaskSourcesSettings`, `TaskSourceServerSettings`, legacy adapter | `TaskStorageSettings.cs`, new source settings files | `TaskSourceSettingsMigrationTests`, `SettingsViewModelTests` relevant cases | legacy `TaskStorage` остается source of truth | legacy local/server config меняет active path/url/login |
+| 3. Source manager | `ITaskSourceManager`, `TaskSourceRuntime`, stateless `ITaskStorageBuilder`; active source routes current single source | `Services/*TaskSource*`, `TaskStorageFactory.cs`, `ITaskStorageFactory.cs` | `TaskSourceManagerTests`, `MainWindowViewModelSourceBindingTests` | old `TaskStorageFactory` still present until stage passes | two runtimes share mutable storage/default state |
+| 4. Main VM routing | `MainWindowViewModel` binds to active source runtime, keeps current UX | `MainWindowViewModel.cs`, fixture/test host updates | `MainWindowViewModelTests`, `MainScreenLoadingUiTests` | revert VM constructor/routing while keeping settings models | existing snapshot fixture does not load same tasks |
+| 5. Task VM context | `TaskItemViewModelContext` and factory remove `TaskItemViewModel.*Instance` | `TaskItemViewModel.cs`, `UnifiedTaskStorage.cs` | `TaskItemViewModelContextTests`, task status/transition targeted tests | restore static fallback until context route passes | task command writes to wrong storage/source |
+| 6. UI control cleanup | `GraphControl` and `MainControl` resolve owner/dialogs through context/commands | `GraphControl.axaml.cs`, `MainControl.axaml.cs` | `RoadmapGraphUiTests`, `MainControlTreeCommandsUiTests` or nearest affected UI suite | static fallback can be restored independently | Roadmap selection/details or command wiring regresses |
+| 7. Platform path services | replace static default path/folder-prep/git-path resolver | `Program.cs`, `MainActivity.cs`, `Program.cs` Browser, `BackupViaGitService.cs`, TestHost | startup tests, `SettingsRemoteTypeHeadlessTests` if settings path behavior changes | legacy static wrappers kept until platform tests pass | platform default path or Android folder access breaks |
+| 8. Runtime composition | `UnlimotionClientRuntime` owns services; `App.Init` becomes a thin compatibility bridge during this refactor | `App.axaml.cs`, platform entry points | `SingleViewStartupUiTests`, `MainScreenLoadingUiTests`, build | runtime can be bypassed by old App.Init wrapper during migration | app startup requires process-wide mutable service fields |
+| 9. Final audit | source-blocking static audit and full validation | all touched files | `rg` audit, `dotnet build`, targeted tests, full `Unlimotion.Test` run | revert latest stage only if audit fails | hidden blocking static remains without explicit accepted-risk |
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов для refactor-only EXEC.
+
+Deferred product questions for later feature spec:
+- Нужно ли показывать задачи из всех источников одновременно или только active source?
+- Допустимы ли cross-source relations?
+- Как должен работать Git backup для нескольких локальных источников?
+- Нужен ли per-source язык/тема или они остаются app-wide?
+
+## 15. Соответствие профилю
+- Профиль: `.NET desktop client`, `refactor-architecture`, `refactoring-policy`, `testing-dotnet`.
+- Выполненные требования профиля:
+  - Составлена AS-IS/TO-BE схема зависимостей.
+  - Зафиксированы public API/контрактные точки миграции: `ITaskStorageFactory`, `TaskStorageSettings`, `MainWindowViewModel`, `TaskItemViewModel`, platform startup.
+  - Рефакторинг отделен от функционального multi-source UI.
+  - Запланирован safety net до structural changes.
+  - Запланированы `dotnet build`, targeted TUnit tests и full test run.
+  - UI test requirement учтен: UI tests обязательны при UI-facing changes.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.ViewModel/TaskStorageSettings.cs` | добавить `TaskSourcesSettings`, `TaskSourceDescriptor`, `TaskSourceServerSettings`, legacy compatibility | persisted migration foundation |
+| `src/Unlimotion/Services/ITaskStorageFactory.cs` | заменить single-current factory contract на source/runtime contract | убрать `CurrentStorage` singleton |
+| `src/Unlimotion/Services/TaskStorageFactory.cs` | преобразовать в stateless `ITaskStorageBuilder` implementation | source-aware runtime |
+| `src/Unlimotion/Services/TaskSourceManager.cs` | добавить active source manager/runtime ownership | несколько source runtime без global current |
+| `src/Unlimotion/UnifiedTaskStorage.cs` | принимать `TaskViewModelFactory`/context | убрать static VM fallbacks |
+| `src/Unlimotion.ViewModel/TaskItemViewModel.cs` | убрать static instances, использовать context | source-safe task commands/toasts |
+| `src/Unlimotion.ViewModel/MainWindowViewModel.cs` | зависеть от `ITaskSourceManager` | подготовка active/multiple sources |
+| `src/Unlimotion.ViewModel/SettingsViewModel.cs` | адаптировать single-source UI к active source descriptor | совместимость текущего UI |
+| `src/Unlimotion/ServerStorage.cs` | принимать source-scoped server settings/token callbacks | несколько server source без общего `ClientSettings` |
+| `src/Unlimotion/Views/MainControl.axaml.cs` | убрать static dialogs, делегировать move/export logic | UI control без global state |
+| `src/Unlimotion/Views/GraphControl.axaml.cs` | убрать fallback на `MainWindowInstance` | owner resolution через DataContext |
+| `src/Unlimotion/App.axaml.cs` | вынести static composition в runtime | instance-scoped app services |
+| `src/Unlimotion.Desktop/Program.cs` | создавать runtime options вместо записи static defaults | platform composition |
+| `src/Unlimotion.Android/MainActivity.cs` | передавать platform services/options | platform composition |
+| `src/Unlimotion.Browser/Program.cs` | использовать общий runtime builder | убрать divergent startup |
+| `tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs` | использовать source manager/test runtime | deterministic tests |
+| `src/Unlimotion.Test/*` | добавить/обновить source/context/migration/UI smoke tests | safety net |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Storage selection | `TaskStorageFactory.CurrentStorage` | `ITaskSourceManager.ActiveSource.Storage` |
+| Default path | `TaskStorageFactory.DefaultStoragePath` static | `AppClientOptions.DefaultTaskStoragePath`/path service |
+| Android folder access | `TaskStorageFactory.PrepareFileStoragePathAsync` static | platform file access service |
+| Git path resolution | `BackupViaGitService.GetAbsolutePath` static | injected path resolver |
+| Task VM notifications | `TaskItemViewModel.NotificationManagerInstance` | `TaskItemViewModelContext.NotificationManager` |
+| Roadmap owner fallback | `TaskItemViewModel.MainWindowInstance` | visual tree/DataContext owner |
+| Dialogs in MainControl | `MainControl.DialogsInstance` | view model command/service dependency |
+| Config source | single `TaskStorage` | `TaskSources` with legacy `TaskStorage` adapter |
+| Server credentials | global `TaskStorage.Login/Password` and `ClientSettings` | `TaskSources.ServerSettings[sourceId]`, legacy mirror for `default` only |
+| Storage builder | factory owns current storage | stateless `ITaskStorageBuilder` creates storage for requested descriptor |
+| App composition | `App.Init` static fields | `UnlimotionClientRuntime` instance owned by `App`/entry point |
+
+## 18. Альтернативы и компромиссы
+- Вариант: сразу внедрить DI container.
+  - Плюсы: стандартная service lifetime модель.
+  - Минусы: большой diff, риск переписать app startup ради контейнера, не решает сам по себе source identity.
+  - Почему не выбран: локальный runtime/source manager дешевле и ближе к текущей архитектуре.
+- Вариант: сделать `CompositeTaskStorage : ITaskStorage`, который объединяет несколько storage.
+  - Плюсы: минимум изменений в `MainWindowViewModel`.
+  - Минусы: маскирует source ownership, команды могут писать не туда, cross-source relation semantics останутся неявными.
+  - Почему не выбран: задача именно убрать скрытый single-current state и подготовить source-aware модель.
+- Вариант: оставить static App, но добавить список storage внутрь `TaskStorageFactory`.
+  - Плюсы: быстрый путь к прототипу.
+  - Минусы: сохраняет process-wide mutable state и тестовые пересечения.
+  - Почему не выбран: противоречит основной проблеме.
+- Вариант: удалить все static classes механически.
+  - Плюсы: формально меньше `static`.
+  - Минусы: ломает extension/pure helper patterns, Avalonia properties и ухудшает читаемость без связи с multi-source.
+  - Почему не выбран: scope ограничен blocking mutable static/singleton state.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, корневая проблема, цели и Non-Goals раскрыты. |
+| B. Качество дизайна | 6-10 | PASS | Выбран один runtime/source-manager/storage-builder контракт; server auth source-scoped. |
+| C. Безопасность изменений | 11-13 | PASS | Acceptance, риски, stage gates, rollback и legacy sync зафиксированы. |
+| D. Проверяемость | 14-16 | PASS | Есть AC, migration/unit/UI targeted tests, TUnit-команды и file change table. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Нет блокирующих вопросов, есть milestone table с stop conditions. |
+| F. Соответствие профилю | 20 | PASS | AS-IS/TO-BE схема, migration points и refactor safety net зафиксированы. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Refactor-only scope отделен от будущего multi-source UI. |
+| 2. Понимание текущего состояния | 5 | Перечислены реальные static/single-current зависимости и entry point-ы. |
+| 3. Конкретность целевого дизайна | 5 | Выбраны `UnlimotionClientRuntime`, `ITaskSourceManager`, stateless `ITaskStorageBuilder`, source-scoped server settings. |
+| 4. Безопасность (миграция, откат) | 5 | Legacy `TaskStorage`/`ClientSettings` compatibility, stage rollback и неизменность task files описаны. |
+| 5. Тестируемость | 5 | Есть characterization, migration/unit/UI targeted suites и full validation path. |
+| 6. Готовность к автономной реализации | 5 | План разбит на gated milestones, блокирующих вопросов нет. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Scope reviewed: `specs/2026-06-16-client-multi-source-refactor.md`, instruction stack (`quest-governance`, `quest-mode`, `.NET desktop client`, `refactor-architecture`, `refactoring-policy`, `testing-dotnet`, local UI override), open questions, planned changed files.
+- Decision: можно запрашивать подтверждение.
+- Review passes:
+  - Scope/Evidence pass: inspected `App.axaml.cs`, platform entry points, `TaskStorageFactory`, `ITaskStorage`, `UnifiedTaskStorage`, `TaskItemViewModel`, `MainWindowViewModel`, `MainControl`, `GraphControl`, `TaskStorageSettings`, test fixture and TUnit project surface.
+  - Contract pass: spec keeps EXEC blocked behind `Спеку подтверждаю`, preserves single-source behavior, avoids unrelated helper-static rewrite, includes source-scoped server auth and migration/test requirements.
+  - Adversarial risk pass: main counterexamples checked: server credentials no longer global in TO-BE, backup still active-source only by Non-Goal, UI multi-source semantics deferred, hidden platform statics included in scope.
+  - Re-review after fixes / Fix and re-review: fixed review findings for server auth, UI tests, milestone gates and architecture ambiguity; rechecked sections 6, 7, 9, 10, 11, 13, 16, 17 and quality gate.
+  - Stop decision: PASS because design, acceptance, rollout and validation are concrete, prior HIGH/MEDIUM findings are fixed, and no blocking question remains.
+- Evidence inspected:
+  - `rg` results for source-blocking static/singleton state.
+  - Concrete code reads in `App.axaml.cs`, `TaskStorageFactory.cs`, `ITaskStorageFactory.cs`, `MainWindowViewModel.cs`, `TaskItemViewModel.cs`, `MainControl.axaml.cs`, `GraphControl.axaml.cs`, `TaskStorageSettings.cs`, `ServerStorage.cs`, `FileStorage.cs`, `Program.cs`, `MainActivity.cs`, `UnlimotionAppLaunchHost.cs`.
+- Depth checklist:
+  - Scope drift / unrelated changes: explicit Non-Goals exclude pure helper statics and full UI feature.
+  - Acceptance criteria: AC1-AC10 cover current behavior, source isolation, static removal, migration and server auth isolation.
+  - Validation evidence: test plan includes targeted and full commands; no code executed yet because phase is SPEC.
+  - Unsupported claims: source-blocking claims are grounded in inspected files.
+  - Regression / edge case: settings migration, source-scoped server credentials/tokens, backup and roadmap owner fallback covered.
+  - Comments/docs/changelog: no docs/changelog changes planned unless implementation changes public architecture docs.
+  - Hidden contract change: public persisted config compatibility called out.
+  - Manual-review challenge: likely reviewer concern would be "why not remove all static"; spec explicitly classifies blocking vs non-blocking static.
+- No-findings justification: final pass found no remaining blocker/high issue because source-scoped auth, stage gates, UI tests and architecture choices are explicit.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | design / data | Server source auth/token state was underspecified and still effectively global. | Add source-scoped `TaskSourceServerSettings`, `ServerStorage` source-specific settings/callbacks and legacy `default` sync rule. | fixed |
+| MEDIUM | validation / profile | UI test contract did not name suites for planned `GraphControl`/`MainControl` changes. | Add `RoadmapGraphUiTests` and `MainControlTreeCommandsUiTests` targeted commands and applicability rules. | fixed |
+| MEDIUM | rollout / risk | EXEC plan was too broad without per-stage stop/rollback gates. | Replace linear list with milestone table containing deliverable, files, tests, rollback point and stop condition. | fixed |
+| MEDIUM | design / contract | Core architecture had `or` choices for runtime/factory/read model. | Choose `UnlimotionClientRuntime`, `ITaskSourceManager` and stateless `ITaskStorageBuilder`; defer aggregation. | fixed |
+| LOW | follow-up | Multi-source UI behavior is intentionally deferred. | Create a separate product/UI spec when adding selector/management UX. | follow-up |
+
+- Fixed before continuing: server auth model, concrete architecture choices, UI test commands and milestone gates.
+- Checks rerun: manual SPEC linter/rubric/review loop completed in this file after fixes.
+- Needs human: требуется подтверждение фразой `Спеку подтверждаю`.
+- Residual risks / follow-ups: multi-source backup and cross-source relations need separate product decisions.
+
+### Post-EXEC Review
+- Статус: Выполнен после EXEC
+- Scope reviewed: source settings/runtime, storage builder/manager, source-scoped server auth, VM/control static fallback removal, platform default/path hooks, tests.
+- Decision: PASS.
+- Review passes:
+  - Scope/Evidence pass: checked diff and `rg` for removed `TaskItemViewModel.NotificationManagerInstance`, `TaskItemViewModel.MainWindowInstance`, `MainControl.DialogsInstance`, `TaskStorageFactory.DefaultStoragePath`, `TaskStorageFactory.PrepareFileStoragePathAsync`, `BackupViaGitService.GetAbsolutePath`.
+  - Contract pass: current UI remains active-source-only; legacy `TaskStorage` is still mirrored for default source; `TaskSources` is read/written through adapter because the existing writable JSON provider cannot persist arrays safely.
+  - Adversarial risk pass: source-specific server settings/token state are isolated; non-default server tokens do not overwrite legacy `ClientSettings`; task VM commands keep owning storage reference.
+  - Re-review after fixes / Fix and re-review: fixed provider array write failure by using provider-friendly `SourceEntries`/`ServerSettingEntries` physical layout behind the public `TaskSourcesSettings` model.
+  - Stop decision: PASS with full test run green.
+- Evidence inspected:
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore -p:UseSharedCompilation=false`
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/TaskSourceManagerTests/*" --maximum-parallel-tests 1 --output Detailed` -> 5/5
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/RoadmapGraphUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 47/47
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 43/43
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainScreenLoadingUiTests/*|/*/*/SingleViewStartupUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 2/2
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/BackupViaGitServiceTests/*" --maximum-parallel-tests 1 --output Detailed` -> 52/52
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --output Detailed` -> 532/532
+- Depth checklist:
+  - Scope drift / unrelated changes: no unrelated refactor beyond source/runtime/static cleanup.
+  - Acceptance criteria: AC1, AC3, AC4, AC5, AC6, AC7, AC10 covered by tests; AC2 covered by source-scoped server construction/migration unit coverage, without live server connection.
+  - Validation evidence: targeted and full TUnit commands green.
+  - Unsupported claims: no live multi-source UI was claimed; UI selector remains outside this refactor.
+  - Regression / edge case: writable JSON array limitation addressed by adapter layout and unit tests.
+  - Comments/docs/changelog: spec journal updated; no changelog needed for internal refactor.
+  - Hidden contract change: persisted `TaskSources` physical layout differs from proposed JSON array to match provider constraints, while public settings model remains list-based.
+  - Manual-review challenge: 2026-06-18 follow-up removes the old `ITaskStorageFactory.CurrentStorage`/`CurrentWatcher` shim entirely; production code reads `SourceManager.ActiveStorage`/`ActiveWatcher`.
+- No-findings justification: no BLOCKER/HIGH/MEDIUM issue remains after full validation; remaining items are follow-ups for full runtime DI/UI.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | architecture follow-up | `App` still exposes static bootstrap hooks, but 2026-06-18 follow-up moved runtime services/storage/VM state to the app instance. | Move full app composition to `UnlimotionClientRuntime` in a later dedicated pass if deeper lifecycle cleanup is required. | accepted follow-up |
+| LOW | compatibility shim | `ITaskStorageFactory.CurrentStorage` / `CurrentWatcher` remained for old tests/callers in the first implementation. | 2026-06-18 follow-up removed the shim and migrated callers/fakes to `SourceManager.ActiveStorage` / `ActiveWatcher`. | fixed |
+
+- Fixed before final report: writable JSON persistence layout, platform static hooks, source context test fixtures.
+- Checks rerun: build, targeted source/runtime, Roadmap, MainControl tree commands, startup smoke, backup, full serial test run.
+- Validation evidence: full run 532/532 passed.
+- Unrelated changes: none intentionally included.
+- Needs human: no blocking decision remains.
+- Residual risks / follow-ups: multi-source selector UI, cross-source relations, multi-source backup semantics and full `App` runtime extraction remain separate product/architecture follow-ups.
+
+### Post-EXEC Review Addendum: review findings fix
+- Статус: PASS с зафиксированным full-run caveat.
+- Scope reviewed: review findings, `TaskSourceManager`, `TaskStorageFactory`, `ITaskStorageFactory`, `App.Init`, direct `FileStorage` call sites, source/runtime tests and related fakes.
+- Decision: можно завершать исправления; блокирующих review findings не осталось.
+- Review passes:
+  - Scope/Evidence pass: inspected relevant diff, `git status --short`, `git diff --stat`, `git diff --check`, static-hook search and repeated targeted TUnit evidence.
+  - Contract pass: startup now activates persisted `TaskSources.ActiveSourceId`; same-id replacement disconnects replaced runtime; direct local storage commands normalize whitespace path through app default; file-mode scheduler uses actual active `FileStorage`, not legacy `TaskStorage.IsServerMode`.
+  - Adversarial risk pass: non-default server source no longer starts file backup scheduler; same-id switch has regression coverage; no removed static hooks returned.
+  - Re-review after fixes / Fix and re-review: after scheduler edge-case fix, build, source-manager tests and startup smoke were rerun.
+  - Stop decision: PASS; full serial run has known headless/order-dependent failures, but both failed tests passed isolated and at class level.
+- Evidence inspected:
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore -p:UseSharedCompilation=false` -> passed
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/TaskSourceManagerTests/*" --maximum-parallel-tests 1 --output Detailed` -> 7/7
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/SettingsViewModelTests/*" --maximum-parallel-tests 1 --output Detailed` -> 69/69
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/BackupViaGitServiceTests/*" --maximum-parallel-tests 1 --output Detailed` -> 52/52
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainScreenLoadingUiTests/*|/*/*/SingleViewStartupUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 2/2
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 43/43
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/PackageUpdateCompatibilityUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 1/1
+  - Full serial `dotnet test ... -- --maximum-parallel-tests 1 --output Detailed` -> 532/534; failed `TreeDragUi_DragPreparation_PreservesExistingMultiSelectionVisualState` with Avalonia.Headless teardown `NullReferenceException` and `RoadmapDropAndFolderPickerCompatibility_Work`, both passed in isolated reruns.
+  - `git diff --check` -> passed, CRLF warnings only.
+  - `rg` for removed static hooks -> no production matches; remaining direct `new FileStorage(storagePath...)` matches are normalized builder/test helper.
+- Depth checklist:
+  - Scope drift / unrelated changes: review-fix stayed within source runtime startup/lifecycle and tests.
+  - Acceptance criteria: startup active source, same-id lifecycle, default path fallback and static hook removal covered.
+  - Validation evidence: targeted unit/UI/service/startup checks green; full serial caveat investigated with isolated/class reruns.
+  - Unsupported claims: no claim that full serial is green after addendum.
+  - Regression / edge case: active non-default server source no longer enters file scheduler path.
+  - Comments/docs/changelog: spec addendum and journal updated; no changelog needed for internal refactor.
+  - Hidden contract change: `ITaskStorageFactory.CreateConfiguredStorage` added for startup path and implemented in test fakes.
+  - Manual-review challenge: likely remaining concern is full serial failure; evidence says failed tests are not reproducible in isolated/class runs.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | startup / persistence | Startup re-derived `default` from legacy `TaskStorage` and ignored persisted non-default active source. | Add configured-source activation and use it from `App.Init`. | fixed |
+| HIGH | lifecycle | Same source id replacement created a new runtime without disconnecting the replaced storage/session. | Disconnect and dispose replaced runtime before replacement; add regression coverage. | fixed |
+| MEDIUM | path fallback | Direct app `FileStorage` calls passed whitespace path through to relative `Tasks`. | Normalize whitespace path through `ResolveDefaultTaskStoragePath()`. | fixed |
+| MEDIUM | startup / scheduler | Startup scheduler used legacy `TaskStorage.IsServerMode` instead of actual active source storage kind. | Initialize scheduler only when active storage is `FileStorage`. | fixed |
+| LOW | validation caveat | Full serial run ended 532/534 because of order-dependent/headless failures not reproduced in isolated/class reruns. | Record caveat and rely on targeted reruns for affected surfaces. | accepted-risk |
+
+- Fixed before final report: all review findings above.
+- Checks rerun: build, source-manager, settings, backup, startup smoke, tree commands UI, package compatibility UI, static-hook search and diff check.
+- Validation evidence: targeted affected suites green; full serial caveat investigated.
+- Unrelated changes: none intentionally included.
+- Needs human: no blocking decision remains.
+- Residual risks / follow-ups: full suite order-dependence remains a test-suite stability issue outside this refactor.
+
+### Post-EXEC Review Addendum: targeted/full validation refresh
+- Статус: PASS.
+- Scope reviewed: PR diff against `origin/main`, local working tree, failed GitHub `All tests` evidence, targeted reruns, full serial TUnit run, safe-dispose changes for observed Avalonia.Headless teardown failures.
+- Decision: можно завершать и обновлять PR; старый full-run caveat снят новым зеленым full-run evidence.
+- Review passes:
+  - Scope/Evidence pass: checked `gh pr view 265`, failed CI log, `git diff --name-status origin/main...HEAD`, `git diff --stat origin/main...HEAD`, local `git status --short --branch`, targeted class reruns and full serial rerun.
+  - Contract pass: safe-dispose changes do not alter product behavior; they only apply the existing `DisposeIgnoringHeadlessTeardownNullReferenceAsync` workaround to two tests that failed in teardown.
+  - Adversarial risk pass: CI flyout-null failures in `MainControlTaskStatusIconUiTests` were rerun at class level and passed; local full-run paste-outline failures were rerun at method/class level and passed after build-server cleanup; no source/runtime production change was needed.
+  - Re-review after fixes / Fix and re-review: after converting the two teardown tests to explicit safe dispose, `SingleViewStartupUiTests`, `SettingsControlResponsiveUiTests`, `MainControlTaskStatusIconUiTests`, full serial suite, build and diff check were rerun.
+  - Stop decision: PASS; targeted and full validation are green.
+- Evidence inspected:
+  - GitHub `All tests` failed on 2026-06-16 with 537/540 and failures in `MainControlTaskStatusIconUiTests` plus Avalonia.Headless teardown NRE in `SingleViewStartupUiTests`.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlTaskStatusIconUiTests/*|/*/*/SingleViewStartupUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 18/18 before fix.
+  - Full serial before fix exposed Avalonia.Headless teardown NRE in `SettingsControlResponsiveUiTests`; this matched the existing safe-dispose workaround pattern.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/SingleViewStartupUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 4/4.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/SettingsControlResponsiveUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 12/12.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainControlTaskStatusIconUiTests/*" --maximum-parallel-tests 1 --output Detailed` -> 18/18.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --maximum-parallel-tests 1 --timeout 10m --output Detailed --show-stdout Failed --show-stderr Failed` -> 538/538.
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj --no-restore -p:UseSharedCompilation=false` -> passed.
+  - `git diff --check` -> passed, CRLF warnings only.
+- Depth checklist:
+  - Scope drift / unrelated changes: no production changes added; validation fix limited to two tests with observed teardown NRE.
+  - Acceptance criteria: targeted and full validation evidence now cover startup, settings UI, source runtime and wider regression surface.
+  - Validation evidence: targeted classes and full serial suite green.
+  - Unsupported claims: no claim that CI is green until branch is pushed and GitHub reruns checks.
+  - Regression / edge case: safe dispose catches only Avalonia.Headless teardown NRE by stack frame, preserving assertion failures.
+  - Comments/docs/changelog: spec addendum and journal updated; no changelog needed.
+  - Hidden contract change: none; test teardown handling only.
+  - Manual-review challenge: likely question is whether safe-dispose masks product failures; the helper catches only `HeadlessUnitTestSession.DisposeAsync` NRE and the affected tests passed their assertions before teardown.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | validation / CI | Full validation was not green and GitHub `All tests` had a teardown failure in `SingleViewStartupUiTests`. | Apply existing safe-dispose workaround to the failing startup teardown path and rerun targeted/full validation. | fixed |
+| MEDIUM | validation / local full-run | Local full-run exposed the same Avalonia.Headless teardown NRE pattern in `SettingsControlResponsiveUiTests`. | Apply existing safe-dispose workaround to the observed settings teardown path and rerun targeted/full validation. | fixed |
+
+- Fixed before final report: safe dispose in `SettingsControl_TaskOutlineClipboardCheckBoxes_PersistSettings` and `SingleViewStartup_DoesNotReloadInitializedTaskStorage`.
+- Checks rerun: affected targeted classes, CI-failed task-status class, full serial suite, build, diff check.
+- Validation evidence: full run 538/538 passed.
+- Unrelated changes: none intentionally included.
+- Needs human: no blocking decision remains.
+- Residual risks / follow-ups: GitHub CI must rerun after push to confirm remote environment.
+
+### Post-EXEC Review Addendum: CI/full validation stabilization
+- Статус: PASS.
+- Supersedes: предыдущий `targeted/full validation refresh` addendum по части scope; фиксация была расширена после повторных full-run failures.
+- Scope reviewed: failed GitHub `All tests` evidence, repeated local full serial failures, UI headless teardown pattern, task status flyout tests, completed/archived projection test, tree command copy/paste outline tests, global headless UI-test session lifecycle.
+- Decision: можно обновлять PR; локальные targeted suites и full serial TUnit run зеленые.
+- Review passes:
+  - Scope/Evidence pass: inspected failing GitHub logs and local full-run logs, reran failing methods/classes after each fix, then reran full serial suite.
+  - Contract pass: production code unchanged in this stabilization pass; changes are limited to test lifecycle/waiting and do not alter client multi-source runtime behavior.
+  - Adversarial risk pass: `SafeHeadlessUnitTestSession` only changes disposal behavior for `await using` headless UI tests and delegates `Dispatch`/`DispatchAsync` to the native session; assertion failures still propagate.
+  - Re-review after fixes / Fix and re-review: after broad safe-dispose conversion and tree-command wait stabilization, affected targeted suites and full serial validation were rerun.
+  - Stop decision: PASS; targeted and full validation are green locally, GitHub CI must rerun after push.
+- Evidence inspected:
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/SettingsControlResponsiveUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 12/12.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 43/43.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainControlTaskStatusIconUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 18/18.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainWindowViewModelTests/CompletedAndArchivedProjections_DateFiltersCanRevealOlderStatusHistoryTasks" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 1/1.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/SingleViewStartupUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 4/4.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --timeout 10m --output Detailed --show-stdout Failed --show-stderr Failed` -> 538/538.
+- Depth checklist:
+  - Scope drift / unrelated changes: no production code added; test changes address observed CI/full validation instability.
+  - Acceptance criteria: UI-facing headless suites, startup smoke and full serial validation are green locally.
+  - Validation evidence: affected targeted classes plus full suite green.
+  - Unsupported claims: no claim that GitHub CI is green until branch is pushed and checks complete.
+  - Regression / edge case: native `Dispatch` tests that are sensitive to dispatch semantics remain on direct `HeadlessUnitTestSession` with explicit safe dispose.
+  - Comments/docs/changelog: spec addendum and journal updated; no changelog needed.
+  - Hidden contract change: none in production; `SafeHeadlessUnitTestSession` is a test-only lifecycle wrapper.
+  - Manual-review challenge: broad test wrapper conversion could look large, but it is mechanical and limited to replacing teardown path for `await using` headless UI sessions.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | validation / headless teardown | Full runs repeatedly failed with Avalonia.Headless `HeadlessUnitTestSession.DisposeAsync()` NRE in different UI-test classes. | Add test-only `SafeHeadlessUnitTestSession` and apply it to `await using` headless UI sessions. | fixed |
+| MEDIUM | validation / status picker UI | CI observed `TaskStatusPicker.Flyout` as null immediately after click. | Wait for arranged visible status picker and opened `MenuFlyout`; use neutral mouse-up modifiers. | fixed |
+| MEDIUM | validation / projections | Completed/archived projection test mutated date fields in-place without refreshing the source cache. | Refresh the source cache after test-only status-history date mutation. | fixed |
+| MEDIUM | validation / tree commands | Outline copy/paste tests used short waits around DynamicData filters and async hotkey paste. | Use existing long wait budget, wait for paste start, and focus/select the target tree before paste hotkey. | fixed |
+
+- Fixed before final report: headless safe-dispose wrapper, status flyout wait, projection cache refresh, tree command wait/focus stabilization.
+- Checks rerun: settings UI class, tree commands UI class, task-status UI class, projection method, single-view startup class, full serial suite.
+- Validation evidence: full run 538/538 passed.
+- Unrelated changes: none intentionally included.
+- Needs human: no blocking decision remains.
+- Residual risks / follow-ups: GitHub CI must rerun after push to confirm remote environment.
+
+### Post-EXEC Review Addendum: rebased targeted/full validation
+- Статус: PASS.
+- Supersedes: предыдущий `CI/full validation stabilization` addendum по финальному validation evidence после rebase на актуальный `origin/main`.
+- Scope reviewed: rebased PR diff, resolved `RoadmapGraphUiTests` conflict, GitHub/local full-run failures, status picker current-card tests, tree command copy/paste outline tests, `PasteTaskOutline` multi-root destination handling, full serial TUnit run.
+- Decision: можно обновлять PR; локальные targeted suites, full serial TUnit run и `git diff --check` зеленые.
+- Review passes:
+  - Scope/Evidence pass: после rebase проверены conflict resolution, status/tree/paste affected tests, full suite и whitespace diff.
+  - Contract pass: multi-source runtime behavior сохранён; production-fix ограничен существующим paste-outline flow и использует тот же captured destination contract.
+  - Adversarial risk pass: multi-root paste теперь заново резолвит captured destination перед каждым top-level node, чтобы relation/cache update после первого subtree не оставлял второй root на устаревшем parent VM.
+  - Re-review after fixes / Fix and re-review: после status flyout, tree async waits, scenario autosave-race guard и paste destination refresh rerun targeted + full validation.
+  - Stop decision: PASS; targeted and full validation are green locally, GitHub CI must rerun after push.
+- Evidence inspected:
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/RoadmapGraphUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 47/47.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlTaskStatusIconUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 20/20.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainWindowViewModelTests/PasteTaskOutline_*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 5/5.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 43/43.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --timeout 10m --output Detailed --show-stdout Failed --show-stderr Failed` -> 541/541.
+  - `git diff --check` -> passed, CRLF warnings only.
+- Depth checklist:
+  - Scope drift / unrelated changes: fixes limited to observed validation blockers and paste-outline bug uncovered by validation.
+  - Acceptance criteria: UI-facing suites, source/runtime regression surface and full serial validation are green locally.
+  - Validation evidence: affected targeted classes plus full suite green.
+  - Unsupported claims: no claim that GitHub CI is green until branch is pushed and checks complete.
+  - Regression / edge case: paste-outline keeps captured destination semantics and now handles multiple top-level pasted roots against refreshed relation state.
+  - Comments/docs/changelog: spec addendum and journal updated; no changelog needed.
+  - Hidden contract change: none intended; user-visible paste result becomes more robust for multi-root outline clipboard content.
+  - Manual-review challenge: production change is outside multi-source refactor surface, but it is directly justified by full validation failure in existing paste-outline UI flow.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | validation / rebased full run | Full validation after rebase exposed remaining order-dependent UI test failures. | Fix status flyout waits, tree async waits and scenario setup races, then rerun targeted/full validation. | fixed |
+| MEDIUM | product / paste outline | Multi-root outline paste could use stale destination parent state after creating the first top-level pasted subtree. | Re-resolve captured destination before each top-level pasted node. | fixed |
+
+- Fixed before final report: status current-card flyout tests, tree command async waits, search scenario autosave/update race, multi-root paste destination refresh.
+- Checks rerun: Roadmap graph class, task-status UI class, paste-outline VM methods, tree commands UI class, full serial suite, diff check.
+- Validation evidence: full run 541/541 passed.
+- Unrelated changes: none intentionally included.
+- Needs human: no blocking decision remains.
+- Residual risks / follow-ups: GitHub CI must rerun after push to confirm remote environment.
+
+### Post-EXEC Review Addendum: GitHub CI projection and full-run fix
+- Статус: PASS.
+- Supersedes: предыдущий `rebased targeted/full validation` addendum по финальному validation evidence после GitHub `All tests` failure на head `bbc6943`.
+- Scope reviewed: failed GitHub `All tests` log, completed/archived projection test, emoji filter flyout all-toggle UI path, tree command outline copy setup, affected targeted reruns, full serial TUnit run and whitespace diff.
+- Decision: можно обновлять PR; локальные targeted checks, full serial TUnit run и `git diff --check` зеленые.
+- Review passes:
+  - Scope/Evidence pass: inspected remote failure first, then reproduced/fixed targeted projection issue and full-run local blockers.
+  - Contract pass: projection test now refreshes active source-cache subscribers after activating completed/archived modes; emoji filter behavior keeps the same selectable items and summary text contract.
+  - Adversarial risk pass: `ShowTasks` no longer causes `EmojiFilterMultiSelectSearchBox` to rebuild its displayed list during the same key event because search membership does not depend on checked state.
+  - Re-review after fixes / Fix and re-review: after projection refresh, test-only autosave guards and emoji list churn fix, affected targeted tests and full serial validation were rerun.
+  - Stop decision: PASS; targeted and full validation are green locally, GitHub CI must rerun after push.
+- Evidence inspected:
+  - GitHub `All tests` on `bbc6943` failed in `CompletedAndArchivedProjections_DateFiltersCanRevealOlderStatusHistoryTasks` because `oldArchivedHidden` stayed false.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainWindowViewModelTests/CompletedAndArchivedProjections_DateFiltersCanRevealOlderStatusHistoryTasks" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 1/1.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlFilterToolbarResponsiveUiTests/FilterFlyout_EmojiFilters_AllItemTogglesEveryEmojiFilter" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 1/1.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/TreeCommandUi_CopyTaskOutline_UsesCurrentFiltersAndSort" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 1/1.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --timeout 10m --output Detailed --show-stdout Failed --show-stderr Failed` -> 541/541.
+  - `git diff --check` -> passed, CRLF warnings only.
+- Depth checklist:
+  - Scope drift / unrelated changes: production change is limited to emoji filter list refresh behavior uncovered by full UI validation; other changes are test stabilization for observed CI/full-run blockers.
+  - Acceptance criteria: CI-failed projection scenario, affected UI flows and full serial validation are green locally.
+  - Validation evidence: failing remote scenario, affected targeted tests and full suite are covered.
+  - Unsupported claims: no claim that GitHub CI is green until branch is pushed and checks complete.
+  - Regression / edge case: emoji search text and displayed filter membership still refresh when title/emoji/sort/search data changes; checked state now updates summary only.
+  - Comments/docs/changelog: spec addendum and journal updated; no changelog needed.
+  - Hidden contract change: none intended; the all-toggle UI path becomes less prone to live list churn during keyboard handling.
+  - Manual-review challenge: emoji control production change is outside the original multi-source refactor, but it fixes a full validation failure in an existing UI flow without changing visible behavior.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | validation / GitHub CI | Remote `All tests` failed because completed/archived date-filter projection did not refresh after mode activation. | Refresh the active source cache after activating each projection and guard test-only timestamp mutations from autosave. | fixed |
+| MEDIUM | UI / emoji filter | Toggling the `All` emoji filter rebuilt the displayed list during the key event and could trigger Avalonia list generator errors. | Update summary text for `ShowTasks` changes without reapplying the search filter. | fixed |
+| MEDIUM | validation / tree commands | Outline copy test setup still used direct title mutation plus explicit repository update, creating an autosave/update race. | Use the existing `UpdateTaskForScenarioAsync` setup helper for all scenario task title changes. | fixed |
+
+- Fixed before final report: projection active-cache refresh, projection timestamp autosave guard, emoji filter `ShowTasks` refresh split, tree command setup autosave guard.
+- Checks rerun: projection CI-failed method, emoji all-toggle method, tree outline copy method, full serial suite, diff check.
+- Validation evidence: full run 541/541 passed.
+- Unrelated changes: none intentionally included.
+- Needs human: no blocking decision remains.
+- Residual risks / follow-ups: GitHub CI must rerun after push to confirm remote environment.
+
+### Post-EXEC Review Addendum: GitHub CI paste-outline relation lookup fix
+- Статус: PASS.
+- Supersedes: предыдущий `GitHub CI projection and full-run fix` addendum по финальному validation evidence после GitHub `All tests` failure на head `f92b03a`.
+- Scope reviewed: failed GitHub `All tests` log, `PasteTaskOutline_CreatesNestedTasksUnderCurrentTask`, paste-outline relation assertions, paste-outline targeted group, full serial TUnit run and whitespace diff.
+- Decision: можно обновлять PR; локальные paste-outline targeted checks, full serial TUnit run и `git diff --check` зеленые.
+- Review passes:
+  - Scope/Evidence pass: inspected remote failure first; failure was isolated to stale VM relation assertions after paste created the expected tasks.
+  - Contract pass: production paste-outline behavior unchanged; the test now asserts against fresh repository state, matching DynamicData/cache replacement semantics.
+  - Adversarial risk pass: final relation assertions re-lookup parent/root/child/grandchild by ID before checking relation lists, so CI timing does not depend on stale object references.
+  - Re-review after fixes / Fix and re-review: after test lookup fix, reran CI-failed method, paste-outline group, full serial validation and diff check.
+  - Stop decision: PASS; targeted and full validation are green locally, GitHub CI must rerun after push.
+- Evidence inspected:
+  - GitHub `All tests` on `f92b03a` failed in `PasteTaskOutline_CreatesNestedTasksUnderCurrentTask`; all three pasted tasks existed by title, but relation assertion used stale VM references.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainWindowViewModelTests/PasteTaskOutline_CreatesNestedTasksUnderCurrentTask" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 1/1.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --treenode-filter "/*/*/MainWindowViewModelTests/PasteTaskOutline_*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 5/5.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --timeout 10m --output Detailed --show-stdout Failed --show-stderr Failed` -> 541/541.
+  - `git diff --check` -> passed, CRLF warnings only.
+- Depth checklist:
+  - Scope drift / unrelated changes: no production code added in this addendum; change is limited to the CI-failed paste-outline test.
+  - Acceptance criteria: CI-failed paste-outline scenario, paste-outline group and full serial validation are green locally.
+  - Validation evidence: failing remote scenario, targeted paste-outline tests and full suite are covered.
+  - Unsupported claims: no claim that GitHub CI is green until branch is pushed and checks complete.
+  - Regression / edge case: test still verifies parent/root/child/grandchild relation chain, but no longer assumes pre-update VM objects are live relation carriers.
+  - Comments/docs/changelog: spec addendum and journal updated; no changelog needed.
+  - Hidden contract change: none; test assertion model now matches repository-cache semantics.
+  - Manual-review challenge: this is a test-only fix after a remote-only failure, but it is directly grounded in CI evidence and preserves the same behavioral assertion.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| MEDIUM | validation / GitHub CI | Paste-outline CI test asserted relations through stale VM instances after repository updates. | Re-lookup pasted tasks and parent by ID before relation wait/final asserts. | fixed |
+
+- Fixed before final report: paste-outline relation assertions now use fresh repository lookups.
+- Checks rerun: CI-failed paste-outline method, paste-outline VM group, full serial suite, diff check.
+- Validation evidence: full run 541/541 passed.
+- Unrelated changes: none intentionally included.
+- Needs human: no blocking decision remains.
+- Residual risks / follow-ups: GitHub CI must rerun after push to confirm remote environment.
+
+### Post-EXEC Review Addendum 2026-06-18: defects from central-instruction review
+
+- Scope reviewed: local diff after central-instruction review findings, source/auth switching, App runtime composition, Browser/Android startup composition, backup path resolution, headless UI status-picker tests, full serial TUnit evidence.
+- Decision: можно обновлять PR after push; local targeted suites, Browser build, full serial TUnit run and whitespace diff are green. Android local build remains environment-blocked before compile by missing SDK workload.
+- Fixes applied:
+  - Removed production `ITaskStorageFactory.CurrentStorage` / `CurrentWatcher`; active runtime access now goes through `ITaskSourceManager.ActiveStorage` / `ActiveWatcher`.
+  - Moved `App` runtime services, storage factory, VM, notification, backup and update references to instance state; static state is limited to bootstrap/pending configuration hooks.
+  - Preserved non-default task source identity during Settings connect/switch instead of routing through the legacy default source.
+  - Prevented non-default server source creation from copying legacy `ClientSettings` access/refresh tokens.
+  - Split server storage disconnect and explicit sign-out: source switching disconnects without clearing persisted tokens; SignOut remains credential-clearing.
+  - Resolved repository path from the active file source before legacy `TaskStorage.Path`, and notified active watcher through the source manager.
+  - Browser startup now initializes the shared `App` composition path; Android startup re-applies file-storage path preparation when the core app was already initialized before `MainActivity`.
+  - Narrowed headless teardown `NullReferenceException` swallowing to the known Avalonia.Headless dispose frame.
+  - Updated current task-card status UI tests to open `TaskStatusPicker` through routed pointer events instead of private `BuildStatusFlyout`.
+  - Aligned `SingleViewStartupUiTests` with current `Application.Current` composition after runtime statics were removed.
+- Validation:
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false` -> passed.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/TaskSourceManagerTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 10/10.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/SettingsViewModelTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 69/69.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/BackupViaGitServiceTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 53/53.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainControlTaskStatusIconUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 20/20.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/SingleViewStartupUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 4/4.
+  - `dotnet build src\Unlimotion.Browser\Unlimotion.Browser.csproj -c Debug -p:UseSharedCompilation=false` -> passed.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 545/545.
+  - `git diff --check` -> passed, CRLF warnings only.
+- Android validation caveat:
+  - `dotnet build src\Unlimotion.Android\Unlimotion.Android.csproj -c Debug --no-restore -p:UseSharedCompilation=false` -> blocked before compile by `NETSDK1147`: missing workload `wasm-tools`.
+  - Decision needed only if local Android compile evidence is mandatory before push: either install/restore required workloads in the SDK environment, or rely on CI Android build as the authoritative platform validation.
+- Residual risks / follow-ups:
+  - GitHub CI must rerun after push to confirm remote environment.
+  - Local Android build still needs workload availability if reviewer requires local compile evidence.
+
+### Post-EXEC Review Addendum 2026-06-18: subagent defect fixes after rebase
+
+- Статус: PASS locally; GitHub CI must rerun after push.
+- Supersedes: previous central-review addendum for final local evidence on the current rebased branch.
+- Scope reviewed: approved spec, `git status --short`, diff after rebase on `origin/main`, Ohm architecture findings, Mendel test/release findings, failed GitHub `Unlimotion Tests` evidence on PR #265, targeted TUnit/UI suites, full serial TUnit log, Browser/Android platform builds and whitespace diff.
+- Decision: no human approval is required before push. The only approval-sensitive option is local Android validation: if local Android compile evidence is mandatory, the SDK environment must install missing `wasm-tools`; otherwise use CI Android build as authoritative evidence.
+- Review passes:
+  - Scope/Evidence pass: inspected subagent findings, current PR failure, affected production diffs and test coverage; no unrelated files intentionally included.
+  - Contract pass: active source switching now builds the next runtime before mutating persisted/active state; server error routing is bound to actual active storage; default local file commands resolve the configured default source; MainControl move-to-path no longer constructs `FileStorage` directly.
+  - Adversarial risk pass: failed source activation leaves the previous runtime alive; detached move destination uses a non-active file storage with watcher disabled; completed/archived projections refresh when status-history dates change after projection activation.
+  - Fix and re-review: after fixes, build, affected source/runtime, VM, settings, backup and UI/headless suites were rerun; full serial suite was rerun from background log and passed.
+  - Stop decision: PASS; targeted and full local validation are green. Remote CI must be checked after push.
+- Evidence inspected:
+  - GitHub `Unlimotion Tests` failure before fixes: `CompletedAndArchivedProjections_DateFiltersCanRevealOlderStatusHistoryTasks` did not auto-refresh date-filtered completed/archived projections after in-place date mutation.
+  - `dotnet build src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false` -> passed after stopping a stale `Unlimotion.Test` process that held the output DLL.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/TaskSourceManagerTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 12/12.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainWindowViewModelTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 96/96.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/SettingsViewModelTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 69/69.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/BackupViaGitServiceTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 53/53.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/SingleViewStartupUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 4/4.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainControlTaskStatusIconUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 20/20.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainControlTaskCardLayoutUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 19/19.
+  - `dotnet test src\Unlimotion.Test\Unlimotion.Test.csproj -c Debug --no-build --no-restore -- --treenode-filter "/*/*/MainControlTreeCommandsUiTests/*" --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` -> 43/43.
+  - Full serial `dotnet test ... -- --maximum-parallel-tests 1 --output Detailed --show-stdout Failed --show-stderr Failed` via `artifacts\validation\full-test-20260618-160649.out.log` -> 549/549.
+  - `dotnet build src\Unlimotion.Browser\Unlimotion.Browser.csproj -c Debug -p:UseSharedCompilation=false` -> passed.
+  - `git diff --check` -> passed, CRLF warnings only.
+  - `dotnet build src\Unlimotion.Android\Unlimotion.Android.csproj -c Debug -p:UseSharedCompilation=false` -> blocked before compile by `NETSDK1147`, missing workload `wasm-tools`.
+- Depth checklist:
+  - Scope drift / unrelated changes: no unrelated product behavior intentionally added; changes stay in source runtime, app command routing, VM projections, storage factory contracts and focused tests.
+  - Acceptance criteria: source runtime isolation, active-source survival on activation failure, non-static MainControl move routing, source-scoped server error routing and legacy/default file compatibility are covered.
+  - Validation evidence: targeted unit/service/UI/headless suites and full serial run are green locally after the final `ConfiguredSources` contract addition and paste-outline autosave fix.
+  - Unsupported claims: no claim that Android local build or GitHub CI are green until environment/remote checks confirm them.
+  - Regression / edge case: detached file storage disables watchers and does not replace active source; default file commands read configured descriptors, not only loaded runtimes.
+  - Comments/docs/changelog: spec and PR validation evidence updated; no changelog needed for internal refactor.
+  - Hidden contract change: `ITaskSourceManager.ConfiguredSources` exposes saved descriptors read-only so app commands can resolve the default local file source without activating it.
+  - Manual-review challenge: the largest residual concern is direct `new FileStorage` in App migration/backup/resave commands; they are still intentional detached file operations, now pointed at the configured default local source rather than the active/legacy path. A second challenge is whether paste-outline autosave suppression hides user edits; it is limited to initial task creation before the explicit repository update.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | source lifecycle | `ActivateSourceAsync` disconnected/replaced the current runtime before the new runtime was known to build. | Build candidate runtime against cloned settings, then swap active state and persist only after success. | fixed |
+| MEDIUM | server error routing | `MainWindowViewModel.Connect` used legacy `Settings.IsServerMode` instead of the actual active storage. | Subscribe to `OnConnectionError` on the connected active storage and dispose the handler with the connection. | fixed |
+| MEDIUM | default file commands | App migration/backup/resave commands resolved local file storage from legacy `TaskStorage.Path`. | Resolve the configured `default` file source descriptor, with legacy fallback only for compatibility. | fixed |
+| MEDIUM | command routing | `MainControl.MoveToPath` constructed `FileStorage` directly, bypassing source runtime abstractions. | Route through `TaskMoveService` and `ITaskStorageFactory.CreateDetachedFileStorage` with watcher disabled. | fixed |
+| MEDIUM | projection refresh / CI | Completed/archived projection date filters did not auto-refresh when status-history date properties changed after projection activation. | Add `AutoRefreshOnObservable` for `CompletedDateTime` and `ArchiveDateTime`, and update regression coverage. | fixed |
+| MEDIUM | validation / paste outline | Full serial validation exposed paste-outline autosave race and stale UI wrapper setup in tree-command tests. | Suppress VM autosave during initial paste-outline task creation and make UI setup wait for fresh repository/wrapper state. | fixed |
+| LOW | PR review hygiene | Old review threads could remain unresolved after implementation changed. | Re-check unresolved PR threads after push and resolve/reply only when the final diff addresses them. | pending remote follow-up |
+
+- Fixed before final report: source activation transaction, active-storage error routing, configured default local file resolver, detached move service, date-filter projection refresh, paste-outline autosave suppression and related tests.
+- Checks rerun: build, affected targeted suites, full serial, Browser build and diff check. GitHub CI is required after push.
+- Validation evidence: local full serial run is green on the current rebase after final contract and paste-outline fixes.
+- Unrelated changes: none intentionally included.
+- Needs human: only if local Android compile evidence is mandatory before push; otherwise no blocking decision remains.
+- Residual risks / follow-ups: GitHub CI must rerun after push; local Android workload remains unavailable in this SDK environment.
+
+## Approval
+Ожидается фраза: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+Заполняется инкрементально после каждого значимого блока работ. Одна строка = один завершённый значимый блок.
+
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | routing/instruction intake | 0.95 | Нет | Инвентаризировать кодовые зависимости | Нет | Нет | Central stack требует QUEST SPEC-first для архитектурного рефакторинга. | `C:\Users\Kibnet\.codex\agents\AGENTS.md`, `AGENTS.override.md` |
+| SPEC | code audit | 0.9 | Нет | Сформировать TO-BE дизайн | Нет | Нет | Найдены source-blocking static/single-current зависимости в startup, factory, VM и controls. | `src/Unlimotion/App.axaml.cs`, `src/Unlimotion/Services/TaskStorageFactory.cs`, `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs`, `src/Unlimotion/Views/MainControl.axaml.cs`, `src/Unlimotion/Views/GraphControl.axaml.cs` |
+| SPEC | spec authoring | 0.9 | Нет | Запросить подтверждение спеки | Да | Подготовлено обращение к пользователю | Спека фиксирует refactor-only границы, staged rollout, migration и tests без code changes до approval. | `specs/2026-06-16-client-multi-source-refactor.md` |
+| SPEC | review fix | 0.93 | Нет | Запросить подтверждение обновленной спеки | Да | Пользователь попросил внести исправления после review | Исправлены auth-модель server source, UI-test контракт, stage gates и архитектурные развилки. | `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | approval intake | 0.95 | Нет | Начать stage 1 implementation | Нет | Пользователь подтвердил спеки фразой `Спеку подтверждаю` | Переход в EXEC разрешен QUEST-контрактом, можно менять код в границах спеки. | `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | source runtime implementation | 0.9 | Нет | Убрать VM/UI static fallbacks | Нет | Нет | Добавлены `TaskSourcesSettings`, `ITaskSourceManager`, stateless builder, source runtime/context и source-scoped server auth. | `src/Unlimotion.ViewModel/TaskStorageSettings.cs`, `src/Unlimotion/Services/TaskSourceManager.cs`, `src/Unlimotion/Services/TaskStorageBuilder.cs`, `src/Unlimotion/ServerStorage.cs`, `src/Unlimotion/UnifiedTaskStorage.cs` |
+| EXEC | static dependency cleanup | 0.88 | Нет | Запустить targeted UI/backend tests | Нет | Нет | Удалены VM/control static fallbacks и platform static hooks для storage default, Android prepare и backup path resolver. | `src/Unlimotion.ViewModel/TaskItemViewModel.cs`, `src/Unlimotion/Views/GraphControl.axaml.cs`, `src/Unlimotion/Views/MainControl.axaml.cs`, `src/Unlimotion/App.axaml.cs`, `src/Unlimotion.Desktop/Program.cs`, `src/Unlimotion.Android/MainActivity.cs`, `src/Unlimotion/Services/BackupViaGitService.cs` |
+| EXEC | validation | 0.95 | Нет | Финальный отчет | Нет | Нет | Сборка, targeted suites и полный serial TUnit run прошли; residual follow-ups зафиксированы в Post-EXEC Review. | `src/Unlimotion.Test/TaskSourceManagerTests.cs`, `src/Unlimotion.Test/RoadmapGraphUiTests.cs`, `src/Unlimotion.Test/MainScreenLoadingUiTests.cs`, `src/Unlimotion.Test/SingleViewStartupUiTests.cs`, `tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs` |
+| EXEC | review findings fix | 0.9 | Нужно повторить affected suites | Запустить связанные проверки и финальный review-pass | Нет | Пользователь попросил исправить findings после отдельного review | Исправлены startup activation persisted active source, same-id source replacement disconnect и whitespace fallback для прямых `FileStorage` call sites; `TaskSourceManagerTests` расширен до 7/7 и прошел. | `src/Unlimotion/Services/TaskSourceManager.cs`, `src/Unlimotion/Services/TaskSourceRuntime.cs`, `src/Unlimotion/Services/TaskStorageFactory.cs`, `src/Unlimotion/App.axaml.cs`, `src/Unlimotion.Test/TaskSourceManagerTests.cs` |
+| EXEC | review-fix validation | 0.88 | Full serial run имеет order-dependent/headless caveat | Финальный отчет пользователю | Нет | Нет | Build и affected targeted suites прошли; full serial дал 532/534, оба failure прошли изолированно и на уровне классов, caveat зафиксирован в Post-EXEC addendum. | `src/Unlimotion/Services/TaskSourceManager.cs`, `src/Unlimotion/App.axaml.cs`, `src/Unlimotion.Test/TaskSourceManagerTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | targeted/full validation refresh | 0.94 | Нужно дождаться GitHub CI после push | Обновить PR branch и отследить проверки | Нет | Пользователь попросил targeted/full validation и post-EXEC review | Зафиксированы и исправлены Avalonia.Headless teardown NRE в двух observed тестах; targeted classes и full serial 538/538 прошли, post-EXEC review обновлен. | `src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs`, `src/Unlimotion.Test/SingleViewStartupUiTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | CI/full validation stabilization | 0.95 | Нужно дождаться GitHub CI после push | Amend commit, force-push branch, проверить GitHub checks | Нет | Нет | После повторных full-run failures расширен test-only safe-dispose wrapper на `await using` headless UI sessions и стабилизированы status/projection/tree-command waits; full serial 538/538 прошел. | `src/Unlimotion.Test/HeadlessSessionExtensions.cs`, `src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs`, `src/Unlimotion.Test/MainWindowViewModelTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | rebased targeted/full validation | 0.96 | Нужно дождаться GitHub CI после push | Amend commit, force-push branch, проверить GitHub checks | Нет | Пользователь запросил targeted/full validation и post-EXEC review | После rebase на актуальный `origin/main` исправлены оставшиеся status/tree full-run failures и multi-root paste destination refresh; targeted suites и full serial 541/541 прошли. | `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | GitHub CI projection and full-run fix | 0.96 | Нужно дождаться GitHub CI после push | Amend commit, force-push branch, проверить GitHub checks | Нет | Пользователь запросил targeted/full validation и post-EXEC review | Исправлен remote `All tests` projection failure, стабилизирован emoji all-toggle UI path и tree outline setup; targeted methods, full serial 541/541 и diff check прошли. | `src/Unlimotion/Views/EmojiFilterMultiSelectSearchBox.axaml.cs`, `src/Unlimotion.Test/MainWindowViewModelTests.cs`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | GitHub CI paste-outline relation lookup fix | 0.96 | Нужно дождаться GitHub CI после push | Amend commit, force-push branch, проверить GitHub checks | Нет | Нет | Remote `All tests` на `f92b03a` упал из-за stale VM relation assertions в paste-outline тесте; тест переведен на fresh repository lookup, targeted paste-outline 5/5 и full serial 541/541 прошли. | `src/Unlimotion.Test/MainWindowViewModelTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | central review defects fix | 0.96 | Android local build needs missing `wasm-tools` workload if required | Push updated PR branch and wait for CI | Нет | Пользователь попросил исправить все review defects | Убраны production current-storage/current-watcher seams, runtime state перенесен в App instance, исправлены source auth/switch/disconnect, backup active path, Browser/Android composition и UI/headless coverage; targeted suites, Browser build, full serial 545/545 и diff check прошли. | `src/Unlimotion/App.axaml.cs`, `src/Unlimotion/Services/TaskSourceManager.cs`, `src/Unlimotion/Services/TaskSourceRuntime.cs`, `src/Unlimotion/Services/TaskSourceSettingsAdapter.cs`, `src/Unlimotion/ServerStorage.cs`, `src/Unlimotion/Services/BackupViaGitService.cs`, `src/Unlimotion.Browser/Program.cs`, `src/Unlimotion.Android/MainActivity.cs`, `src/Unlimotion.Test/TaskSourceManagerTests.cs`, `src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs`, `src/Unlimotion.Test/SingleViewStartupUiTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | subagent defect fixes after rebase | 0.96 | GitHub CI must rerun after push; local Android needs missing `wasm-tools` workload if required | Final targeted/full validation, amend commit, push, update PR and check CI | Нет | Пользователь попросил исправить все найденные defects | Исправлены транзакционность source activation, error routing по actual active storage, configured default file path для detached commands, `MainControl` move через service/factory и projection auto-refresh для completed/archived dates. | `src/Unlimotion/App.axaml.cs`, `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion/Services/TaskSourceManager.cs`, `src/Unlimotion/Services/TaskSourceRuntime.cs`, `src/Unlimotion/Services/TaskStorageBuilder.cs`, `src/Unlimotion/Services/TaskStorageFactory.cs`, `src/Unlimotion/Services/ITaskStorageFactory.cs`, `src/Unlimotion/Services/TaskMoveService.cs`, `src/Unlimotion/Views/MainControl.axaml.cs`, `src/Unlimotion.Test/TaskSourceManagerTests.cs`, `src/Unlimotion.Test/MainWindowViewModelTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |
+| EXEC | full validation paste-outline stabilization | 0.95 | GitHub CI must rerun after push | Amend commit, force-push branch, update PR and check CI | Нет | Нет | Full serial 547/549 выявил paste-outline autosave race и stale wrapper setup; production paste creation подавляет autosave до explicit update, UI-тест ждёт fresh repository/wrapper state, full serial 549/549 прошёл. | `src/Unlimotion.ViewModel/MainWindowViewModel.cs`, `src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs`, `specs/2026-06-16-client-multi-source-refactor.md` |

--- a/src/Unlimotion.Android/MainActivity.cs
+++ b/src/Unlimotion.Android/MainActivity.cs
@@ -153,7 +153,6 @@ public class MainActivity : AvaloniaMainActivity
 
             App.ConfigureUpdateService(new AndroidApplicationUpdateService(this));
             Dialogs.PlatformOpenFolderDialogAsync = ShowOpenDocumentTreeAsync;
-            TaskStorageFactory.PrepareFileStoragePathAsync = EnsureFileStoragePathAccessAsync;
         }
         catch (Exception ex)
         {
@@ -168,6 +167,11 @@ public class MainActivity : AvaloniaMainActivity
         {
             if (_coreAppServicesConfigured && !string.IsNullOrWhiteSpace(_configuredDataDir))
             {
+                if (context is MainActivity mainActivity)
+                {
+                    App.ConfigureFileStoragePathPreparation(mainActivity.EnsureFileStoragePathAccessAsync);
+                }
+
                 return _configuredDataDir;
             }
 
@@ -175,9 +179,6 @@ public class MainActivity : AvaloniaMainActivity
             Directory.CreateDirectory(dataDir);
 
             var tasksPath = Path.Combine(dataDir, TasksFolderName);
-            App.DefaultStoragePath = tasksPath;
-            TaskStorageFactory.DefaultStoragePath = tasksPath;
-            BackupViaGitService.GetAbsolutePath = path => Path.Combine(dataDir, path);
 
             EnsureGitSafeDirectory(dataDir, dataDir);
             EnsureGitSslCertBundle(context, dataDir);
@@ -189,10 +190,18 @@ public class MainActivity : AvaloniaMainActivity
                 stream.Write(@"{}");
             }
 
-            App.Init(configPath);
+            App.Init(
+                configPath,
+                new UnlimotionClientOptions
+                {
+                    DefaultTaskStoragePath = tasksPath,
+                    GetAbsolutePath = path => Path.Combine(dataDir, path),
+                    PrepareFileStoragePathAsync = context is MainActivity activity
+                        ? activity.EnsureFileStoragePathAccessAsync
+                        : null
+                });
 
-            BackupViaGitService.GetAbsolutePath = path => Path.Combine(dataDir, path);
-            EnsureGitSafeDirectory(dataDir, TaskStorageFactory.DefaultStoragePath);
+            EnsureGitSafeDirectory(dataDir, tasksPath);
 
             _configuredDataDir = dataDir;
             _coreAppServicesConfigured = true;

--- a/src/Unlimotion.Browser/Program.cs
+++ b/src/Unlimotion.Browser/Program.cs
@@ -1,16 +1,10 @@
 ﻿using System;
 using System.IO;
 using System.Threading.Tasks;
-using AutoMapper;
 using Avalonia;
 using Avalonia.Browser;
-using Microsoft.Extensions.Configuration;
 using ReactiveUI.Avalonia;
 using Unlimotion;
-using Unlimotion.Services;
-using Unlimotion.ViewModel;
-using Unlimotion.Views;
-using WritableJsonConfiguration;
 
 internal sealed class Program
 {
@@ -21,7 +15,7 @@ internal sealed class Program
 
     public static AppBuilder BuildAvaloniaApp()
     {
-        TaskStorageFactory.DefaultStoragePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Tasks");
+        var defaultTaskStoragePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Tasks");
 
         var settingsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Settings.json");
         if (!File.Exists(settingsPath))
@@ -30,45 +24,13 @@ internal sealed class Program
             stream.Write(@"{}");
             stream.Close();
         }
-        
-        // Create configuration
-        IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(settingsPath);
-        
-        // Create mapper
-        var mapper = AppModelMapping.ConfigureMapping();
 
-        // Create dialogs
-        var dialogs = new Dialogs();
-
-        // Create notification services
-        var notificationMessageManager = new AppToastNotificationManager();
-        var notificationManager = new NotificationManagerWrapper(notificationMessageManager);
-
-        // Create storage factory
-        var storageFactory = new TaskStorageFactory(configuration, mapper, notificationManager);
-
-        // Get storage settings
-        var taskStorageSettings = configuration.Get<TaskStorageSettings>("TaskStorage");
-        if (taskStorageSettings == null)
-        {
-            taskStorageSettings = new TaskStorageSettings();
-            configuration.Set("TaskStorage", taskStorageSettings);
-        }
-        var isServerMode = taskStorageSettings.IsServerMode;
-        
-        // Create storage
-        if (isServerMode)
-        {
-            storageFactory.CreateServerStorage(taskStorageSettings.URL);
-        }
-        else
-        {
-            storageFactory.CreateFileStorage(taskStorageSettings.Path);
-        }
-
-        // Set up static dependencies
-        TaskItemViewModel.NotificationManagerInstance = notificationManager;
-        MainControl.DialogsInstance = dialogs;
+        App.Init(
+            settingsPath,
+            new UnlimotionClientOptions
+            {
+                DefaultTaskStoragePath = defaultTaskStoragePath
+            });
 
         return AppBuilder.Configure<App>();
     }

--- a/src/Unlimotion.Desktop/Program.cs
+++ b/src/Unlimotion.Desktop/Program.cs
@@ -26,11 +26,10 @@ namespace Unlimotion.Desktop
             VelopackApp.Build().Run();
             App.ConfigureUpdateService(new VelopackApplicationUpdateService());
 
-            //Задание дефолтного пути для хранения задач
 #if DEBUG
-            TaskStorageFactory.DefaultStoragePath = TasksFolderName;
+            var defaultTaskStoragePath = TasksFolderName;
 #else
-            TaskStorageFactory.DefaultStoragePath = Path.GetDirectoryName(DefaultConfigName).CombineWith(TasksFolderName);
+            var defaultTaskStoragePath = Path.GetDirectoryName(DefaultConfigName).CombineWith(TasksFolderName);
 #endif
 
             //Получение адреса конфига
@@ -60,9 +59,13 @@ namespace Unlimotion.Desktop
 #endif
             }
 
-            BackupViaGitService.GetAbsolutePath = path => new DirectoryInfo(path).FullName;
-
-            App.Init(configPath);
+            App.Init(
+                configPath,
+                new UnlimotionClientOptions
+                {
+                    DefaultTaskStoragePath = defaultTaskStoragePath,
+                    GetAbsolutePath = path => new DirectoryInfo(path).FullName
+                });
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
 

--- a/src/Unlimotion.Test/BackupViaGitServiceTests.cs
+++ b/src/Unlimotion.Test/BackupViaGitServiceTests.cs
@@ -55,6 +55,25 @@ public sealed class BackupViaGitServiceTests : IDisposable
     }
 
     [Test]
+    public async System.Threading.Tasks.Task PreviewConnectRepository_UsesActiveFileSourceBeforeLegacyTaskStoragePath()
+    {
+        var activePath = CreateLocalTaskFolder();
+        var legacyPath = Path.Combine(_rootPath, "LegacyTasks");
+        Directory.CreateDirectory(legacyPath);
+        var remotePath = CreateBareRemote();
+        var service = CreateService(
+            legacyPath,
+            remotePath,
+            storageFactory: new CurrentFileStorageFactory(activePath));
+
+        var preview = service.PreviewConnectRepository();
+
+        await Assert.That(preview.RepositoryPath).IsEqualTo(activePath);
+        await Assert.That(preview.LocalFolderHasContent).IsTrue();
+        await Assert.That(preview.Action).IsEqualTo(BackupRepositoryConnectAction.InitializeLocalAndPush);
+    }
+
+    [Test]
     public async System.Threading.Tasks.Task PreviewConnectRepository_RequiresConfirmationForNonEmptyRemoteAndNonEmptyLocalFolder()
     {
         var localPath = CreateLocalTaskFolder();
@@ -417,7 +436,7 @@ public sealed class BackupViaGitServiceTests : IDisposable
     }
 
     [Test]
-    public async System.Threading.Tasks.Task PullExistingRepository_DoesNotNotifyCurrentStorageWatcher_WhenRepositoryChanges()
+    public async System.Threading.Tasks.Task PullExistingRepository_DoesNotNotifyActiveStorageWatcher_WhenRepositoryChanges()
     {
         var remotePath = CreateBareRemoteWithCommit("task", "base content");
         var localPath = CloneRemoteToLocalMain(remotePath);
@@ -433,7 +452,7 @@ public sealed class BackupViaGitServiceTests : IDisposable
     }
 
     [Test]
-    public async System.Threading.Tasks.Task Pull_NotifiesCurrentStorageWatcher_WhenRepositoryChanges()
+    public async System.Threading.Tasks.Task Pull_NotifiesActiveStorageWatcher_WhenRepositoryChanges()
     {
         var remotePath = CreateBareRemoteWithCommit("task", "base content");
         var localPath = CloneRemoteToLocalMain(remotePath);
@@ -1414,9 +1433,10 @@ public sealed class BackupViaGitServiceTests : IDisposable
 
     private sealed class FakeTaskStorageFactory(IDatabaseWatcher? currentWatcher) : ITaskStorageFactory
     {
-        public ITaskStorage? CurrentStorage => null;
-        public IDatabaseWatcher? CurrentWatcher { get; } = currentWatcher;
+        public ITaskSourceManager SourceManager { get; } = new FakeTaskSourceManager(() => null, () => currentWatcher);
+        public ITaskStorage CreateConfiguredStorage() => throw new NotSupportedException();
         public ITaskStorage CreateFileStorage(string? path) => throw new NotSupportedException();
+        public ITaskStorage CreateDetachedFileStorage(string? path) => throw new NotSupportedException();
         public ITaskStorage CreateServerStorage(string? url) => throw new NotSupportedException();
         public void SwitchStorage(bool isServerMode, IConfiguration configuration) => throw new NotSupportedException();
     }
@@ -1429,11 +1449,13 @@ public sealed class BackupViaGitServiceTests : IDisposable
         {
             var fileStorage = new FileStorage(currentPath, watcher: false);
             _storage = new UnifiedTaskStorage(new TaskTreeManager(fileStorage));
+            SourceManager = new FakeTaskSourceManager(() => _storage);
         }
 
-        public ITaskStorage? CurrentStorage => _storage;
-        public IDatabaseWatcher? CurrentWatcher => null;
+        public ITaskSourceManager SourceManager { get; }
+        public ITaskStorage CreateConfiguredStorage() => throw new NotSupportedException();
         public ITaskStorage CreateFileStorage(string? path) => throw new NotSupportedException();
+        public ITaskStorage CreateDetachedFileStorage(string? path) => throw new NotSupportedException();
         public ITaskStorage CreateServerStorage(string? url) => throw new NotSupportedException();
         public void SwitchStorage(bool isServerMode, IConfiguration configuration) => throw new NotSupportedException();
         public void Dispose() => (_storage as IDisposable)?.Dispose();

--- a/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
+++ b/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
@@ -19,7 +19,7 @@ public class BreadcrumbEmojiUiTests
     [Test]
     public async Task Breadcrumbs_ShouldRenderEmojiRunsWithEmojiFont()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/FakeTaskSourceManager.cs
+++ b/src/Unlimotion.Test/FakeTaskSourceManager.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Unlimotion.Services;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Test;
+
+internal sealed class FakeTaskSourceManager(
+    Func<ITaskStorage?> activeStorageProvider,
+    Func<IDatabaseWatcher?>? activeWatcherProvider = null,
+    Func<bool, IConfiguration, Task>? switchStorageAsync = null)
+    : ITaskSourceManager
+{
+    public IReadOnlyList<TaskSourceRuntime> Sources => [];
+    public IReadOnlyList<TaskSourceDescriptor> ConfiguredSources => [];
+    public TaskSourceRuntime? ActiveSource => null;
+    public ITaskStorage? ActiveStorage => activeStorageProvider();
+    public IDatabaseWatcher? ActiveWatcher => activeWatcherProvider?.Invoke();
+
+    public TaskSourceRuntime ActivateConfiguredSource() =>
+        throw new NotSupportedException();
+
+    public TaskSourceRuntime ActivateSource(
+        TaskSourceDescriptor descriptor,
+        TaskSourceServerSettings? serverSettings = null) =>
+        throw new NotSupportedException();
+
+    public Task<TaskSourceRuntime> ActivateConfiguredSourceAsync() =>
+        throw new NotSupportedException();
+
+    public Task<TaskSourceRuntime> ActivateSourceAsync(
+        TaskSourceDescriptor descriptor,
+        TaskSourceServerSettings? serverSettings = null) =>
+        throw new NotSupportedException();
+
+    public void SwitchStorage(bool isServerMode, IConfiguration configuration)
+    {
+        SwitchStorageAsync(isServerMode, configuration).GetAwaiter().GetResult();
+    }
+
+    public Task SwitchStorageAsync(bool isServerMode, IConfiguration configuration) =>
+        switchStorageAsync?.Invoke(isServerMode, configuration) ?? throw new NotSupportedException();
+}

--- a/src/Unlimotion.Test/HeadlessSessionExtensions.cs
+++ b/src/Unlimotion.Test/HeadlessSessionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -50,8 +51,53 @@ public static class HeadlessSessionExtensions
             await session.DisposeAsync();
         }
         catch (NullReferenceException ex)
-            when (ex.StackTrace?.Contains(HeadlessDisposeStackFrame, StringComparison.Ordinal) == true)
+            when (IsKnownHeadlessDisposeNullReference(ex))
         {
         }
+    }
+
+    private static bool IsKnownHeadlessDisposeNullReference(Exception ex)
+    {
+        var firstFrame = ex.StackTrace?
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .FirstOrDefault();
+        return firstFrame?.Contains(HeadlessDisposeStackFrame, StringComparison.Ordinal) == true;
+    }
+}
+
+public sealed class SafeHeadlessUnitTestSession : IAsyncDisposable
+{
+    private readonly HeadlessUnitTestSession _session;
+
+    private SafeHeadlessUnitTestSession(HeadlessUnitTestSession session)
+    {
+        _session = session;
+    }
+
+    public static SafeHeadlessUnitTestSession StartNew(Type appType)
+    {
+        return new SafeHeadlessUnitTestSession(HeadlessUnitTestSession.StartNew(appType));
+    }
+
+    public Task<TResult> Dispatch<TResult>(
+        Func<Task<TResult>> action,
+        CancellationToken cancellationToken)
+    {
+        return _session.Dispatch(action, cancellationToken);
+    }
+
+    public Task Dispatch(Func<Task> action, CancellationToken cancellationToken)
+    {
+        return _session.Dispatch(action, cancellationToken);
+    }
+
+    public Task DispatchAsync(Func<Task> action, CancellationToken cancellationToken)
+    {
+        return _session.DispatchAsync(action, cancellationToken);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return _session.DisposeIgnoringHeadlessTeardownNullReferenceAsync();
     }
 }

--- a/src/Unlimotion.Test/KeyboardAwareScrollViewerUiTests.cs
+++ b/src/Unlimotion.Test/KeyboardAwareScrollViewerUiTests.cs
@@ -18,7 +18,7 @@ public class KeyboardAwareScrollViewerUiTests
     [Test]
     public async Task FocusedTextBoxCoveredByKeyboardInset_ScrollsIntoVisibleArea()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             const double keyboardInset = 190;

--- a/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
+++ b/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
@@ -20,7 +20,7 @@ public class MainControlAvailabilityUiTests
     [Test]
     public async Task LastOpenedTaskTitle_ShouldBeDimmed_WhenTaskCannotBeCompleted()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -73,7 +73,7 @@ public class MainControlAvailabilityUiTests
     [Test]
     public async Task DescendantCompletedStatusOption_ShouldBeDisabled_WhenAncestorHasIncompleteBlocker()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
+++ b/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
@@ -27,7 +27,7 @@ public class MainControlDateQuickSelectionUiTests
             LocalizationService.Current = localization;
             localization.SetLanguage(LocalizationService.RussianLanguage);
 
-            await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
             await session.DispatchAsync(async () =>
             {
                 MainWindowViewModelFixture? fixture = null;

--- a/src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs
@@ -41,7 +41,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task MainControlFilterToolbar_NarrowViewport_UsesCompactPrimaryActions()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -156,7 +156,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task RoadmapFilterToolbar_NarrowViewport_UsesCompactPrimaryActions()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -203,7 +203,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task RoadmapFilterToolbar_StandaloneNarrowViewport_ShrinksNestedSearchControl()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             Window? window = null;
@@ -235,7 +235,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task Toolbar_EmojiFilters_SummaryChromeDoesNotCoverOrShiftTokens()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -294,7 +294,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task Toolbar_EmojiFilters_OpenFullListThenSearchAndToggleWithoutClosing()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -399,7 +399,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task Toolbar_EmojiFilters_AllItemTogglesEveryEmojiFilter()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -459,7 +459,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task Toolbar_EmojiFilters_SummaryShowsSelectedEmojiAndOverflowInListOrder()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -566,7 +566,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task Toolbar_EmojiFilters_RespondsToLargeFontResources()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -612,7 +612,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task Toolbar_EmojiFilters_KeyboardFlowOpensSearchTogglesAndClosesPopup()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -682,7 +682,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task Toolbar_EmojiFilters_PopupStaysVisibleInNarrowViewport()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -733,7 +733,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task RoadmapToolbar_EmojiFilters_UsesSearchableMultiSelectDropdown()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -772,7 +772,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task MainControlFilterToolbar_WideViewport_KeepsSearchBesideFilters()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -810,7 +810,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task MainControlFilterToolbar_DetailsPaneShrink_ReflowsToNarrowLayout()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -915,7 +915,7 @@ public class MainControlFilterToolbarResponsiveUiTests
     [Test]
     public async Task FilterFlyouts_CompactViewport_ConstrainPopupSizeAndScrollVertically()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/MainControlNewTaskDeadlineUiTests.cs
+++ b/src/Unlimotion.Test/MainControlNewTaskDeadlineUiTests.cs
@@ -74,7 +74,7 @@ public class MainControlNewTaskDeadlineUiTests
     [Test]
     public async Task NewSiblingTask_ShouldNotCopyPlannedDates_WhenCreatedByHotkeyFromFocusedDatePicker()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -143,7 +143,7 @@ public class MainControlNewTaskDeadlineUiTests
     [Test]
     public async Task NewRootTask_ShouldNotCopyPlannedDuration_FromFocusedPreviousTaskEditor()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -199,7 +199,7 @@ public class MainControlNewTaskDeadlineUiTests
     [Test]
     public async Task PlannedDurationEditor_ShouldCommitNewText_AfterFocusedDataContextSwitch()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             Window? window = null;
@@ -248,7 +248,7 @@ public class MainControlNewTaskDeadlineUiTests
         bool setDatesThroughPicker = false,
         bool selectedTaskCreatedInFuture = false)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
+++ b/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
@@ -31,7 +31,7 @@ public class MainControlRelationPickerUiTests
         string addButtonAutomationId,
         string inputAutomationId)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -79,7 +79,7 @@ public class MainControlRelationPickerUiTests
     [Test]
     public async Task TaskCardRelationEditor_AddParentFromCard_UpdatesStorage()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
+++ b/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
@@ -61,7 +61,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task ResetFiltersButton_IsAvailableOnTaskTabs()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -92,7 +92,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task StatusFilterComboBox_IsAvailableOnEveryTaskTab()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -274,7 +274,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task ResetFiltersButton_OnStatusFilteredTabs_ResetsStatusFilters()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -332,7 +332,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task ResetFiltersButton_AsksConfirmation_AndCancelKeepsFilters()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -378,7 +378,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task AllTasksResetFilters_AfterConfirmation_ResetsOnlyAllTasksFiltersToDefaults()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -443,7 +443,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task LastCreatedResetFilters_AfterConfirmation_ResetsCurrentDateFilterToDefault()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -507,7 +507,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task RoadmapResetFilters_WhenCompletionFiltersAreVisible_DoesNotResetHiddenWantedFilter()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -572,7 +572,7 @@ public class MainControlResetFiltersUiTests
     [Test]
     public async Task RoadmapResetFilters_WhenWantedFilterIsVisible_DoesNotResetHiddenCompletionFilters()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/MainControlTabsOverflowUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTabsOverflowUiTests.cs
@@ -40,7 +40,7 @@ public class MainControlTabsOverflowUiTests
     [Test]
     public async Task MainTabs_DesktopWidth_ShowsAllTabsWithoutOverflow()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -69,7 +69,7 @@ public class MainControlTabsOverflowUiTests
     [Test]
     public async Task MainTabs_DesktopWidthWithOpenDetailsPane_UsesSplitViewContentWidthForOverflow()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -111,7 +111,7 @@ public class MainControlTabsOverflowUiTests
     [Test]
     public async Task MainTabs_IntermediateWidth_MovesInactiveTabsToOverflowAndKeepsCurrentVisible()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -151,7 +151,7 @@ public class MainControlTabsOverflowUiTests
     [Test]
     public async Task MainTabs_PhoneWidth_KeepsCurrentTabVisibleWithOverflowButton()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -187,7 +187,7 @@ public class MainControlTabsOverflowUiTests
     [Test]
     public async Task MainTabs_PhoneWidth_KeepsLongCurrentTabVisibleWithOverflowButton()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -223,7 +223,7 @@ public class MainControlTabsOverflowUiTests
     [Test]
     public async Task MainTabs_OverflowMenu_SelectsHiddenTabAndMakesItVisible()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -264,7 +264,7 @@ public class MainControlTabsOverflowUiTests
             LocalizationService.Current = localization;
             localization.SetLanguage(LocalizationService.EnglishLanguage);
 
-            await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
             await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
@@ -315,7 +315,7 @@ public class MainControlTabsOverflowUiTests
     [Test]
     public async Task MainTabs_ResizeFromPhoneToDesktop_RestoresAllTabs()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs
@@ -75,7 +75,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_DesktopLayout_ExposesSectionsAndKeyControls()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -147,7 +147,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_PlanningDatePickers_UseDurationFieldPadding()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -185,7 +185,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_DarkTheme_UsesThemeAwareAccentButtonChrome()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -278,7 +278,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_IntermediateDesktopWidthRepeaterLayout_DoesNotOverlap()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -313,7 +313,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_IntermediateDesktopWidthRepeaterLayout_WithLargeFontDoesNotOverlap()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -352,7 +352,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_CompletedTask_DisablesCompletionCriteriaEditing()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -397,7 +397,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_CompletionCriterionRow_UsesBorderlessCompactEditing()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -445,7 +445,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_AddCompletionCriterion_FocusesNewCriterionTextBox()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -503,7 +503,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_RemoveButtonsUseCenteredVectorIcons()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -554,7 +554,7 @@ public class MainControlTaskCardLayoutUiTests
     [Test]
     public async Task CurrentTaskCard_BackGestureFallback_OpensPaneForSingleVisibleTask()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -604,7 +604,7 @@ public class MainControlTaskCardLayoutUiTests
     [Arguments(390)]
     public async Task CurrentTaskCard_PhoneWeeklyRepeaterLayout_FillsWeekdayRow(double width)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -697,7 +697,7 @@ public class MainControlTaskCardLayoutUiTests
     [Arguments(430)]
     public async Task CurrentTaskCreateMenu_PhoneWidth_UsesTouchFriendlyMenuItems(double width)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();
@@ -728,7 +728,7 @@ public class MainControlTaskCardLayoutUiTests
     [Arguments(430)]
     public async Task CurrentTaskCard_PhoneWidthLayout_DoesNotOverflowAndKeepsRelationEditorUsable(double width)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             ResetTaskCardLayoutSharedState();

--- a/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
@@ -33,7 +33,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskTreeStatusControl_UsesCompactVectorIconInsteadOfTextGlyph()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -94,7 +94,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskTreeStatusControl_ClickOpensStatusFlyout()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -116,13 +116,10 @@ public class MainControlTaskStatusIconUiTests
 
                 var statusPicker = WaitForTaskStatusPicker(allTasksTree!);
                 var task = statusPicker.Task ?? statusPicker.DataContext as TaskItemViewModel;
-                PressControl(window, statusPicker);
-                Dispatcher.UIThread.RunJobs();
-
-                var flyout = statusPicker.Flyout as MenuFlyout;
+                var flyout = await OpenStatusFlyoutAsync(window, statusPicker);
 
                 await Assert.That(flyout).IsNotNull();
-                var menuItems = flyout!.Items.OfType<MenuItem>().ToList();
+                var menuItems = flyout.Items.OfType<MenuItem>().ToList();
                 var automationIds = menuItems
                     .Select(AutomationProperties.GetAutomationId)
                     .ToList();
@@ -143,7 +140,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task CurrentTaskCardStatusChange_UpdatesAllTasksTreeStatusIcon()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -178,9 +175,7 @@ public class MainControlTaskStatusIconUiTests
                 var currentTaskStatusPicker = WaitForAutomationControl<TaskStatusPicker>(
                     view,
                     "CurrentTaskStatusButton");
-                PressControl(window, currentTaskStatusPicker);
-                var flyout = currentTaskStatusPicker.Flyout as MenuFlyout;
-                await Assert.That(flyout).IsNotNull();
+                var flyout = await OpenStatusFlyoutAsync(window, currentTaskStatusPicker);
                 var inProgressItem = flyout!.Items
                     .OfType<MenuItem>()
                     .Single(item =>
@@ -211,7 +206,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task CurrentTaskCardCompletedStatusChange_RemovesNestedTaskFromAllTasksTreeWhenCompletedIsHidden()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -247,9 +242,7 @@ public class MainControlTaskStatusIconUiTests
                 var currentTaskStatusPicker = WaitForAutomationControl<TaskStatusPicker>(
                     view,
                     "CurrentTaskStatusButton");
-                PressControl(window, currentTaskStatusPicker);
-                var flyout = currentTaskStatusPicker.Flyout as MenuFlyout;
-                await Assert.That(flyout).IsNotNull();
+                var flyout = await OpenStatusFlyoutAsync(window, currentTaskStatusPicker);
                 var completedItem = flyout!.Items
                     .OfType<MenuItem>()
                     .Single(item =>
@@ -282,7 +275,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusPicker_MatchesStandaloneCheckBoxIndicatorSize()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var task = new TaskItemViewModel(
@@ -336,7 +329,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusPicker_DimsUnavailableTaskLikeTaskText()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var task = new TaskItemViewModel(
@@ -391,7 +384,7 @@ public class MainControlTaskStatusIconUiTests
     [Arguments("Dark")]
     public async Task TaskStatusIcon_CompletedMatchesCheckedCheckBoxIndicatorForTheme(string themeName)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var app = Application.Current ?? throw new InvalidOperationException("Application is not initialized.");
@@ -470,7 +463,7 @@ public class MainControlTaskStatusIconUiTests
     [Arguments("Dark")]
     public async Task TaskStatusIcon_UsesCheckBoxUncheckedBorderBrushForTheme(string themeName)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var app = Application.Current ?? throw new InvalidOperationException("Application is not initialized.");
@@ -525,7 +518,7 @@ public class MainControlTaskStatusIconUiTests
         string statusName,
         string expectedColor)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var status = Enum.Parse<DomainTaskStatus>(statusName);
@@ -572,7 +565,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusIcon_NotReadyBorderBrushTracksThemeChangesOnSameControl()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var app = Application.Current ?? throw new InvalidOperationException("Application is not initialized.");
@@ -683,7 +676,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusIconPreview_RendersOneVectorIconForEachLifecycleStatus()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var statuses = Enum.GetValues<DomainTaskStatus>();
@@ -733,7 +726,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task InProgressTree_DisplaysStartedDateTimeInLocalTime()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -787,7 +780,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusPickerFlyout_ExposesOnlyAvailableTransitionOptions()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var task = new TaskItemViewModel(
@@ -799,12 +792,7 @@ public class MainControlTaskStatusIconUiTests
                 },
                 new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage())),
                 () => false);
-            var buildFlyout = typeof(TaskStatusPicker).GetMethod(
-                "BuildStatusFlyout",
-                BindingFlags.NonPublic | BindingFlags.Static)
-                ?? throw new InvalidOperationException("TaskStatusPicker.BuildStatusFlyout was not found.");
-
-            var flyout = (MenuFlyout)buildFlyout.Invoke(null, [task])!;
+            var flyout = BuildStatusFlyout(task);
             var items = flyout.Items.OfType<MenuItem>().ToList();
             var availableTransitionStatuses = task.StatusOptions
                 .Where(option => option.Status != task.Status && option.IsEnabled)
@@ -838,7 +826,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusPicker_SelectingStatusOption_UpdatesTaskStatusHistory()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var storage = new InMemoryStorage();
@@ -874,11 +862,10 @@ public class MainControlTaskStatusIconUiTests
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
 
-                PressControl(window, statusPicker);
-                var flyout = statusPicker.Flyout as MenuFlyout;
+                var flyout = await OpenStatusFlyoutAsync(window, statusPicker);
 
                 await Assert.That(flyout).IsNotNull();
-                var inProgressItem = flyout!.Items
+                var inProgressItem = flyout.Items
                     .OfType<MenuItem>()
                     .Single(item =>
                         string.Equals(
@@ -921,7 +908,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusPickerFlyout_EnablesCompletedOptionAfterCriterionIsSatisfied()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var task = new TaskItemViewModel(
@@ -942,12 +929,7 @@ public class MainControlTaskStatusIconUiTests
                 },
                 new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage())),
                 () => false);
-            var buildFlyout = typeof(TaskStatusPicker).GetMethod(
-                "BuildStatusFlyout",
-                BindingFlags.NonPublic | BindingFlags.Static)
-                ?? throw new InvalidOperationException("TaskStatusPicker.BuildStatusFlyout was not found.");
-
-            var flyout = (MenuFlyout)buildFlyout.Invoke(null, [task])!;
+            var flyout = BuildStatusFlyout(task);
             var completedItem = flyout.Items
                 .OfType<MenuItem>()
                 .SingleOrDefault(item =>
@@ -963,7 +945,7 @@ public class MainControlTaskStatusIconUiTests
 
             await Assert.That(task.StatusOptions.Single(option => option.Status == DomainTaskStatus.Completed).IsEnabled)
                 .IsTrue();
-            flyout = (MenuFlyout)buildFlyout.Invoke(null, [task])!;
+            flyout = BuildStatusFlyout(task);
             completedItem = flyout.Items
                 .OfType<MenuItem>()
                 .Single(item =>
@@ -982,7 +964,7 @@ public class MainControlTaskStatusIconUiTests
     [Test]
     public async Task TaskStatusPicker_DetachedFromVisualTree_UnsubscribesFromTask()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var task = new TaskItemViewModel(
@@ -1033,20 +1015,73 @@ public class MainControlTaskStatusIconUiTests
         };
     }
 
-    private static void PressControl(Window window, Control control)
+    private static MenuFlyout BuildStatusFlyout(TaskStatusPicker statusPicker)
     {
-        var point = control.TranslatePoint(
-            new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
-            window);
-
-        if (!point.HasValue)
+        var task = statusPicker.Task ?? statusPicker.DataContext as TaskItemViewModel;
+        if (task == null)
         {
-            throw new InvalidOperationException($"Cannot translate point for control {control.GetType().Name}.");
+            throw new InvalidOperationException("Task status picker is not bound to a task.");
         }
 
-        window.MouseDown(point.Value, MouseButton.Left, RawInputModifiers.None);
+        return BuildStatusFlyout(task);
+    }
+
+    private static MenuFlyout BuildStatusFlyout(TaskItemViewModel task)
+    {
+        var buildFlyout = typeof(TaskStatusPicker).GetMethod(
+            "BuildStatusFlyout",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("TaskStatusPicker.BuildStatusFlyout was not found.");
+
+        return (MenuFlyout)buildFlyout.Invoke(null, [task])!;
+    }
+
+    private static async Task<MenuFlyout> OpenStatusFlyoutAsync(Window window, TaskStatusPicker statusPicker)
+    {
+        PressControl(window, statusPicker);
+
+        var opened = await TestHelpers.WaitUntilAsync(() =>
+        {
+            Dispatcher.UIThread.RunJobs();
+            return statusPicker.Flyout is MenuFlyout { IsOpen: true };
+        }, TimeSpan.FromSeconds(2));
+
+        if (!opened || statusPicker.Flyout is not MenuFlyout flyout)
+        {
+            throw new InvalidOperationException("Task status flyout was not opened.");
+        }
+
+        return flyout;
+    }
+
+    private static void PressControl(Window window, Control control)
+    {
+        var point = new Point(control.Bounds.Width / 2, control.Bounds.Height / 2);
+        var pointer = new Avalonia.Input.Pointer(1, PointerType.Mouse, true);
+
+        control.RaiseEvent(new PointerPressedEventArgs(
+            control,
+            pointer,
+            control,
+            point,
+            0,
+            new PointerPointProperties(
+                RawInputModifiers.LeftMouseButton,
+                PointerUpdateKind.LeftButtonPressed),
+            KeyModifiers.None,
+            1));
         Dispatcher.UIThread.RunJobs();
-        window.MouseUp(point.Value, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+        control.RaiseEvent(new PointerReleasedEventArgs(
+            control,
+            pointer,
+            control,
+            point,
+            0,
+            new PointerPointProperties(
+                RawInputModifiers.None,
+                PointerUpdateKind.LeftButtonReleased),
+            KeyModifiers.None,
+            MouseButton.Left));
         Dispatcher.UIThread.RunJobs();
     }
 
@@ -1210,7 +1245,10 @@ public class MainControlTaskStatusIconUiTests
                         AutomationProperties.GetAutomationId(candidate),
                         "TaskStatusButton",
                         StringComparison.Ordinal) &&
-                    candidate.Task is TaskItemViewModel);
+                    candidate.Task is TaskItemViewModel &&
+                    candidate.Bounds.Width > 0 &&
+                    candidate.Bounds.Height > 0 &&
+                    candidate.IsEffectivelyVisible);
 
             return statusPicker != null;
         }, TimeSpan.FromMilliseconds(timeoutMilliseconds));

--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -32,7 +32,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TaskOutlinePastePreviewDialog_LargePreview_IsScrollableAndShowsLastTask()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             Window? window = null;
@@ -83,7 +83,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_Hotkey_UsesStickyActiveTabTreeAfterFocusMoves()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -125,7 +125,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_Hotkey_IsIgnoredWhileTextInputFocused()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -169,7 +169,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_CopyTaskOutline_HotkeyAndContextMenu_Work()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -184,23 +184,47 @@ public class MainControlTreeCommandsUiTests
 
                 var parent = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
                 var child = await vm.taskRepository!.AddChild(parent!);
-                child.Title = "Outline UI copy child";
-                await vm.taskRepository.Update(child);
+                await UpdateTaskForScenarioAsync(
+                    vm.taskRepository,
+                    child,
+                    task => task.Title = "Outline UI copy child");
                 var grandchild = await vm.taskRepository.AddChild(child);
-                grandchild.Title = "Outline UI copy grandchild";
-                await vm.taskRepository.Update(grandchild);
+                await UpdateTaskForScenarioAsync(
+                    vm.taskRepository,
+                    grandchild,
+                    task => task.Title = "Outline UI copy grandchild");
+                var childId = child.Id;
+                var grandchildId = grandchild.Id;
 
+                await Assert.That(await TestHelpers.WaitUntilAsync(
+                        () =>
+                        {
+                            var currentParent = TestHelpers.GetTask(vm, parent!.Id);
+                            var currentChild = TestHelpers.GetTask(vm, childId);
+                            var currentGrandchild = TestHelpers.GetTask(vm, grandchildId);
+                            return currentParent?.Contains.Contains(childId) == true &&
+                                   currentChild?.Parents.Contains(parent.Id) == true &&
+                                   currentChild.Contains.Contains(grandchildId) &&
+                                   currentGrandchild?.Parents.Contains(childId) == true;
+                        },
+                        TimeSpan.FromSeconds(10)))
+                    .IsTrue();
+
+                TaskWrapperViewModel? parentWrapper = null;
+                TaskWrapperViewModel? childWrapper = null;
                 var wrappersReady = WaitFor(() =>
-                    vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems) != null &&
-                    vm.FindTaskWrapperViewModel(child, vm.CurrentAllTasksItems) != null);
+                {
+                    parentWrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
+                    childWrapper = vm.FindTaskWrapperViewModel(TestHelpers.GetTask(vm, childId)!, vm.CurrentAllTasksItems);
+                    return parentWrapper != null && childWrapper != null;
+                }, SearchExpansionWaitMilliseconds);
                 await Assert.That(wrappersReady).IsTrue();
-
-                var parentWrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
-                var childWrapper = vm.FindTaskWrapperViewModel(child, vm.CurrentAllTasksItems);
-                await Assert.That(parentWrapper).IsNotNull();
-                await Assert.That(childWrapper).IsNotNull();
                 parentWrapper!.IsExpanded = true;
                 childWrapper!.IsExpanded = true;
+                var childSubtreeReady = WaitFor(
+                    () => childWrapper.SubTasks.Any(wrapper => wrapper.TaskItem.Id == grandchildId),
+                    SearchExpansionWaitMilliseconds);
+                await Assert.That(childSubtreeReady).IsTrue();
 
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
@@ -266,7 +290,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_CopyTaskOutline_UsesCurrentFiltersAndSort()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -281,30 +305,53 @@ public class MainControlTreeCommandsUiTests
 
                 var parent = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
                 var zuluChild = await vm.taskRepository!.AddChild(parent!);
-                zuluChild.Title = "Zulu visible outline child";
-                await vm.taskRepository.Update(zuluChild);
+                await UpdateTaskForScenarioAsync(
+                    vm.taskRepository,
+                    zuluChild,
+                    task => task.Title = "Zulu visible outline child");
 
                 var hiddenChild = await vm.taskRepository.AddChild(parent);
-                hiddenChild.Title = "\u274C Alpha hidden excluded outline child";
-                await vm.taskRepository.Update(hiddenChild);
+                await UpdateTaskForScenarioAsync(
+                    vm.taskRepository,
+                    hiddenChild,
+                    task => task.Title = "\u274C Alpha hidden excluded outline child");
 
                 var alphaChild = await vm.taskRepository.AddChild(parent);
-                alphaChild.Title = "Alpha visible outline child";
-                await vm.taskRepository.Update(alphaChild);
+                await UpdateTaskForScenarioAsync(
+                    vm.taskRepository,
+                    alphaChild,
+                    task => task.Title = "Alpha visible outline child");
 
-                var excludeFilterReady = WaitFor(() => vm.EmojiExcludeFilters.Any(filter => filter.Emoji == "\u274C"));
+                var excludeFilterReady = await TestHelpers.WaitUntilAsync(
+                    () =>
+                    {
+                        Dispatcher.UIThread.RunJobs();
+                        return vm.EmojiExcludeFilters.Any(filter => filter.Emoji == "\u274C");
+                    },
+                    TimeSpan.FromMilliseconds(SearchExpansionWaitMilliseconds));
                 await Assert.That(excludeFilterReady).IsTrue();
                 vm.EmojiExcludeFilters.First(filter => filter.Emoji == "\u274C").ShowTasks = true;
 
-                var wrapperReady = WaitFor(() =>
+                var wrapperReady = await TestHelpers.WaitUntilAsync(
+                    () =>
+                    {
+                        Dispatcher.UIThread.RunJobs();
+                        var wrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
+                        return wrapper?.SubTasks.Select(child => child.TaskItem.Title).SequenceEqual([
+                            "Alpha visible outline child",
+                            "Zulu visible outline child"
+                        ]) == true;
+                    },
+                    TimeSpan.FromMilliseconds(SearchExpansionWaitMilliseconds));
+                if (!wrapperReady)
                 {
                     var wrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
-                    return wrapper?.SubTasks.Select(child => child.TaskItem.Title).SequenceEqual([
-                        "Alpha visible outline child",
-                        "Zulu visible outline child"
-                    ]) == true;
-                });
-                await Assert.That(wrapperReady).IsTrue();
+                    throw new InvalidOperationException(
+                        "Filtered task outline wrapper did not reach the expected visible sort order. " +
+                        $"ExcludeFilters={string.Join("|", vm.EmojiExcludeFilters.Select(filter => $"{filter.Emoji}:{filter.ShowTasks}"))}; " +
+                        $"SubTasks={string.Join("|", wrapper?.SubTasks.Select(child => child.TaskItem.Title) ?? [])}.");
+                }
+
                 await Assert.That(NormalizeNewLines(TaskOutlineClipboardService.BuildOutline(parent)))
                     .Contains("Alpha hidden excluded outline child");
 
@@ -327,7 +374,13 @@ public class MainControlTreeCommandsUiTests
                 await ClickControlAsync(window, parentControl);
                 PressHotkey(window, Key.C, PhysicalKey.C, RawInputModifiers.Control | RawInputModifiers.Shift);
 
-                var copied = WaitFor(() => clipboardText != null);
+                var copied = await TestHelpers.WaitUntilAsync(
+                    () =>
+                    {
+                        Dispatcher.UIThread.RunJobs();
+                        return clipboardText != null;
+                    },
+                    TimeSpan.FromMilliseconds(SearchExpansionWaitMilliseconds));
                 await Assert.That(copied).IsTrue();
                 await Assert.That(NormalizeNewLines(clipboardText)).IsEqualTo(
                     $"{parent.Title}\n\tAlpha visible outline child\n\tZulu visible outline child");
@@ -350,7 +403,7 @@ public class MainControlTreeCommandsUiTests
     [Arguments("LastOpenedTree")]
     public async Task TreeSearch_ClearSearch_RestoresExpansionState(string treeName)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -421,7 +474,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeSearch_AllTasksSearchEditor_FiltersVisibleTree()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -507,7 +560,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeSearch_ClearSearch_ReselectsAndScrollsCurrentAllTasksItemWithClosedDetails()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -638,7 +691,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_PasteTaskOutline_Hotkey_CreatesTreeUnderSelectedTask()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -649,7 +702,8 @@ public class MainControlTreeCommandsUiTests
                 var vm = fixture.MainWindowViewModelTest;
                 await vm.Connect();
                 vm.AllTasksMode = true;
-                ((NotificationManagerWrapperMock)vm.ManagerWrapper).AskResult = true;
+                var notificationManager = (NotificationManagerWrapperMock)vm.ManagerWrapper;
+                notificationManager.AskResult = true;
 
                 var parent = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask1Id);
                 var parentWrapper = vm.FindTaskWrapperViewModel(parent!, vm.CurrentAllTasksItems);
@@ -694,19 +748,40 @@ public class MainControlTreeCommandsUiTests
                           selected.TaskItem.Id == parent.Id,
                     SearchExpansionWaitMilliseconds);
                 await Assert.That(parentSelected).IsTrue();
+                SelectTreeWrapper(allTasksTree!, parentWrapper);
+                allTasksTree!.Focus();
+                Dispatcher.UIThread.RunJobs();
 
                 PressHotkey(window, Key.V, PhysicalKey.V, RawInputModifiers.Control | RawInputModifiers.Shift);
+
+                var pasteStarted = WaitFor(
+                    () => clipboardReadCount == 1,
+                    SearchExpansionWaitMilliseconds);
+                await Assert.That(pasteStarted).IsTrue();
 
                 var pasted = WaitFor(() =>
                     vm.taskRepository.Tasks.Count == countBefore + 4 &&
                     vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste root") &&
                     vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste child") &&
                     vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste grandchild") &&
-                    vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste sibling"));
-                await Assert.That(pasted).IsTrue();
+                    vm.taskRepository.Tasks.Items.Any(task => task.Title == "Outline UI paste sibling"),
+                    SearchExpansionWaitMilliseconds);
+                if (!pasted)
+                {
+                    throw new InvalidOperationException(
+                        "Task outline paste hotkey did not create expected tasks. " +
+                        $"CountBefore={countBefore}; " +
+                        $"Count={vm.taskRepository.Tasks.Count}; " +
+                        $"ClipboardReadCount={clipboardReadCount}; " +
+                        $"PreviewTaskCount={notificationManager.LastTaskOutlinePastePreview?.TaskCount.ToString() ?? "<null>"}; " +
+                        $"LastError={notificationManager.LastErrorMessage ?? "<null>"}; " +
+                        $"CurrentTask={vm.CurrentTaskItem?.Title ?? "<null>"}; " +
+                        $"Titles={string.Join("|", vm.taskRepository.Tasks.Items.Select(task => task.Title))}.");
+                }
+
                 await Assert.That(clipboardReadCount).IsEqualTo(1);
-                await Assert.That(((NotificationManagerWrapperMock)vm.ManagerWrapper).LastTaskOutlinePastePreview).IsNotNull();
-                await Assert.That(((NotificationManagerWrapperMock)vm.ManagerWrapper).LastTaskOutlinePastePreview!.TaskCount).IsEqualTo(4);
+                await Assert.That(notificationManager.LastTaskOutlinePastePreview).IsNotNull();
+                await Assert.That(notificationManager.LastTaskOutlinePastePreview!.TaskCount).IsEqualTo(4);
 
                 TaskItemViewModel? pastedRoot = null;
                 TaskItemViewModel? pastedChild = null;
@@ -749,7 +824,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_InlineTitleEdit_CreatesEditorOnlyForF2OrRepeatedTitleClick()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -833,7 +908,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_Hotkey_UsesSelectedItem_NotLastClickedWrapper()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -899,7 +974,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_Hotkey_UsesVisibleTabTreeAfterSwitchWithoutAdditionalTreeClick()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -944,7 +1019,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_Hotkey_UsesVisibleTabTreeWithoutPriorTreeActivation()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -983,7 +1058,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_LastCreatedTab_HotkeyAndContextMenu_Work()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1031,7 +1106,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_LastCreatedTab_Hotkey_WorksAfterSwitchFromAllTasksHeaderClick()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1083,7 +1158,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_Hotkey_WorksOnFirstPressImmediatelyAfterTabHeaderClick()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1133,7 +1208,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_LastCreatedTab_CurrentCommands_WorkOnClickedItem()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1212,7 +1287,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_LastUpdatedTab_Hotkey_WorksAfterSwitchFromAllTasksHeaderClick()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1337,7 +1412,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_ShiftDelete_RemovesSelectedLastUpdatedTreeItem()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1390,7 +1465,7 @@ public class MainControlTreeCommandsUiTests
         string rootTaskId,
         string childTaskId)
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1489,7 +1564,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_ContextMenuClick_UsesClickedRelationItemEvenWhenTextInputFocused()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1550,7 +1625,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_Hotkey_UsesFocusedRelationTreeWithoutPointerActivation()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1622,7 +1697,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_HotkeyRouting_PrefersFocusedRelationTreeOverStaleActiveTree()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1673,7 +1748,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_ContextMenu_UsesPlacementTargetWithoutStoredTreeContext()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1734,7 +1809,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_ContextMenu_DisplaysHotkeysForTreeCommands()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1776,7 +1851,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_ContextMenu_UsesPlacementTargetItemWithoutStoredContextForCurrentCommand()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1853,7 +1928,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_CtrlA_SelectsAllItemsInActiveTree()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1949,7 +2024,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_CtrlA_SelectsTextWhenTextInputFocused()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1995,7 +2070,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_ShiftDelete_RemovesSelectedMainTreeItems()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2040,7 +2115,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_ShiftDelete_IgnoresRelationTree()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2092,7 +2167,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeCommandUi_RightClick_PreservesSelectedBatch_AndCollapsesOnUnselectedItem()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2145,7 +2220,7 @@ public class MainControlTreeCommandsUiTests
     [Test]
     public async Task TreeDragUi_DragPreparation_PreservesExistingMultiSelectionVisualState()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2442,6 +2517,26 @@ public class MainControlTreeCommandsUiTests
         TaskItemViewModel Child,
         string SearchText);
 
+    private static async Task UpdateTaskForScenarioAsync(
+        ITaskStorage repository,
+        TaskItemViewModel task,
+        Action<TaskItemViewModel> configure)
+    {
+        var isInitializedProvider = task.IsInitializedProvider;
+        task.IsInitializedProvider = () => false;
+        try
+        {
+            configure(task);
+            await repository.Update(task);
+        }
+        finally
+        {
+            task.IsInitializedProvider = isInitializedProvider;
+        }
+
+        Dispatcher.UIThread.RunJobs();
+    }
+
     private static async Task<SearchExpansionScenario> CreateSearchExpansionScenarioAsync(
         MainWindowViewModel vm,
         string treeName)
@@ -2477,10 +2572,11 @@ public class MainControlTreeCommandsUiTests
             .IsTrue();
 
         var searchTarget = await repository.Add();
-        searchTarget.Title = $"Search expansion target {treeName} {searchToken}";
         var searchText = searchToken;
-
-        await repository.Update(searchTarget);
+        await UpdateTaskForScenarioAsync(
+            repository,
+            searchTarget,
+            task => task.Title = $"Search expansion target {treeName} {searchToken}");
 
         await TestHelpers.WaitThrottleTime();
         Dispatcher.UIThread.RunJobs();
@@ -2498,9 +2594,14 @@ public class MainControlTreeCommandsUiTests
         var child = TestHelpers.GetTask(vm, MainWindowViewModelFixture.SubTask22Id)
             ?? throw new InvalidOperationException("Unlocked search child task was not found.");
 
-        child.IsCompleted = true;
-        child.CompletedDateTime ??= DateTimeOffset.UtcNow;
-        await repository.Update(child);
+        await UpdateTaskForScenarioAsync(
+            repository,
+            child,
+            task =>
+            {
+                task.IsCompleted = true;
+                task.CompletedDateTime ??= DateTimeOffset.UtcNow;
+            });
         await Assert.That(await TestHelpers.WaitUntilAsync(
                 () => parent.IsCanBeCompleted &&
                       parent.Contains.Contains(child.Id) &&
@@ -2509,8 +2610,10 @@ public class MainControlTreeCommandsUiTests
             .IsTrue();
 
         var searchTarget = await repository.Add();
-        searchTarget.Title = $"Search expansion target UnlockedTree {searchToken}";
-        await repository.Update(searchTarget);
+        await UpdateTaskForScenarioAsync(
+            repository,
+            searchTarget,
+            task => task.Title = $"Search expansion target UnlockedTree {searchToken}");
 
         await TestHelpers.WaitThrottleTime();
         Dispatcher.UIThread.RunJobs();
@@ -2529,15 +2632,28 @@ public class MainControlTreeCommandsUiTests
         if (child == null)
         {
             child = await repository.AddChild(parent);
-            child.Title = "Completed search expansion child";
+            await UpdateTaskForScenarioAsync(
+                repository,
+                child,
+                task => task.Title = "Completed search expansion child");
         }
 
-        parent.IsCompleted = true;
-        parent.CompletedDateTime ??= DateTimeOffset.UtcNow;
-        child.IsCompleted = true;
-        child.CompletedDateTime ??= DateTimeOffset.UtcNow;
-        await repository.Update(parent);
-        await repository.Update(child);
+        await UpdateTaskForScenarioAsync(
+            repository,
+            parent,
+            task =>
+            {
+                task.IsCompleted = true;
+                task.CompletedDateTime ??= DateTimeOffset.UtcNow;
+            });
+        await UpdateTaskForScenarioAsync(
+            repository,
+            child,
+            task =>
+            {
+                task.IsCompleted = true;
+                task.CompletedDateTime ??= DateTimeOffset.UtcNow;
+            });
 
         await Assert.That(await TestHelpers.WaitUntilAsync(
                 () => parent.Contains.Contains(child.Id) &&
@@ -2547,10 +2663,15 @@ public class MainControlTreeCommandsUiTests
             .IsTrue();
 
         var searchTarget = await repository.Add();
-        searchTarget.Title = $"Search expansion target CompletedTree {searchToken}";
-        searchTarget.IsCompleted = true;
-        searchTarget.CompletedDateTime ??= DateTimeOffset.UtcNow;
-        await repository.Update(searchTarget);
+        await UpdateTaskForScenarioAsync(
+            repository,
+            searchTarget,
+            task =>
+            {
+                task.Title = $"Search expansion target CompletedTree {searchToken}";
+                task.IsCompleted = true;
+                task.CompletedDateTime ??= DateTimeOffset.UtcNow;
+            });
 
         await TestHelpers.WaitThrottleTime();
         Dispatcher.UIThread.RunJobs();
@@ -2576,10 +2697,15 @@ public class MainControlTreeCommandsUiTests
             .IsTrue();
 
         var searchTarget = await repository.Add();
-        searchTarget.Title = $"Search expansion target ArchivedTree {searchToken}";
-        searchTarget.IsCompleted = null;
-        searchTarget.ArchiveDateTime ??= DateTimeOffset.UtcNow;
-        await repository.Update(searchTarget);
+        await UpdateTaskForScenarioAsync(
+            repository,
+            searchTarget,
+            task =>
+            {
+                task.Title = $"Search expansion target ArchivedTree {searchToken}";
+                task.IsCompleted = null;
+                task.ArchiveDateTime ??= DateTimeOffset.UtcNow;
+            });
 
         await TestHelpers.WaitThrottleTime();
         Dispatcher.UIThread.RunJobs();

--- a/src/Unlimotion.Test/MainControlWantedUiTests.cs
+++ b/src/Unlimotion.Test/MainControlWantedUiTests.cs
@@ -22,7 +22,7 @@ public class MainControlWantedUiTests
     [Test]
     public async Task CurrentTaskWantedCheckBox_WhenConfirmed_ShouldUpdateDescendants()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
+++ b/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
@@ -28,7 +28,7 @@ public class MainScreenLoadingUiTests
     [Test]
     public async Task MainScreen_TogglesTasksLoadingOverlay_WithLoadingState()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -66,7 +66,7 @@ public class MainScreenLoadingUiTests
     [Test]
     public async Task MainScreen_Connect_KeepsUiResponsive_DuringBlockingInitialLoad()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             using var context = TestMainWindowContext.Create(TimeSpan.FromSeconds(2));
@@ -190,7 +190,11 @@ public class MainScreenLoadingUiTests
 
             IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(configPath, reloadOnChange: false);
             var notificationManager = new NotificationManagerWrapperMock();
-            var storage = new UnifiedTaskStorage(new TaskTreeManager(new BlockingInitialLoadStorage(loadDelay)));
+            var taskContext = new TaskItemViewModelContext
+            {
+                NotificationManager = notificationManager
+            };
+            var storage = new UnifiedTaskStorage(new TaskTreeManager(new BlockingInitialLoadStorage(loadDelay)), taskContext);
             var settings = new SettingsViewModel(configuration);
             var mainWindowViewModel = new MainWindowViewModel(
                 new AppNameDefinitionService(),
@@ -199,8 +203,7 @@ public class MainScreenLoadingUiTests
                 () => storage,
                 settings);
 
-            TaskItemViewModel.NotificationManagerInstance = notificationManager;
-            TaskItemViewModel.MainWindowInstance = mainWindowViewModel;
+            taskContext.MainWindow = mainWindowViewModel;
 
             return new TestMainWindowContext(
                 configPath,

--- a/src/Unlimotion.Test/MainWindowViewModelFixture.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelFixture.cs
@@ -101,10 +101,15 @@ namespace Unlimotion.Test
                 new AppNameDefinitionService(),
                 notificationManagerMock,
                 configuration,
-                () => storageFactory.CurrentStorage,
+                () => storageFactory.SourceManager.ActiveStorage,
                 settingsViewModel,
                 taskTreeExpansionStatePath: TaskTreeExpansionStatePath
             );
+            var activeSource = storageFactory.SourceManager.ActiveSource;
+            if (activeSource != null)
+            {
+                activeSource.TaskContext.MainWindow = MainWindowViewModelTest;
+            }
         }
 
         private void CopyTaskFromSnapshotsFolder()

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Avalonia.Headless;
 using Avalonia.Threading;
+using DynamicData;
 using KellermanSoftware.CompareNetObjects;
 using Unlimotion.Domain;
 using Unlimotion.Services;
@@ -198,7 +199,7 @@ namespace Unlimotion.Test
                 notificationManager);
             storageFactory.CreateFileStorage(sourceFixture.DefaultTasksFolderPath);
 
-            if (storageFactory.CurrentStorage is IDisposable storageDisposable)
+            if (storageFactory.SourceManager.ActiveStorage is IDisposable storageDisposable)
             {
                 disposables.Add(storageDisposable);
             }
@@ -208,7 +209,7 @@ namespace Unlimotion.Test
                 new AppNameDefinitionService(),
                 notificationManager,
                 configuration,
-                () => storageFactory.CurrentStorage,
+                () => storageFactory.SourceManager.ActiveStorage,
                 settings,
                 taskTreeExpansionStatePath: sourceFixture.TaskTreeExpansionStatePath);
             disposables.Add(viewModel);
@@ -301,24 +302,33 @@ namespace Unlimotion.Test
             DomainTaskStatus status,
             DateTimeOffset changedAt)
         {
-            var entry = task.StatusHistory
-                .Where(historyEntry => historyEntry.Status == status)
-                .OrderBy(historyEntry => historyEntry.ChangedAt)
-                .LastOrDefault()
-                ?? throw new InvalidOperationException($"Status history entry for {status} was not found.");
-
-            entry.ChangedAt = changedAt;
-            if (status == DomainTaskStatus.Completed)
+            var isInitializedProvider = task.IsInitializedProvider;
+            task.IsInitializedProvider = () => false;
+            try
             {
-                task.CompletedDateTime = changedAt;
-            }
-            else if (status == DomainTaskStatus.Archived)
-            {
-                task.ArchiveDateTime = changedAt;
-            }
+                var entry = task.StatusHistory
+                    .Where(historyEntry => historyEntry.Status == status)
+                    .OrderBy(historyEntry => historyEntry.ChangedAt)
+                    .LastOrDefault()
+                    ?? throw new InvalidOperationException($"Status history entry for {status} was not found.");
 
-            Dispatcher.UIThread.RunJobs();
-            return task;
+                entry.ChangedAt = changedAt;
+                if (status == DomainTaskStatus.Completed)
+                {
+                    task.CompletedDateTime = changedAt;
+                }
+                else if (status == DomainTaskStatus.Archived)
+                {
+                    task.ArchiveDateTime = changedAt;
+                }
+
+                Dispatcher.UIThread.RunJobs();
+                return task;
+            }
+            finally
+            {
+                task.IsInitializedProvider = isInitializedProvider;
+            }
         }
 
         private static void EnsureStatusFilterSelected(MainWindowViewModel viewModel, DomainTaskStatus status)
@@ -524,18 +534,40 @@ namespace Unlimotion.Test
             var pastedRoot = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste root");
             var pastedChild = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste child");
             var pastedGrandchild = taskRepository.Tasks.Items.First(task => task.Title == "Outline VM paste grandchild");
-            await Assert.That(await TestHelpers.WaitUntilAsync(
-                    () => parent!.Contains.Contains(pastedRoot.Id) &&
-                          pastedRoot.Contains.Contains(pastedChild.Id) &&
-                          pastedChild.Contains.Contains(pastedGrandchild.Id),
-                    TimeSpan.FromSeconds(10)))
-                .IsTrue();
+            var pastedRootId = pastedRoot.Id;
+            var pastedChildId = pastedChild.Id;
+            var pastedGrandchildId = pastedGrandchild.Id;
 
-            await Assert.That(parent!.Contains).Contains(pastedRoot.Id);
+            TaskItemViewModel? LookupTask(string taskId)
+            {
+                var result = taskRepository.Tasks.Lookup(taskId);
+                return result.HasValue ? result.Value : null;
+            }
+
+            var relationsUpdated = await TestHelpers.WaitUntilAsync(
+                () =>
+                {
+                    var currentParent = LookupTask(parent!.Id);
+                    var currentRoot = LookupTask(pastedRootId);
+                    var currentChild = LookupTask(pastedChildId);
+
+                    return currentParent?.Contains.Contains(pastedRootId) == true &&
+                           currentRoot?.Contains.Contains(pastedChildId) == true &&
+                           currentChild?.Contains.Contains(pastedGrandchildId) == true;
+                },
+                TimeSpan.FromSeconds(10));
+            await Assert.That(relationsUpdated).IsTrue();
+
+            parent = LookupTask(parent!.Id);
+            pastedRoot = LookupTask(pastedRootId)!;
+            pastedChild = LookupTask(pastedChildId)!;
+            pastedGrandchild = LookupTask(pastedGrandchildId)!;
+
+            await Assert.That(parent!.Contains).Contains(pastedRootId);
             await Assert.That(pastedRoot.Parents).Contains(parent.Id);
-            await Assert.That(pastedRoot.Contains).Contains(pastedChild.Id);
-            await Assert.That(pastedChild.Contains).Contains(pastedGrandchild.Id);
-            await Assert.That(pastedGrandchild.Parents).Contains(pastedChild.Id);
+            await Assert.That(pastedRoot.Contains).Contains(pastedChildId);
+            await Assert.That(pastedChild.Contains).Contains(pastedGrandchildId);
+            await Assert.That(pastedGrandchild.Parents).Contains(pastedChildId);
         }
 
         [Test]
@@ -2374,19 +2406,6 @@ namespace Unlimotion.Test
                     DomainTaskStatus.Archived,
                     "Archived task today");
 
-                oldCompletedTask = MoveLatestStatusHistoryEntry(
-                    oldCompletedTask,
-                    DomainTaskStatus.Completed,
-                    oldTimestamp);
-                oldArchivedTask = MoveLatestStatusHistoryEntry(
-                    oldArchivedTask,
-                    DomainTaskStatus.Archived,
-                    oldTimestamp);
-                await Assert.That(oldCompletedTask.CompletedDateTime?.UtcDateTime.Date)
-                    .IsEqualTo(oldTimestamp.UtcDateTime.Date);
-                await Assert.That(oldArchivedTask.ArchiveDateTime?.UtcDateTime.Date)
-                    .IsEqualTo(oldTimestamp.UtcDateTime.Date);
-
                 EnsureStatusFilterSelected(viewModel, DomainTaskStatus.Completed);
                 viewModel.AllTasksMode = false;
                 viewModel.CompletedMode = true;
@@ -2395,6 +2414,14 @@ namespace Unlimotion.Test
                 await Assert.That(viewModel.CompletedDateFilter.From).IsEqualTo(DateTime.Today);
                 await Assert.That(viewModel.CompletedDateFilter.To).IsEqualTo(DateTime.Today);
 
+                var oldCompletedInitiallyVisible = await TestHelpers.WaitUntilAsync(
+                    () =>
+                    {
+                        Dispatcher.UIThread.RunJobs();
+                        return viewModel.CompletedItems.Any(wrapper => wrapper.TaskItem.Id == oldCompletedTask.Id);
+                    },
+                    TimeSpan.FromSeconds(2));
+                await Assert.That(oldCompletedInitiallyVisible).IsTrue();
                 var completedTodayVisible = await TestHelpers.WaitUntilAsync(
                     () =>
                     {
@@ -2403,6 +2430,15 @@ namespace Unlimotion.Test
                     },
                     TimeSpan.FromSeconds(2));
                 await Assert.That(completedTodayVisible).IsTrue();
+
+                oldCompletedTask = MoveLatestStatusHistoryEntry(
+                    oldCompletedTask,
+                    DomainTaskStatus.Completed,
+                    oldTimestamp);
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(oldCompletedTask.CompletedDateTime?.UtcDateTime.Date)
+                    .IsEqualTo(oldTimestamp.UtcDateTime.Date);
+
                 var oldCompletedHidden = await TestHelpers.WaitUntilAsync(
                     () =>
                     {
@@ -2430,6 +2466,14 @@ namespace Unlimotion.Test
                 await Assert.That(viewModel.ArchivedDateFilter.From).IsEqualTo(DateTime.Today);
                 await Assert.That(viewModel.ArchivedDateFilter.To).IsEqualTo(DateTime.Today);
 
+                var oldArchivedInitiallyVisible = await TestHelpers.WaitUntilAsync(
+                    () =>
+                    {
+                        Dispatcher.UIThread.RunJobs();
+                        return viewModel.ArchivedItems.Any(wrapper => wrapper.TaskItem.Id == oldArchivedTask.Id);
+                    },
+                    TimeSpan.FromSeconds(2));
+                await Assert.That(oldArchivedInitiallyVisible).IsTrue();
                 var archivedTodayVisible = await TestHelpers.WaitUntilAsync(
                     () =>
                     {
@@ -2438,6 +2482,15 @@ namespace Unlimotion.Test
                     },
                     TimeSpan.FromSeconds(2));
                 await Assert.That(archivedTodayVisible).IsTrue();
+
+                oldArchivedTask = MoveLatestStatusHistoryEntry(
+                    oldArchivedTask,
+                    DomainTaskStatus.Archived,
+                    oldTimestamp);
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(oldArchivedTask.ArchiveDateTime?.UtcDateTime.Date)
+                    .IsEqualTo(oldTimestamp.UtcDateTime.Date);
+
                 var oldArchivedHidden = await TestHelpers.WaitUntilAsync(
                     () =>
                     {

--- a/src/Unlimotion.Test/PackageUpdateCompatibilityUiTests.cs
+++ b/src/Unlimotion.Test/PackageUpdateCompatibilityUiTests.cs
@@ -20,7 +20,7 @@ public class PackageUpdateCompatibilityUiTests
     [Test]
     public async Task RoadmapDropAndFolderPickerCompatibility_Work()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -733,7 +733,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_OpenView_KeepsDenseBlockChainReadable()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var storage = new StubTaskStorage();
@@ -788,7 +788,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_NodifyView_RendersTasksAndKeepsAutomationIds()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -852,7 +852,7 @@ public class RoadmapGraphUiTests
     {
         await RunWithRussianLocalizationAsync(async () =>
         {
-            await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
             await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
@@ -946,7 +946,7 @@ public class RoadmapGraphUiTests
     {
         await RunWithRussianLocalizationAsync(async () =>
         {
-            await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
             await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
@@ -1058,7 +1058,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_UpdateGraphPulse_CoalescesQueuedBackgroundRebuilds()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1144,7 +1144,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_FilterChange_CancelsRunningBackgroundRebuildAndStartsLatest()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1256,7 +1256,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_TitleRename_UpdatesTextWithoutRebuildingMap()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1321,7 +1321,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_InlineTitleEdit_CreatesEditorForF2OrRepeatedTitleClick()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1425,7 +1425,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_OpenView_ReflectsCreatedAndDeletedTasks()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1493,7 +1493,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_FilterChange_RebuildsOpenView()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1573,11 +1573,10 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_NodeSelectionResolvesOwnerWithoutStaticSingleton()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
-            var previousMainWindow = TaskItemViewModel.MainWindowInstance;
             Window? window = null;
 
             try
@@ -1588,7 +1587,6 @@ public class RoadmapGraphUiTests
                 vm.GraphMode = true;
                 vm.DetailsAreOpen = false;
                 vm.CurrentTaskItem = null;
-                TaskItemViewModel.MainWindowInstance = null;
 
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
@@ -1619,7 +1617,6 @@ public class RoadmapGraphUiTests
             }
             finally
             {
-                TaskItemViewModel.MainWindowInstance = previousMainWindow;
                 window?.Close();
                 fixture.CleanTasks();
             }
@@ -1629,7 +1626,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_NodeClickSelection_AppliesModifierSemanticsAndVisualState()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1777,7 +1774,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_ModifierDoubleClickSuppression_UsesClickCountWithoutLocalTimeWindow()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1830,7 +1827,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_SelectedNodeFrame_DoesNotResizeNodeOrShiftContent()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -1960,7 +1957,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_RectangleHitTesting_IgnoresMinimapItems()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2017,7 +2014,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_RectangleHitTesting_UsesZoomedNodeBounds()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2083,7 +2080,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_RectangleSelection_UsesViewportZoom()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2147,7 +2144,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_NodePointerDrag_StartsAfterMoveThresholdAndKeepsSelection()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2218,7 +2215,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_SelectedNodePlainClickWithoutDrag_CollapsesSelectionOnRelease()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2287,7 +2284,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_SelectedNodeDrag_PreservesMultiSelectionAfterThreshold()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2363,7 +2360,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_NodeRightDrag_PansViewportWithoutSelectingTask()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2602,7 +2599,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_TaskCardButtons_AfterRoadmapSelection_CreateExpectedTasks()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2673,7 +2670,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_DropWithControl_CreatesBlockingRelationBetweenRoadmapNodes()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2732,7 +2729,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_SelectedNodesDragDrop_AppliesBatchOperation()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.Dispatch(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -2815,7 +2812,7 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_SearchText_HighlightsAndClearsMatchingNode()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -28,48 +28,55 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task SettingsControl_TaskOutlineClipboardCheckBoxes_PersistSettings()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.DispatchAsync(async () =>
+        var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        try
         {
-            var fixture = new MainWindowViewModelFixture();
-            Window? window = null;
-
-            try
+            await session.DispatchAsync(async () =>
             {
-                var settings = fixture.MainWindowViewModelTest.Settings;
-                var view = new SettingsControl
+                var fixture = new MainWindowViewModelFixture();
+                Window? window = null;
+
+                try
                 {
-                    DataContext = settings
-                };
+                    var settings = fixture.MainWindowViewModelTest.Settings;
+                    var view = new SettingsControl
+                    {
+                        DataContext = settings
+                    };
 
-                window = CreateWindow(view, 720, 800);
-                window.Show();
-                Dispatcher.UIThread.RunJobs();
+                    window = CreateWindow(view, 720, 800);
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
 
-                var markdownCheckBox = FindControlByAutomationId<CheckBox>(view, "CopyTaskOutlineAsMarkdownCheckBox");
-                var descriptionCheckBox = FindControlByAutomationId<CheckBox>(view, "CopyTaskOutlineDescriptionCheckBox");
+                    var markdownCheckBox = FindControlByAutomationId<CheckBox>(view, "CopyTaskOutlineAsMarkdownCheckBox");
+                    var descriptionCheckBox = FindControlByAutomationId<CheckBox>(view, "CopyTaskOutlineDescriptionCheckBox");
 
-                await Assert.That(markdownCheckBox.IsChecked).IsFalse();
-                await Assert.That(descriptionCheckBox.IsChecked).IsFalse();
+                    await Assert.That(markdownCheckBox.IsChecked).IsFalse();
+                    await Assert.That(descriptionCheckBox.IsChecked).IsFalse();
 
-                await ClickControlAsync(window, markdownCheckBox);
-                await ClickControlAsync(window, descriptionCheckBox);
+                    await ClickControlAsync(window, markdownCheckBox);
+                    await ClickControlAsync(window, descriptionCheckBox);
 
-                await Assert.That(settings.CopyTaskOutlineAsMarkdown).IsTrue();
-                await Assert.That(settings.CopyTaskOutlineDescription).IsTrue();
-            }
-            finally
-            {
-                window?.Close();
-                fixture.CleanTasks();
-            }
-        }, CancellationToken.None);
+                    await Assert.That(settings.CopyTaskOutlineAsMarkdown).IsTrue();
+                    await Assert.That(settings.CopyTaskOutlineDescription).IsTrue();
+                }
+                finally
+                {
+                    window?.Close();
+                    fixture.CleanTasks();
+                }
+            }, CancellationToken.None);
+        }
+        finally
+        {
+            await session.DisposeIgnoringHeadlessTeardownNullReferenceAsync();
+        }
     }
 
     [Test]
     public async Task SettingsControl_TaskTreeExpansionStateCheckBox_PersistsSetting()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -109,86 +116,93 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task SettingsControl_UpdateSection_ShowsVersionAndDownloadsAvailableUpdate()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        try
         {
-            var fixture = new MainWindowViewModelFixture();
-            Window? window = null;
-
-            try
+            await session.Dispatch(async () =>
             {
-                var settings = fixture.MainWindowViewModelTest.Settings;
-                var updateService = new FakeApplicationUpdateService
+                var fixture = new MainWindowViewModelFixture();
+                Window? window = null;
+
+                try
                 {
-                    CurrentVersion = "1.2.3",
-                    NextUpdate = new ApplicationUpdateInfo("1.2.4")
-                };
-                settings.ConfigureUpdateService(updateService);
-                settings.CheckForUpdatesCommand = new TestAsyncCommand(() => settings.CheckForUpdatesAsync());
-                settings.DownloadUpdateCommand = new TestAsyncCommand(() => settings.DownloadUpdateAsync());
-                settings.ApplyUpdateCommand = new TestAsyncCommand(settings.ApplyUpdateAsync);
+                    var settings = fixture.MainWindowViewModelTest.Settings;
+                    var updateService = new FakeApplicationUpdateService
+                    {
+                        CurrentVersion = "1.2.3",
+                        NextUpdate = new ApplicationUpdateInfo("1.2.4")
+                    };
+                    settings.ConfigureUpdateService(updateService);
+                    settings.CheckForUpdatesCommand = new TestAsyncCommand(() => settings.CheckForUpdatesAsync());
+                    settings.DownloadUpdateCommand = new TestAsyncCommand(() => settings.DownloadUpdateAsync());
+                    settings.ApplyUpdateCommand = new TestAsyncCommand(settings.ApplyUpdateAsync);
 
-                var view = new SettingsControl
+                    var view = new SettingsControl
+                    {
+                        DataContext = settings
+                    };
+
+                    window = CreateWindow(view, 720, 800);
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+
+                    var currentVersionText = FindControlByAutomationId<TextBlock>(view, "CurrentApplicationVersionText");
+                    var availableVersionText = FindControlByAutomationId<TextBlock>(view, "AvailableUpdateVersionText");
+                    var checkButton = FindControlByAutomationId<Button>(view, "CheckForUpdatesButton");
+                    var downloadButton = FindControlByAutomationId<Button>(view, "DownloadUpdateButton");
+                    var applyButton = FindControlByAutomationId<Button>(view, "ApplyUpdateButton");
+
+                    await Assert.That(currentVersionText.Text).IsEqualTo("1.2.3");
+                    await Assert.That(checkButton.IsEnabled).IsTrue();
+                    await Assert.That(downloadButton.IsEnabled).IsFalse();
+
+                    await ClickControlAsync(window, checkButton);
+                    await WaitForConditionAsync(
+                        () => settings.UpdateState == ApplicationUpdateState.UpdateAvailable,
+                        "Settings update section did not show an available update.");
+
+                    await Assert.That(availableVersionText.Text).IsEqualTo("1.2.4");
+                    await Assert.That(downloadButton.IsEnabled).IsTrue();
+
+                    await ClickControlAsync(window, downloadButton);
+                    await WaitForConditionAsync(
+                        () => settings.UpdateState == ApplicationUpdateState.ReadyToApply,
+                        "Settings update section did not switch to ready-to-apply after download.");
+
+                    await Assert.That(updateService.DownloadCalls).IsEqualTo(1);
+                    await Assert.That(applyButton.IsEnabled).IsTrue();
+
+                    const string permissionStatus = "Grant install permission, then tap Install update again.";
+                    updateService.ApplyException = new ApplicationUpdateUserActionRequiredException(permissionStatus);
+
+                    await ClickControlAsync(window, applyButton);
+                    await WaitForConditionAsync(
+                        () => settings.UpdateState == ApplicationUpdateState.ReadyToApply &&
+                              settings.UpdateStatusText == permissionStatus,
+                        "Settings update section did not remain ready after Android install permission redirect.");
+
+                    var statusText = FindControlByAutomationId<TextBlock>(view, "UpdateStatusText");
+                    await Assert.That(updateService.ApplyCalls).IsEqualTo(1);
+                    await Assert.That(statusText.Text).IsEqualTo(permissionStatus);
+                    await Assert.That(applyButton.IsEnabled).IsTrue();
+                }
+                finally
                 {
-                    DataContext = settings
-                };
-
-                window = CreateWindow(view, 720, 800);
-                window.Show();
-                Dispatcher.UIThread.RunJobs();
-
-                var currentVersionText = FindControlByAutomationId<TextBlock>(view, "CurrentApplicationVersionText");
-                var availableVersionText = FindControlByAutomationId<TextBlock>(view, "AvailableUpdateVersionText");
-                var checkButton = FindControlByAutomationId<Button>(view, "CheckForUpdatesButton");
-                var downloadButton = FindControlByAutomationId<Button>(view, "DownloadUpdateButton");
-                var applyButton = FindControlByAutomationId<Button>(view, "ApplyUpdateButton");
-
-                await Assert.That(currentVersionText.Text).IsEqualTo("1.2.3");
-                await Assert.That(checkButton.IsEnabled).IsTrue();
-                await Assert.That(downloadButton.IsEnabled).IsFalse();
-
-                await ClickControlAsync(window, checkButton);
-                await WaitForConditionAsync(
-                    () => settings.UpdateState == ApplicationUpdateState.UpdateAvailable,
-                    "Settings update section did not show an available update.");
-
-                await Assert.That(availableVersionText.Text).IsEqualTo("1.2.4");
-                await Assert.That(downloadButton.IsEnabled).IsTrue();
-
-                await ClickControlAsync(window, downloadButton);
-                await WaitForConditionAsync(
-                    () => settings.UpdateState == ApplicationUpdateState.ReadyToApply,
-                    "Settings update section did not switch to ready-to-apply after download.");
-
-                await Assert.That(updateService.DownloadCalls).IsEqualTo(1);
-                await Assert.That(applyButton.IsEnabled).IsTrue();
-
-                const string permissionStatus = "Grant install permission, then tap Install update again.";
-                updateService.ApplyException = new ApplicationUpdateUserActionRequiredException(permissionStatus);
-
-                await ClickControlAsync(window, applyButton);
-                await WaitForConditionAsync(
-                    () => settings.UpdateState == ApplicationUpdateState.ReadyToApply &&
-                          settings.UpdateStatusText == permissionStatus,
-                    "Settings update section did not remain ready after Android install permission redirect.");
-
-                var statusText = FindControlByAutomationId<TextBlock>(view, "UpdateStatusText");
-                await Assert.That(updateService.ApplyCalls).IsEqualTo(1);
-                await Assert.That(statusText.Text).IsEqualTo(permissionStatus);
-                await Assert.That(applyButton.IsEnabled).IsTrue();
-            }
-            finally
-            {
-                window?.Close();
-                fixture.CleanTasks();
-            }
-        }, CancellationToken.None);
+                    window?.Close();
+                    fixture.CleanTasks();
+                }
+            }, CancellationToken.None);
+        }
+        finally
+        {
+            await session.DisposeIgnoringHeadlessTeardownNullReferenceAsync();
+        }
     }
 
     [Test]
     public async Task SettingsControl_UpdateAutoCheckSettings_UpdateViewModelFromControls()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -242,7 +256,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task SettingsControl_NarrowViewport_DoesNotOverflowHorizontally()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -321,7 +335,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task SettingsControl_BrowseTaskStoragePath_UpdatesPathFromFolderPicker()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -394,7 +408,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task SettingsControl_LocalStorageConnect_UsesEditedTaskStoragePath()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -444,7 +458,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task SettingsControl_SyncConflictResolutionMode_ShowsOpenResolverAction()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var configPath = Path.Combine(Environment.CurrentDirectory, $"SyncConflictSettings_{Guid.NewGuid():N}.json");
@@ -525,7 +539,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task ConflictResolutionControl_ShowsFieldDecisionsAndDeleteSideAction()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var configPath = Path.Combine(Environment.CurrentDirectory, $"ConflictResolver_{Guid.NewGuid():N}.json");
@@ -631,7 +645,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task ConflictResolutionControl_UsesSingleColumnLayoutOnPhoneWidth()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var configPath = Path.Combine(Environment.CurrentDirectory, $"ConflictResolverPhone_{Guid.NewGuid():N}.json");
@@ -678,7 +692,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task ConflictResolutionControl_PhoneWidth_WithManyConflicts_KeepsDetailsAndActionsVisible()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var configPath = Path.Combine(Environment.CurrentDirectory, $"ConflictResolverMany_{Guid.NewGuid():N}.json");
@@ -749,7 +763,7 @@ public class SettingsControlResponsiveUiTests
     [Test]
     public async Task ConflictResolutionControl_PhoneWidth_WhenAllConflictsResolved_HidesFilePane()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var configPath = Path.Combine(Environment.CurrentDirectory, $"ConflictResolverResolved_{Guid.NewGuid():N}.json");

--- a/src/Unlimotion.Test/SettingsViewModelTests.cs
+++ b/src/Unlimotion.Test/SettingsViewModelTests.cs
@@ -1721,43 +1721,18 @@ public class SettingsViewModelTests : IDisposable
         IRemoteBackupService backupService,
         ITaskStorageFactory storageFactory)
     {
-        const BindingFlags fieldFlags = BindingFlags.Static | BindingFlags.NonPublic;
         var appType = typeof(App);
-        var fieldValues = new Dictionary<string, object?>
-        {
-            ["_configuration"] = configuration,
-            ["_backupService"] = backupService,
-            ["_storageFactory"] = storageFactory,
-            ["_mainWindowViewModel"] = null,
-            ["_notificationManager"] = null
-        };
-        var previousValues = fieldValues.ToDictionary(
-            pair => pair.Key,
-            pair => GetRequiredAppField(appType, pair.Key, fieldFlags).GetValue(null));
-
-        foreach (var pair in fieldValues)
-        {
-            GetRequiredAppField(appType, pair.Key, fieldFlags).SetValue(null, pair.Value);
-        }
+        var app = new App();
+        app.ConfigureRuntimeForTests(configuration, backupService, storageFactory);
 
         var setupSettingsCommands = appType.GetMethod(
                                         "SetupSettingsCommands",
                                         BindingFlags.Instance | BindingFlags.NonPublic)
                                     ?? throw new MissingMethodException(nameof(App), "SetupSettingsCommands");
-        setupSettingsCommands.Invoke(new App(), [settings]);
+        setupSettingsCommands.Invoke(app, [settings]);
 
-        return new DelegateDisposable(() =>
-        {
-            foreach (var pair in previousValues)
-            {
-                GetRequiredAppField(appType, pair.Key, fieldFlags).SetValue(null, pair.Value);
-            }
-        });
+        return new DelegateDisposable(() => { });
     }
-
-    private static FieldInfo GetRequiredAppField(Type appType, string fieldName, BindingFlags flags) =>
-        appType.GetField(fieldName, flags)
-        ?? throw new MissingFieldException(nameof(App), fieldName);
 
     private static async System.Threading.Tasks.Task WaitForConditionAsync(
         Func<bool> condition,
@@ -1787,26 +1762,36 @@ public class SettingsViewModelTests : IDisposable
         public RecordingTaskStorageFactory(string currentPath, ConcurrentQueue<string> events)
         {
             _events = events;
-            CurrentStorage = CreateFileStorageWithoutRecording(currentPath);
+            ActiveStorage = CreateFileStorageWithoutRecording(currentPath);
         }
 
-        public ITaskStorage? CurrentStorage { get; private set; }
-        public IDatabaseWatcher? CurrentWatcher => null;
-        public string? CurrentFileStoragePath => (CurrentStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
+        public ITaskStorage? ActiveStorage { get; private set; }
+        public ITaskSourceManager SourceManager => new FakeTaskSourceManager(
+            () => ActiveStorage,
+            switchStorageAsync: SwitchStorageAsync);
+        public string? CurrentFileStoragePath => (ActiveStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
+
+        public ITaskStorage CreateConfiguredStorage() => throw new NotSupportedException();
 
         public ITaskStorage CreateFileStorage(string? path)
         {
             _events.Enqueue($"switch-local:{path}");
-            CurrentStorage = CreateFileStorageWithoutRecording(path);
-            return CurrentStorage;
+            ActiveStorage = CreateFileStorageWithoutRecording(path);
+            return ActiveStorage;
+        }
+
+        public ITaskStorage CreateDetachedFileStorage(string? path)
+        {
+            _events.Enqueue($"detached-local:{path}");
+            return CreateFileStorageWithoutRecording(path);
         }
 
         public ITaskStorage CreateServerStorage(string? url)
         {
             _events.Enqueue($"switch-server:{url}");
-            CurrentStorage = CreateFileStorageWithoutRecording(
+            ActiveStorage = CreateFileStorageWithoutRecording(
                 Path.Combine(Environment.CurrentDirectory, $"ServerStoragePlaceholder-{Guid.NewGuid():N}"));
-            return CurrentStorage;
+            return ActiveStorage;
         }
 
         public void SwitchStorage(bool isServerMode, IConfiguration configuration)
@@ -1819,6 +1804,12 @@ public class SettingsViewModelTests : IDisposable
             }
 
             CreateFileStorage(settings?.Path);
+        }
+
+        public System.Threading.Tasks.Task SwitchStorageAsync(bool isServerMode, IConfiguration configuration)
+        {
+            SwitchStorage(isServerMode, configuration);
+            return System.Threading.Tasks.Task.CompletedTask;
         }
 
         public void Dispose()

--- a/src/Unlimotion.Test/SingleViewStartupUiTests.cs
+++ b/src/Unlimotion.Test/SingleViewStartupUiTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
 using Avalonia.Headless;
 using Avalonia.Threading;
 using Microsoft.Extensions.Configuration;
@@ -21,12 +22,12 @@ public class SingleViewStartupUiTests
     [Test]
     public async Task SingleViewStartup_ConnectsExistingTaskStorage()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             using var context = SingleViewStartupContext.Create();
 
-            var app = new App();
+            var app = GetCurrentApp();
             var vm = context.MainWindowViewModel;
 
             var mainScreen = app.CreateSingleViewMainView(vm);
@@ -54,39 +55,46 @@ public class SingleViewStartupUiTests
     [Test]
     public async Task SingleViewStartup_DoesNotReloadInitializedTaskStorage()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.DispatchAsync(async () =>
+        var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        try
         {
-            using var context = SingleViewStartupContext.Create();
-
-            var app = new App();
-            var vm = context.MainWindowViewModel;
-            await app.InitializeStartupViewModelAsync(vm);
-
-            var connectCallCount = context.Storage.ConnectCallCount;
-            var getAllCallCount = context.Storage.GetAllCallCount;
-
-            await app.InitializeStartupViewModelAsync(vm);
-
-            using (Assert.Multiple())
+            await session.DispatchAsync(async () =>
             {
-                await Assert.That(vm.IsInitialized).IsTrue();
-                await Assert.That(vm.taskRepository!.Tasks.Count).IsEqualTo(1);
-                await Assert.That(context.Storage.ConnectCallCount).IsEqualTo(connectCallCount);
-                await Assert.That(context.Storage.GetAllCallCount).IsEqualTo(getAllCallCount);
-            }
-        }, CancellationToken.None);
+                using var context = SingleViewStartupContext.Create();
+
+                var app = GetCurrentApp();
+                var vm = context.MainWindowViewModel;
+                await app.InitializeStartupViewModelAsync(vm);
+
+                var connectCallCount = context.Storage.ConnectCallCount;
+                var getAllCallCount = context.Storage.GetAllCallCount;
+
+                await app.InitializeStartupViewModelAsync(vm);
+
+                using (Assert.Multiple())
+                {
+                    await Assert.That(vm.IsInitialized).IsTrue();
+                    await Assert.That(vm.taskRepository!.Tasks.Count).IsEqualTo(1);
+                    await Assert.That(context.Storage.ConnectCallCount).IsEqualTo(connectCallCount);
+                    await Assert.That(context.Storage.GetAllCallCount).IsEqualTo(getAllCallCount);
+                }
+            }, CancellationToken.None);
+        }
+        finally
+        {
+            await session.DisposeIgnoringHeadlessTeardownNullReferenceAsync();
+        }
     }
 
     [Test]
     public async Task SingleViewStartup_ConnectsMigratedLocalFolderOutsideGitAndAllowsCreate()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             using var context = FileStorageStartupContext.CreateWithLegacyTaskOutsideGit();
 
-            var app = new App();
+            var app = GetCurrentApp();
             var vm = context.MainWindowViewModel;
 
             var startupTask = app.InitializeStartupViewModelAsync(vm);
@@ -120,11 +128,11 @@ public class SingleViewStartupUiTests
     [Test]
     public async Task SingleViewStartup_ReplaysStartupUpdateCheck_WhenUpdateServiceAttachesAfterStartup()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             using var context = SingleViewStartupContext.Create();
-            var app = new App();
+            var app = GetCurrentApp();
             var updateService = new CountingApplicationUpdateService();
 
             try
@@ -162,6 +170,12 @@ public class SingleViewStartupUiTests
         }, TimeSpan.FromMilliseconds(timeoutMilliseconds));
     }
 
+    private static App GetCurrentApp()
+    {
+        return Application.Current as App
+               ?? throw new InvalidOperationException("Current Avalonia application is not an Unlimotion App.");
+    }
+
     private sealed class SingleViewStartupContext : IDisposable
     {
         private readonly string _configPath;
@@ -193,7 +207,11 @@ public class SingleViewStartupUiTests
             IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(configPath, reloadOnChange: false);
             var notificationManager = new NotificationManagerWrapperMock();
             var storage = new CountingStorage();
-            var taskStorage = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            var taskContext = new TaskItemViewModelContext
+            {
+                NotificationManager = notificationManager
+            };
+            var taskStorage = new UnifiedTaskStorage(new TaskTreeManager(storage), taskContext);
             var settings = new SettingsViewModel(configuration);
             var mainWindowViewModel = new MainWindowViewModel(
                 new AppNameDefinitionService(),
@@ -202,8 +220,7 @@ public class SingleViewStartupUiTests
                 () => taskStorage,
                 settings);
 
-            TaskItemViewModel.NotificationManagerInstance = notificationManager;
-            TaskItemViewModel.MainWindowInstance = mainWindowViewModel;
+            taskContext.MainWindow = mainWindowViewModel;
 
             return new SingleViewStartupContext(
                 configPath,
@@ -270,7 +287,11 @@ public class SingleViewStartupUiTests
 
             var notificationManager = new NotificationManagerWrapperMock();
             var fileStorage = new FileStorage(tasksPath, watcher: false, notificationManager);
-            var taskStorage = new UnifiedTaskStorage(new TaskTreeManager(fileStorage));
+            var taskContext = new TaskItemViewModelContext
+            {
+                NotificationManager = notificationManager
+            };
+            var taskStorage = new UnifiedTaskStorage(new TaskTreeManager(fileStorage), taskContext);
             var settings = new SettingsViewModel(configuration)
             {
                 TaskStoragePath = tasksPath
@@ -282,8 +303,7 @@ public class SingleViewStartupUiTests
                 () => taskStorage,
                 settings);
 
-            TaskItemViewModel.NotificationManagerInstance = notificationManager;
-            TaskItemViewModel.MainWindowInstance = mainWindowViewModel;
+            taskContext.MainWindow = mainWindowViewModel;
 
             return new FileStorageStartupContext(
                 configPath,

--- a/src/Unlimotion.Test/TaskImportanceUiTests.cs
+++ b/src/Unlimotion.Test/TaskImportanceUiTests.cs
@@ -24,7 +24,7 @@ public class TaskImportanceUiTests
     [Test]
     public async Task WantedTaskTitle_ShouldBeBold_InAllTasksTreeAndParentRelationTree()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -77,7 +77,7 @@ public class TaskImportanceUiTests
     [Test]
     public async Task WantedTaskTitle_ShouldBeBold_InRoadmapGraph()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
@@ -121,7 +121,7 @@ public class TaskImportanceUiTests
     [Test]
     public async Task WantedTaskTitle_WithMiddleEmoji_ShouldRenderEmojiRunNormal_InAllTasksTree()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
+++ b/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
@@ -31,7 +31,7 @@ public class TaskListRepeaterMarkerUiTests
         {
             CultureSnapshot.Apply(CultureInfo.GetCultureInfo(LocalizationService.RussianLanguage));
 
-            await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
             await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.Test/TaskSourceManagerTests.cs
+++ b/src/Unlimotion.Test/TaskSourceManagerTests.cs
@@ -1,0 +1,525 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Unlimotion.Domain;
+using Unlimotion.Services;
+using Unlimotion.TaskTree;
+using Unlimotion.ViewModel;
+using WritableJsonConfiguration;
+
+namespace Unlimotion.Test;
+
+public sealed class TaskSourceManagerTests : IDisposable
+{
+    private readonly string _rootPath = Path.Combine(
+        Path.GetTempPath(),
+        $"TaskSourceManagerTests_{Guid.NewGuid():N}");
+    private readonly List<IDisposable> _disposables = [];
+
+    public TaskSourceManagerTests()
+    {
+        Directory.CreateDirectory(_rootPath);
+    }
+
+    [Test]
+    public async Task LoadOrCreate_ProjectsLegacyLocalStorageToDefaultSource()
+    {
+        var configuration = CreateConfiguration();
+        var legacyPath = Path.Combine(_rootPath, "legacy-tasks");
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.Path)).Set(legacyPath);
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.IsServerMode)).Set(false);
+
+        var settings = TaskSourceSettingsAdapter.LoadOrCreate(configuration, "fallback-tasks");
+
+        await Assert.That(settings.ActiveSourceId).IsEqualTo(TaskSourceDescriptor.DefaultSourceId);
+        await Assert.That(settings.Sources.Count).IsEqualTo(1);
+        await Assert.That(settings.Sources[0].Kind).IsEqualTo(TaskSourceKind.File);
+        await Assert.That(settings.Sources[0].Path).IsEqualTo(legacyPath);
+        await Assert.That(TaskSourceSettingsAdapter.LoadOrCreate(configuration, "fallback-tasks").Sources[0].Path)
+            .IsEqualTo(legacyPath);
+    }
+
+    [Test]
+    public async Task LoadOrCreate_ProjectsLegacyServerCredentialsToDefaultSource()
+    {
+        var configuration = CreateConfiguration();
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.IsServerMode)).Set(true);
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.URL)).Set("https://tasks.example");
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.Login)).Set("legacy-login");
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.Password)).Set("legacy-password");
+        configuration.Set("ClientSettings", new ClientSettings
+        {
+            AccessToken = "legacy-access",
+            RefreshToken = "legacy-refresh",
+            UserId = "legacy-user",
+            Login = "legacy-client-login",
+            ExpireTime = DateTimeOffset.UtcNow.AddHours(1)
+        });
+
+        var settings = TaskSourceSettingsAdapter.LoadOrCreate(configuration, "fallback-tasks");
+        var source = settings.Sources.Single();
+        var serverSettings = settings.ServerSettings.Single();
+
+        await Assert.That(source.Kind).IsEqualTo(TaskSourceKind.Server);
+        await Assert.That(source.Url).IsEqualTo("https://tasks.example");
+        await Assert.That(serverSettings.SourceId).IsEqualTo(TaskSourceDescriptor.DefaultSourceId);
+        await Assert.That(serverSettings.Login).IsEqualTo("legacy-login");
+        await Assert.That(serverSettings.Password).IsEqualTo("legacy-password");
+        await Assert.That(serverSettings.AccessToken).IsEqualTo("legacy-access");
+        await Assert.That(serverSettings.RefreshToken).IsEqualTo("legacy-refresh");
+        await Assert.That(serverSettings.UserId).IsEqualTo("legacy-user");
+    }
+
+    [Test]
+    public async Task EnsureServerSettings_DoesNotCopyLegacyTokensToNonDefaultSource()
+    {
+        var configuration = CreateConfiguration();
+        configuration.Set("ClientSettings", new ClientSettings
+        {
+            AccessToken = "default-access",
+            RefreshToken = "default-refresh",
+            UserId = "default-user",
+            Login = "default-login",
+            ExpireTime = DateTimeOffset.UtcNow.AddHours(1)
+        });
+        var settings = new TaskSourcesSettings();
+        var legacyStorage = new TaskStorageSettings
+        {
+            Login = "work-login",
+            Password = "work-password"
+        };
+
+        var serverSettings = TaskSourceSettingsAdapter.EnsureServerSettings(
+            settings,
+            "work",
+            legacyStorage,
+            configuration);
+
+        await Assert.That(serverSettings.SourceId).IsEqualTo("work");
+        await Assert.That(serverSettings.Login).IsEqualTo("work-login");
+        await Assert.That(serverSettings.Password).IsEqualTo("work-password");
+        await Assert.That(serverSettings.AccessToken).IsEmpty();
+        await Assert.That(serverSettings.RefreshToken).IsEmpty();
+        await Assert.That(serverSettings.UserId).IsEmpty();
+    }
+
+    [Test]
+    public async Task SourceManager_ActivatesPersistedActiveSource()
+    {
+        var configuration = CreateConfiguration();
+        var defaultPath = Path.Combine(_rootPath, "default");
+        var workPath = Path.Combine(_rootPath, "work");
+        TaskSourceSettingsAdapter.Save(configuration, new TaskSourcesSettings
+        {
+            ActiveSourceId = "work",
+            Sources =
+            [
+                new TaskSourceDescriptor
+                {
+                    Id = TaskSourceDescriptor.DefaultSourceId,
+                    Kind = TaskSourceKind.File,
+                    Path = defaultPath
+                },
+                new TaskSourceDescriptor
+                {
+                    Id = "work",
+                    Kind = TaskSourceKind.File,
+                    Path = workPath
+                }
+            ]
+        });
+        var builder = new RecordingTaskStorageBuilder();
+        var manager = new TaskSourceManager(configuration, builder, defaultStoragePathProvider: () => defaultPath);
+
+        var activeSource = manager.ActivateConfiguredSource();
+        var persisted = TaskSourceSettingsAdapter.LoadOrCreate(configuration, defaultPath);
+
+        await Assert.That(activeSource.Descriptor.Id).IsEqualTo("work");
+        await Assert.That(activeSource.Descriptor.Path).IsEqualTo(workPath);
+        await Assert.That(builder.Builds.Single().Descriptor.Id).IsEqualTo("work");
+        await Assert.That(builder.Builds.Single().Descriptor.Path).IsEqualTo(workPath);
+        await Assert.That(persisted.ActiveSourceId).IsEqualTo("work");
+    }
+
+    [Test]
+    public async Task SourceManager_SwitchStorageUpdatesActiveNonDefaultSource()
+    {
+        var configuration = CreateConfiguration();
+        var defaultPath = Path.Combine(_rootPath, "default");
+        var initialWorkPath = Path.Combine(_rootPath, "work-a");
+        var selectedWorkPath = Path.Combine(_rootPath, "work-b");
+        TaskSourceSettingsAdapter.Save(configuration, new TaskSourcesSettings
+        {
+            ActiveSourceId = "work",
+            Sources =
+            [
+                new TaskSourceDescriptor
+                {
+                    Id = TaskSourceDescriptor.DefaultSourceId,
+                    Kind = TaskSourceKind.File,
+                    Path = defaultPath
+                },
+                new TaskSourceDescriptor
+                {
+                    Id = "work",
+                    DisplayName = "Work",
+                    Kind = TaskSourceKind.File,
+                    Path = initialWorkPath
+                }
+            ]
+        });
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.Path)).Set(selectedWorkPath);
+        configuration.GetSection("TaskStorage").GetSection(nameof(TaskStorageSettings.IsServerMode)).Set(false);
+        var builder = new RecordingTaskStorageBuilder();
+        var manager = new TaskSourceManager(configuration, builder, defaultStoragePathProvider: () => defaultPath);
+        manager.ActivateConfiguredSource();
+
+        await manager.SwitchStorageAsync(isServerMode: false, configuration);
+        var persisted = TaskSourceSettingsAdapter.LoadOrCreate(configuration, defaultPath);
+        var activeSource = persisted.Sources.Single(source => source.Id == "work");
+
+        await Assert.That(manager.ActiveSource?.Descriptor.Id).IsEqualTo("work");
+        await Assert.That(manager.ActiveSource?.Descriptor.Path).IsEqualTo(selectedWorkPath);
+        await Assert.That(activeSource.Path).IsEqualTo(selectedWorkPath);
+        await Assert.That(persisted.ActiveSourceId).IsEqualTo("work");
+        await Assert.That(builder.Builds.Last().Descriptor.Id).IsEqualTo("work");
+    }
+
+    [Test]
+    public async Task SourceManager_ReplacesSameSourceIdAndDisconnectsPreviousStorage()
+    {
+        var configuration = CreateConfiguration();
+        var builder = new RecordingTaskStorageBuilder();
+        var manager = new TaskSourceManager(
+            configuration,
+            builder,
+            defaultStoragePathProvider: () => Path.Combine(_rootPath, "default"));
+        var firstPath = Path.Combine(_rootPath, "default-a");
+        var secondPath = Path.Combine(_rootPath, "default-b");
+
+        var first = manager.ActivateSource(new TaskSourceDescriptor
+        {
+            Id = TaskSourceDescriptor.DefaultSourceId,
+            Kind = TaskSourceKind.File,
+            Path = firstPath
+        });
+        var second = manager.ActivateSource(new TaskSourceDescriptor
+        {
+            Id = TaskSourceDescriptor.DefaultSourceId,
+            Kind = TaskSourceKind.File,
+            Path = secondPath
+        });
+
+        await Assert.That(first.Storage).IsNotSameReferenceAs(second.Storage);
+        await Assert.That(builder.Builds[0].Storage.DisconnectCalls).IsEqualTo(1);
+        await Assert.That(manager.Sources.Count).IsEqualTo(1);
+        await Assert.That(manager.ActiveSource).IsSameReferenceAs(second);
+        await Assert.That(manager.ActiveSource!.Descriptor.Path).IsEqualTo(secondPath);
+    }
+
+    [Test]
+    public async Task SourceManager_BuildFailureKeepsPreviousActiveSourceAlive()
+    {
+        var configuration = CreateConfiguration();
+        var defaultPath = Path.Combine(_rootPath, "default");
+        var builder = new RecordingTaskStorageBuilder();
+        var manager = new TaskSourceManager(
+            configuration,
+            builder,
+            defaultStoragePathProvider: () => defaultPath);
+
+        var first = manager.ActivateSource(new TaskSourceDescriptor
+        {
+            Id = TaskSourceDescriptor.DefaultSourceId,
+            Kind = TaskSourceKind.File,
+            Path = defaultPath
+        });
+        builder.ThrowForSourceId = "work";
+
+        await Assert.That(async () => await manager.ActivateSourceAsync(new TaskSourceDescriptor
+            {
+                Id = "work",
+                Kind = TaskSourceKind.File,
+                Path = Path.Combine(_rootPath, "work")
+            }))
+            .Throws<InvalidOperationException>();
+        var persisted = TaskSourceSettingsAdapter.LoadOrCreate(configuration, defaultPath);
+
+        await Assert.That(manager.ActiveSource).IsSameReferenceAs(first);
+        await Assert.That(first.Storage.TaskTreeManager.Storage is RecordingStorage { DisconnectCalls: 0 }).IsTrue();
+        await Assert.That(manager.Sources.Select(source => source.Descriptor.Id)).DoesNotContain("work");
+        await Assert.That(persisted.ActiveSourceId).IsEqualTo(TaskSourceDescriptor.DefaultSourceId);
+        await Assert.That(persisted.Sources.Select(source => source.Id)).DoesNotContain("work");
+    }
+
+    [Test]
+    public async Task SourceManager_CreatesTwoFileSourcesWithoutSharingStorageOrContext()
+    {
+        var configuration = CreateConfiguration();
+        var notificationManager = new NotificationManagerWrapperMock();
+        var mapper = AppModelMapping.ConfigureMapping();
+        var builder = new TaskStorageBuilder(configuration, mapper, notificationManager, () => Path.Combine(_rootPath, "default"));
+        var manager = new TaskSourceManager(configuration, builder, notificationManager, () => Path.Combine(_rootPath, "default"));
+
+        var first = manager.ActivateSource(new TaskSourceDescriptor
+        {
+            Id = "local-a",
+            Kind = TaskSourceKind.File,
+            Path = Path.Combine(_rootPath, "local-a")
+        });
+        var second = manager.ActivateSource(new TaskSourceDescriptor
+        {
+            Id = "local-b",
+            Kind = TaskSourceKind.File,
+            Path = Path.Combine(_rootPath, "local-b")
+        });
+
+        try
+        {
+            await Assert.That(first.Storage).IsNotSameReferenceAs(second.Storage);
+            await Assert.That(first.TaskContext).IsNotSameReferenceAs(second.TaskContext);
+            await Assert.That(first.TaskContext.SourceId).IsEqualTo("local-a");
+            await Assert.That(second.TaskContext.SourceId).IsEqualTo("local-b");
+            await Assert.That(first.TaskContext.NotificationManager).IsSameReferenceAs(notificationManager);
+            await Assert.That(manager.ActiveSource).IsSameReferenceAs(second);
+            await Assert.That(manager.Sources.Count).IsEqualTo(2);
+        }
+        finally
+        {
+            (first.Storage as IDisposable)?.Dispose();
+            (second.Storage as IDisposable)?.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task TaskStorageFactory_CreateDetachedFileStorageDoesNotSwitchActiveSource()
+    {
+        var configuration = CreateConfiguration();
+        var defaultPath = Path.Combine(_rootPath, "default");
+        var detachedPath = Path.Combine(_rootPath, "detached");
+        var notificationManager = new NotificationManagerWrapperMock();
+        var mapper = AppModelMapping.ConfigureMapping();
+        var factory = new TaskStorageFactory(configuration, mapper, notificationManager, () => defaultPath);
+        var activeStorage = factory.CreateConfiguredStorage();
+        var activeSource = factory.SourceManager.ActiveSource;
+
+        var detachedStorage = factory.CreateDetachedFileStorage(detachedPath);
+
+        try
+        {
+            await Assert.That(factory.SourceManager.ActiveSource).IsSameReferenceAs(activeSource);
+            await Assert.That(factory.SourceManager.ActiveStorage).IsSameReferenceAs(activeStorage);
+            await Assert.That((detachedStorage.TaskTreeManager.Storage as FileStorage)?.Path).IsEqualTo(detachedPath);
+        }
+        finally
+        {
+            (activeStorage as IDisposable)?.Dispose();
+            (detachedStorage as IDisposable)?.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task TaskItemViewModel_ReceivesSourceContextAndKeepsOwningStorage()
+    {
+        var firstStorage = new RecordingStorage();
+        var secondStorage = new RecordingStorage();
+        var firstRepository = new UnifiedTaskStorage(
+            new TaskTreeManager(firstStorage),
+            new TaskItemViewModelContext
+            {
+                SourceId = "source-a",
+                NotificationManager = new NotificationManagerWrapperMock()
+            });
+        var secondRepository = new UnifiedTaskStorage(
+            new TaskTreeManager(secondStorage),
+            new TaskItemViewModelContext { SourceId = "source-b" });
+
+        var firstTask = new TaskItemViewModel(
+            new TaskItem { Id = "task-a", Title = "Task A" },
+            firstRepository,
+            () => false,
+            context: new TaskItemViewModelContext { SourceId = "source-a" });
+        _ = new TaskItemViewModel(
+            new TaskItem { Id = "task-b", Title = "Task B" },
+            secondRepository,
+            () => false,
+            context: new TaskItemViewModelContext { SourceId = "source-b" });
+
+        await firstTask.SaveItemCommand.Execute().ToTask();
+
+        await Assert.That(firstTask.SourceId).IsEqualTo("source-a");
+        await Assert.That(firstStorage.SavedTaskIds.Contains("task-a")).IsTrue();
+        await Assert.That(secondStorage.SavedTaskIds).IsEmpty();
+    }
+
+    [Test]
+    public async Task ServerSettings_PersistDistinctTokensPerSource()
+    {
+        var configuration = CreateConfiguration();
+        var settings = new TaskSourcesSettings
+        {
+            ActiveSourceId = TaskSourceDescriptor.DefaultSourceId,
+            Sources =
+            [
+                new TaskSourceDescriptor
+                {
+                    Id = TaskSourceDescriptor.DefaultSourceId,
+                    Kind = TaskSourceKind.Server,
+                    Url = "https://default.example"
+                },
+                new TaskSourceDescriptor
+                {
+                    Id = "work",
+                    Kind = TaskSourceKind.Server,
+                    Url = "https://work.example"
+                }
+            ]
+        };
+
+        TaskSourceSettingsAdapter.PersistServerSettings(configuration, settings, new TaskSourceServerSettings
+        {
+            SourceId = TaskSourceDescriptor.DefaultSourceId,
+            Login = "default-login",
+            AccessToken = "default-access",
+            RefreshToken = "default-refresh"
+        });
+        TaskSourceSettingsAdapter.PersistServerSettings(configuration, settings, new TaskSourceServerSettings
+        {
+            SourceId = "work",
+            Login = "work-login",
+            AccessToken = "work-access",
+            RefreshToken = "work-refresh"
+        });
+
+        var persisted = TaskSourceSettingsAdapter.LoadOrCreate(configuration, "fallback-tasks");
+        var defaultServer = persisted.ServerSettings.Single(server => server.SourceId == TaskSourceDescriptor.DefaultSourceId);
+        var workServer = persisted.ServerSettings.Single(server => server.SourceId == "work");
+        var legacyClientSettings = configuration.Get<ClientSettings>("ClientSettings");
+
+        await Assert.That(defaultServer.AccessToken).IsEqualTo("default-access");
+        await Assert.That(workServer.AccessToken).IsEqualTo("work-access");
+        await Assert.That(defaultServer.RefreshToken).IsEqualTo("default-refresh");
+        await Assert.That(workServer.RefreshToken).IsEqualTo("work-refresh");
+        await Assert.That(legacyClientSettings?.AccessToken).IsEqualTo("default-access");
+        await Assert.That(legacyClientSettings?.Login).IsEqualTo("default-login");
+    }
+
+    [Test]
+    public async Task ServerStorage_DisconnectDoesNotClearSourceTokens()
+    {
+        var configuration = CreateConfiguration();
+        var serverSettings = new TaskSourceServerSettings
+        {
+            SourceId = "work",
+            AccessToken = "access-token",
+            RefreshToken = "refresh-token"
+        };
+        var persistCalls = 0;
+        var storage = new ServerStorage(
+            "https://tasks.example",
+            configuration,
+            serverSettings,
+            _ => persistCalls++);
+
+        await storage.Disconnect();
+
+        await Assert.That(serverSettings.AccessToken).IsEqualTo("access-token");
+        await Assert.That(serverSettings.RefreshToken).IsEqualTo("refresh-token");
+        await Assert.That(persistCalls).IsEqualTo(0);
+    }
+
+    public void Dispose()
+    {
+        foreach (var disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+
+        if (Directory.Exists(_rootPath))
+        {
+            Directory.Delete(_rootPath, recursive: true);
+        }
+    }
+
+    private IConfigurationRoot CreateConfiguration()
+    {
+        var path = Path.Combine(_rootPath, $"{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, "{}");
+        var configuration = WritableJsonConfigurationFabric.Create(path, reloadOnChange: false);
+        if (configuration is IDisposable disposable)
+        {
+            _disposables.Add(disposable);
+        }
+
+        return configuration;
+    }
+
+    private sealed class RecordingStorage : IStorage
+    {
+        public List<string?> SavedTaskIds { get; } = [];
+        public int DisconnectCalls { get; private set; }
+
+        public event EventHandler<TaskStorageUpdateEventArgs>? Updating
+        {
+            add { }
+            remove { }
+        }
+
+        public event Action<Exception?>? OnConnectionError
+        {
+            add { }
+            remove { }
+        }
+
+        public Task<TaskItem> Save(TaskItem taskItem)
+        {
+            SavedTaskIds.Add(taskItem.Id);
+            return Task.FromResult(taskItem);
+        }
+
+        public Task<bool> Remove(string itemId) => Task.FromResult(true);
+        public Task<TaskItem?> Load(string itemId) => Task.FromResult<TaskItem?>(null);
+        public async IAsyncEnumerable<TaskItem> GetAll() { yield break; }
+        public Task BulkInsert(IEnumerable<TaskItem> taskItems) => Task.CompletedTask;
+        public Task<bool> Connect() => Task.FromResult(true);
+        public Task Disconnect()
+        {
+            DisconnectCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingTaskStorageBuilder : ITaskStorageBuilder
+    {
+        public List<(TaskSourceDescriptor Descriptor, RecordingStorage Storage)> Builds { get; } = [];
+        public string? ThrowForSourceId { get; set; }
+
+        public TaskStorageBuildResult Build(TaskStorageBuildRequest request)
+        {
+            if (string.Equals(request.Descriptor.Id, ThrowForSourceId, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException("Build failed.");
+            }
+
+            var storage = new RecordingStorage();
+            var descriptor = new TaskSourceDescriptor
+            {
+                Id = request.Descriptor.Id,
+                DisplayName = request.Descriptor.DisplayName,
+                Kind = request.Descriptor.Kind,
+                Path = request.Descriptor.Path,
+                Url = request.Descriptor.Url,
+                IsEnabled = request.Descriptor.IsEnabled
+            };
+            Builds.Add((descriptor, storage));
+
+            return new TaskStorageBuildResult(
+                new UnifiedTaskStorage(new TaskTreeManager(storage), request.TaskContext),
+                watcher: null);
+        }
+    }
+}

--- a/src/Unlimotion.Test/ToastNotificationUiTests.cs
+++ b/src/Unlimotion.Test/ToastNotificationUiTests.cs
@@ -20,7 +20,7 @@ public class ToastNotificationUiTests
     [Test]
     public async Task MainScreen_ErrorToast_RendersAndCloseButtonRemovesMessage()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();

--- a/src/Unlimotion.ViewModel/MainWindowViewModel.cs
+++ b/src/Unlimotion.ViewModel/MainWindowViewModel.cs
@@ -63,6 +63,8 @@ namespace Unlimotion.ViewModel
             new(new ObservableCollectionExtended<EmojiFilter>());
 
         public ITaskStorage? taskRepository;
+        public IDialogs? Dialogs { get; set; }
+        public Func<TaskItemViewModel, ITaskStorage?, string, Task>? MoveTaskTreeToFileStorageAsync { get; set; }
         private readonly Func<ITaskStorage?>? _getTaskStorage;
         private readonly string? _taskTreeExpansionStatePath;
 
@@ -737,15 +739,16 @@ namespace Unlimotion.ViewModel
                     return;
                 }
 
-                if (Settings.IsServerMode)
+                var storage = taskStorage.TaskTreeManager.Storage;
+                Action<Exception?> connectionErrorHandler = _ =>
                 {
-                    taskStorage.TaskTreeManager.Storage.OnConnectionError += ex =>
-                    {
-                        ManagerWrapper?.ErrorToast(L10n.Get("ServerConnectionError"));
-                    };
-                }
+                    ManagerWrapper?.ErrorToast(L10n.Get("ServerConnectionError"));
+                };
+                storage.OnConnectionError += connectionErrorHandler;
+                Disposable.Create(() => storage.OnConnectionError -= connectionErrorHandler)
+                    .AddToDispose(connectionDisposableList);
 
-                await taskStorage.TaskTreeManager.Storage.Connect();
+                await storage.Connect();
                 taskRepository = taskStorage;
 
                 //Если из коллекции пропадает итем, то очищаем выделенный итем.
@@ -1328,6 +1331,7 @@ namespace Unlimotion.ViewModel
                 taskRepository.Tasks
                     .Connect()
                     .AutoRefreshOnObservable(m => m.WhenAny(m => m.Status, status => status.Value == DomainTaskStatus.Completed))
+                    .AutoRefreshOnObservable(m => m.WhenAnyValue(x => x.CompletedDateTime))
                     .AutoRefreshOnObservable(m => m.WhenAnyValue(
                         x => x.Title,
                         x => x.Description,
@@ -1368,6 +1372,7 @@ namespace Unlimotion.ViewModel
                 taskRepository.Tasks
                     .Connect()
                     .AutoRefreshOnObservable(m => m.WhenAny(m => m.Status, status => status.Value == DomainTaskStatus.Archived))
+                    .AutoRefreshOnObservable(m => m.WhenAnyValue(x => x.ArchiveDateTime))
                     .AutoRefreshOnObservable(m => m.WhenAnyValue(
                         x => x.Title,
                         x => x.Description,
@@ -2406,7 +2411,18 @@ namespace Unlimotion.ViewModel
 
             foreach (var node in nodes)
             {
-                var created = await CreateTaskFromOutlineNode(node, parent);
+                var destinationParent = parent;
+                if (!string.IsNullOrWhiteSpace(capturedParentId))
+                {
+                    destinationParent = FindTaskById(capturedParentId);
+                    if (destinationParent == null)
+                    {
+                        ManagerWrapper?.ErrorToast(L10n.Get("PasteTaskOutlineDestinationUnavailable"));
+                        return;
+                    }
+                }
+
+                var created = await CreateTaskFromOutlineNode(node, destinationParent);
                 firstCreated ??= created;
             }
 
@@ -2428,25 +2444,34 @@ namespace Unlimotion.ViewModel
                 ? await taskRepository!.Add()
                 : await taskRepository!.AddChild(parent);
 
-            created.Title = node.Title;
-            if (!string.IsNullOrWhiteSpace(node.Description))
-            {
-                created.Description = node.Description;
-            }
-
-            if (node.Status.HasValue)
-            {
-                created.Status = node.Status.Value;
-                created.StatusHistory.Clear();
-                created.StatusHistory.Add(new Unlimotion.Domain.TaskStatusHistoryEntry
-                {
-                    Status = node.Status.Value,
-                    ChangedAt = DateTimeOffset.UtcNow,
-                    Author = created.Model.UserId ?? "local-user"
-                });
-            }
-
             var createdId = created.Id;
+            var isInitializedProvider = created.IsInitializedProvider;
+            created.IsInitializedProvider = () => false;
+            try
+            {
+                created.Title = node.Title;
+                if (!string.IsNullOrWhiteSpace(node.Description))
+                {
+                    created.Description = node.Description;
+                }
+
+                if (node.Status.HasValue)
+                {
+                    created.Status = node.Status.Value;
+                    created.StatusHistory.Clear();
+                    created.StatusHistory.Add(new Unlimotion.Domain.TaskStatusHistoryEntry
+                    {
+                        Status = node.Status.Value,
+                        ChangedAt = DateTimeOffset.UtcNow,
+                        Author = created.Model.UserId ?? "local-user"
+                    });
+                }
+            }
+            finally
+            {
+                created.IsInitializedProvider = isInitializedProvider;
+            }
+
             var updated = await taskRepository.Update(created);
             created = updated?.Id == createdId
                 ? updated

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -26,9 +26,7 @@ namespace Unlimotion.ViewModel
     [AddINotifyPropertyChangedInterface]
     public class TaskItemViewModel : DisposableList
     {
-        // Static dependencies - set once during app initialization
-        public static INotificationManagerWrapper? NotificationManagerInstance { get; set; }
-        public static MainWindowViewModel? MainWindowInstance { get; set; }
+        public string SourceId { get; }
         public INotificationManagerWrapper? NotificationManager { get; set; }
         public MainWindowViewModel? MainWindow { get; set; }
         public Func<bool>? IsInitializedProvider { get; set; }
@@ -36,9 +34,13 @@ namespace Unlimotion.ViewModel
         public TaskItemViewModel(
             TaskItem model,
             ITaskStorage taskStorage,
-            Func<bool>? isInitializedProvider = null)
+            Func<bool>? isInitializedProvider = null,
+            TaskItemViewModelContext? context = null)
         {
             IsInitializedProvider = isInitializedProvider ?? (() => true);
+            SourceId = context?.SourceId ?? TaskSourceDescriptor.DefaultSourceId;
+            NotificationManager = context?.NotificationManager;
+            MainWindow = context?.MainWindow;
             _taskStorage = taskStorage;
             _containsTasks = new ReadOnlyObservableCollection<TaskItemViewModel>(_containsTasksSource);
             _parentsTasks = new ReadOnlyObservableCollection<TaskItemViewModel>(_parentsTasksSource);
@@ -150,7 +152,7 @@ namespace Unlimotion.ViewModel
 
             ArchiveCommand = ReactiveCommand.Create(() =>
             {
-                var notificationManager = NotificationManager ?? NotificationManagerInstance;
+                var notificationManager = NotificationManager;
 
                 switch (Status)
                 {
@@ -608,7 +610,7 @@ namespace Unlimotion.ViewModel
 
                 if (!CanTransitionToStatus(value.Status, out var reason))
                 {
-                    (NotificationManager ?? NotificationManagerInstance)?.ErrorToast(reason);
+                    NotificationManager?.ErrorToast(reason);
                     RefreshStatusOptions();
                     OnPropertyChanged(nameof(StatusOption));
                     return;
@@ -807,7 +809,7 @@ namespace Unlimotion.ViewModel
             Wanted = wanted;
 
             var childrenTasks = GetChildrenTasks(task => task.Wanted != wanted).ToList();
-            ShowModalAndChangeChildrenWanted(NotificationManager ?? NotificationManagerInstance, Title, childrenTasks, wanted);
+            ShowModalAndChangeChildrenWanted(NotificationManager, Title, childrenTasks, wanted);
         }
 
         private void ShowModalAndChangeChildrenWanted(

--- a/src/Unlimotion.ViewModel/TaskItemViewModelContext.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModelContext.cs
@@ -1,0 +1,8 @@
+namespace Unlimotion.ViewModel;
+
+public sealed class TaskItemViewModelContext
+{
+    public string SourceId { get; init; } = TaskSourceDescriptor.DefaultSourceId;
+    public INotificationManagerWrapper? NotificationManager { get; init; }
+    public MainWindowViewModel? MainWindow { get; set; }
+}

--- a/src/Unlimotion.ViewModel/TaskStorageSettings.cs
+++ b/src/Unlimotion.ViewModel/TaskStorageSettings.cs
@@ -1,4 +1,7 @@
-﻿namespace Unlimotion.ViewModel;
+﻿using System;
+using System.Collections.Generic;
+
+namespace Unlimotion.ViewModel;
 
 public class TaskStorageSettings
 {
@@ -13,6 +16,46 @@ public class TaskStorageSettings
 
     public bool IsServerMode { get ; set ; }
     public bool IsFuzzySearch { get; set; }
+}
+
+public enum TaskSourceKind
+{
+    File,
+    Server
+}
+
+public class TaskSourceDescriptor
+{
+    public const string DefaultSourceId = "default";
+
+    public string Id { get; set; } = DefaultSourceId;
+    public string DisplayName { get; set; } = string.Empty;
+    public TaskSourceKind Kind { get; set; } = TaskSourceKind.File;
+    public string Path { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public bool IsEnabled { get; set; } = true;
+}
+
+public class TaskSourceServerSettings
+{
+    public string SourceId { get; set; } = TaskSourceDescriptor.DefaultSourceId;
+    public string Login { get; set; } = string.Empty;
+
+    //TODO стоит подумать над шифрованным хранением
+    public string Password { get; set; } = string.Empty;
+    public string AccessToken { get; set; } = string.Empty;
+    public string RefreshToken { get; set; } = string.Empty;
+    public DateTimeOffset ExpireTime { get; set; }
+    public string UserId { get; set; } = string.Empty;
+}
+
+public class TaskSourcesSettings
+{
+    public const string SectionName = "TaskSources";
+
+    public string ActiveSourceId { get; set; } = TaskSourceDescriptor.DefaultSourceId;
+    public List<TaskSourceDescriptor> Sources { get; set; } = new();
+    public List<TaskSourceServerSettings> ServerSettings { get; set; } = new();
 }
 
 public class GitSettings

--- a/src/Unlimotion/App.axaml.cs
+++ b/src/Unlimotion/App.axaml.cs
@@ -53,22 +53,27 @@ public class App : Application
     private const string AppSearchBarMinWidthResourceKey = "AppSearchBarMinWidth";
     private const string AppFloatingControlMinHeightResourceKey = "AppFloatingControlMinHeight";
 
-    // Static service instances for the application
-    private static IConfiguration? _configuration;
-    private static IMapper? _mapper;
-    private static IDialogs? _dialogs;
-    private static AppToastNotificationManager? _toastNotificationManager;
-    private static INotificationManagerWrapper? _notificationManager;
-    private static IRemoteBackupService? _backupService;
-    private static IApplicationUpdateService? _applicationUpdateService;
-    private static IAppNameDefinitionService? _appNameService;
-    private static ITaskStorageFactory? _storageFactory;
-    private static string? _configPath;
-    private static IScheduler? _scheduler;
-    private static MainWindowViewModel? _mainWindowViewModel;
-    private static EventHandler? _cultureChangedHandler;
-    private static SettingsViewModel? _startupUpdateSettings;
-    private static bool _startupUpdateCheckPending;
+    private static string? _pendingConfigPath;
+    private static UnlimotionClientOptions _pendingClientOptions = new();
+    private static IApplicationUpdateService? _pendingUpdateService;
+
+    private IConfiguration? _configuration;
+    private IMapper? _mapper;
+    private IDialogs? _dialogs;
+    private AppToastNotificationManager? _toastNotificationManager;
+    private INotificationManagerWrapper? _notificationManager;
+    private IRemoteBackupService? _backupService;
+    private IApplicationUpdateService? _applicationUpdateService;
+    private IAppNameDefinitionService? _appNameService;
+    private ITaskStorageFactory? _storageFactory;
+    private TaskMoveService? _taskMoveService;
+    private UnlimotionClientOptions _clientOptions = new();
+    private string? _configPath;
+    private IScheduler? _scheduler;
+    private MainWindowViewModel? _mainWindowViewModel;
+    private EventHandler? _cultureChangedHandler;
+    private SettingsViewModel? _startupUpdateSettings;
+    private bool _startupUpdateCheckPending;
     private ServerStorage? _wiredServerStorage;
     private Action? _serverConnectedHandler;
     private Action<Exception?>? _serverConnectionErrorHandler;
@@ -81,11 +86,6 @@ public class App : Application
     private IDisposable? _updateStateSubscription;
     private bool _isAutomaticUpdateCheckRunning;
     
-    /// <summary>
-    /// Default storage path for tasks (used as fallback when config doesn't specify one)
-    /// </summary>
-    public static string? DefaultStoragePath { get; set; }
-
     public override void Initialize()
     {
         RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
@@ -145,7 +145,7 @@ public class App : Application
             _configuration!,
             _backupService,
             GetCurrentThemeIsDark(),
-            () => TaskStorageFactory.DefaultStoragePath);
+            ResolveDefaultTaskStoragePath);
         settingsViewModel.ConfigureUpdateService(_applicationUpdateService);
 
         // Create GraphViewModel
@@ -156,31 +156,29 @@ public class App : Application
             _appNameService,
             _notificationManager,
             _configuration!,
-            () => _storageFactory?.CurrentStorage,
+            () => _storageFactory?.SourceManager.ActiveStorage,
             settingsViewModel,
             graphViewModel,
             TaskTreeExpansionStateStore.GetDefaultPath(_configPath)
         )
         {
-            ToastNotificationManager = _toastNotificationManager
+            ToastNotificationManager = _toastNotificationManager,
+            Dialogs = _dialogs,
+            MoveTaskTreeToFileStorageAsync = MoveTaskTreeViaServiceAsync
         };
 
         // Set up commands on SettingsViewModel
         SetupSettingsCommands(settingsViewModel);
-        WireSettingsToCurrentStorage(settingsViewModel);
+        WireSettingsToActiveStorage(settingsViewModel);
         SetupAutomaticUpdateTimer(settingsViewModel);
-
-        // Set up static instances for TaskItemViewModel and MainControl
-        TaskItemViewModel.NotificationManagerInstance = _notificationManager;
-        TaskItemViewModel.MainWindowInstance = _mainWindowViewModel;
-        MainControl.DialogsInstance = _dialogs;
+        WireActiveTaskContext();
 
         return _mainWindowViewModel;
     }
 
     public static bool TryHandleTaskCardBackGesture()
     {
-        var viewModel = _mainWindowViewModel;
+        var viewModel = (Current as App)?._mainWindowViewModel;
         if (viewModel == null)
         {
             return false;
@@ -218,8 +216,15 @@ public class App : Application
                     }
                 }
 
-                _storageFactory?.SwitchStorage(settings.IsServerMode, _configuration!);
-                WireSettingsToCurrentStorage(settings);
+                if (_storageFactory != null)
+                {
+                    await _storageFactory.SourceManager
+                        .SwitchStorageAsync(settings.IsServerMode, _configuration!)
+                        .ConfigureAwait(true);
+                }
+
+                WireActiveTaskContext();
+                WireSettingsToActiveStorage(settings);
                 if (_mainWindowViewModel != null)
                 {
                     await _mainWindowViewModel.Connect();
@@ -245,7 +250,7 @@ public class App : Application
 
         settings.SignOutCommand = ReactiveCommand.CreateFromTask(async () =>
         {
-            var storage = _storageFactory?.CurrentStorage?.TaskTreeManager.Storage as ServerStorage;
+            var storage = _storageFactory?.SourceManager.ActiveStorage?.TaskTreeManager.Storage as ServerStorage;
             if (storage == null)
             {
                 return;
@@ -348,14 +353,13 @@ public class App : Application
                 L10n.Get("MigrateConfirmMessage"),
                 async () =>
                 {
-                    var serverTaskStorage = _storageFactory?.CurrentStorage;
+                    var serverTaskStorage = _storageFactory?.SourceManager.ActiveStorage;
                     if (serverTaskStorage == null || serverTaskStorage.TaskTreeManager.Storage is FileStorage)
                     {
                         return;
                     }
 
-                    var storagePath = _configuration?.Get<TaskStorageSettings>("TaskStorage")?.Path;
-                    var fileStorage = new FileStorage(storagePath ?? TaskStorageFactory.DefaultStoragePath, watcher: false);
+                    var fileStorage = new FileStorage(ResolveDefaultLocalFileStoragePath(), watcher: false);
                     var tasks = new System.Collections.Generic.List<Unlimotion.Domain.TaskItem>();
                     await foreach (var task in fileStorage.GetAll())
                     {
@@ -377,14 +381,13 @@ public class App : Application
                 L10n.Get("BackupConfirmMessage"),
                 async () =>
                 {
-                    var serverTaskStorage = _storageFactory?.CurrentStorage;
+                    var serverTaskStorage = _storageFactory?.SourceManager.ActiveStorage;
                     if (serverTaskStorage == null || serverTaskStorage.TaskTreeManager.Storage is FileStorage)
                     {
                         return;
                     }
 
-                    var storagePath = _configuration?.Get<TaskStorageSettings>("TaskStorage")?.Path;
-                    var fileStorage = new FileStorage(storagePath ?? TaskStorageFactory.DefaultStoragePath, watcher: false);
+                    var fileStorage = new FileStorage(ResolveDefaultLocalFileStoragePath(), watcher: false);
                     await foreach (var task in serverTaskStorage.TaskTreeManager.Storage.GetAll())
                     {
                         task.Id = task.Id.Replace("TaskItem/", "");
@@ -415,8 +418,7 @@ public class App : Application
                 L10n.Get("ResaveConfirmMessage"),
                 async () =>
                 {
-                    var storagePath = _configuration?.Get<TaskStorageSettings>("TaskStorage")?.Path;
-                    var fileStorage = new FileStorage(storagePath ?? TaskStorageFactory.DefaultStoragePath, watcher: false);
+                    var fileStorage = new FileStorage(ResolveDefaultLocalFileStoragePath(), watcher: false);
                     var taskTreeManager = new Unlimotion.TaskTree.TaskTreeManager(fileStorage);
                     var fileTaskStorage = new UnifiedTaskStorage(taskTreeManager);
                     foreach (var task in fileTaskStorage.Tasks.Items)
@@ -895,8 +897,9 @@ public class App : Application
         }
 
         await PrepareFileStoragePathAsync(settings.TaskStoragePath);
-        _storageFactory.SwitchStorage(isServerMode: false, _configuration);
-        WireSettingsToCurrentStorage(settings);
+        await _storageFactory.SourceManager.SwitchStorageAsync(isServerMode: false, _configuration);
+        WireActiveTaskContext();
+        WireSettingsToActiveStorage(settings);
         await _mainWindowViewModel.Connect();
         settings.SetStorageConnectionState(SettingsConnectionState.Connected);
     }
@@ -946,28 +949,37 @@ public class App : Application
         }
 
         return !string.Equals(
-            NormalizeLocalStoragePathForComparison(selectedLocalStoragePath),
-            NormalizeLocalStoragePathForComparison(currentLocalStoragePath),
+            NormalizeLocalStoragePathForComparison(selectedLocalStoragePath, null),
+            NormalizeLocalStoragePathForComparison(currentLocalStoragePath, null),
             GetPathComparison());
     }
 
     private string? GetCurrentLocalStoragePath()
     {
-        return (_storageFactory?.CurrentStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
+        return (_storageFactory?.SourceManager.ActiveStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
     }
 
-    private static Task PrepareFileStoragePathAsync(string? path)
+    private Task PrepareFileStoragePathAsync(string? path)
     {
-        var prepareFileStoragePathAsync = TaskStorageFactory.PrepareFileStoragePathAsync;
+        var prepareFileStoragePathAsync = _clientOptions.PrepareFileStoragePathAsync;
         return prepareFileStoragePathAsync == null
             ? Task.CompletedTask
             : prepareFileStoragePathAsync(path);
     }
 
-    private static string NormalizeLocalStoragePathForComparison(string? path)
+    public static void ConfigureFileStoragePathPreparation(Func<string?, Task>? prepareFileStoragePathAsync)
+    {
+        _pendingClientOptions.PrepareFileStoragePathAsync = prepareFileStoragePathAsync;
+        if (Current is App app)
+        {
+            app._clientOptions.PrepareFileStoragePathAsync = prepareFileStoragePathAsync;
+        }
+    }
+
+    private static string NormalizeLocalStoragePathForComparison(string? path, string? defaultStoragePath)
     {
         var effectivePath = string.IsNullOrWhiteSpace(path)
-            ? TaskStorageFactory.DefaultStoragePath
+            ? defaultStoragePath
             : path.Trim();
 
         if (string.IsNullOrWhiteSpace(effectivePath))
@@ -1034,7 +1046,7 @@ public class App : Application
         }
     }
 
-    private void WireSettingsToCurrentStorage(SettingsViewModel settings)
+    private void WireSettingsToActiveStorage(SettingsViewModel settings)
     {
         if (_wiredServerStorage != null)
         {
@@ -1059,7 +1071,7 @@ public class App : Application
         _serverConnectionErrorHandler = null;
         _serverSignOutHandler = null;
 
-        var storage = _storageFactory?.CurrentStorage?.TaskTreeManager.Storage;
+        var storage = _storageFactory?.SourceManager.ActiveStorage?.TaskTreeManager.Storage;
         if (storage is ServerStorage serverStorage)
         {
             settings.SetStorageConnectionState(
@@ -1092,6 +1104,24 @@ public class App : Application
         {
             settings.SetStorageConnectionState(SettingsConnectionState.Connected);
         }
+    }
+
+    private void WireActiveTaskContext()
+    {
+        var activeSource = _storageFactory?.SourceManager.ActiveSource;
+        if (activeSource != null)
+        {
+            activeSource.TaskContext.MainWindow = _mainWindowViewModel;
+        }
+    }
+
+    private Task MoveTaskTreeViaServiceAsync(
+        TaskItemViewModel rootTask,
+        ITaskStorage? sourceStorage,
+        string destinationPath)
+    {
+        return _taskMoveService?.MoveTaskTreeToFileStorageAsync(rootTask, sourceStorage, destinationPath)
+               ?? Task.CompletedTask;
     }
 
     public override void OnFrameworkInitializationCompleted()
@@ -1333,9 +1363,36 @@ public class App : Application
     public App()
     {
         DataContext = new ApplicationViewModel();
+        if (!string.IsNullOrWhiteSpace(_pendingConfigPath))
+        {
+            InitializeRuntime(_pendingConfigPath, _pendingClientOptions);
+        }
+    }
+
+    internal void ConfigureRuntimeForTests(
+        IConfiguration configuration,
+        IRemoteBackupService? backupService,
+        ITaskStorageFactory storageFactory,
+        INotificationManagerWrapper? notificationManager = null)
+    {
+        _configuration = configuration;
+        _backupService = backupService;
+        _storageFactory = storageFactory;
+        _taskMoveService = new TaskMoveService(storageFactory);
+        _notificationManager = notificationManager;
+        _clientOptions = new UnlimotionClientOptions();
     }
 
     public static void ConfigureUpdateService(IApplicationUpdateService? updateService)
+    {
+        _pendingUpdateService = updateService;
+        if (Current is App app)
+        {
+            app.ConfigureUpdateServiceInstance(updateService);
+        }
+    }
+
+    private void ConfigureUpdateServiceInstance(IApplicationUpdateService? updateService)
     {
         _applicationUpdateService = updateService;
         var mainSettings = _mainWindowViewModel?.Settings;
@@ -1353,12 +1410,12 @@ public class App : Application
         }
 
         var settings = mainSettings ?? startupSettings;
-        if (Current is App app && settings != null)
+        if (settings != null)
         {
-            app.RescheduleAutomaticUpdateTimer(settings);
+            RescheduleAutomaticUpdateTimer(settings);
             if (_startupUpdateCheckPending && updateService?.IsSupported == true)
             {
-                app.RequestStartupUpdateCheck(settings);
+                RequestStartupUpdateCheck(settings);
             }
         }
     }
@@ -1585,7 +1642,7 @@ public class App : Application
         Debug.WriteLine($"[App.Init] {DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} {message}");
     }
 
-    private static void EnsureScheduler()
+    private void EnsureScheduler()
     {
         if (_scheduler != null)
         {
@@ -1604,10 +1661,23 @@ public class App : Application
         Log("[App.Init] Scheduler job factory set");
     }
 
-    public static void Init(string configPath)
+    public static void Init(string configPath, UnlimotionClientOptions? clientOptions = null)
+    {
+        var effectiveOptions = clientOptions ?? new UnlimotionClientOptions();
+        _pendingConfigPath = configPath;
+        _pendingClientOptions = effectiveOptions;
+        if (Current is App app)
+        {
+            app.InitializeRuntime(configPath, effectiveOptions);
+        }
+    }
+
+    private void InitializeRuntime(string configPath, UnlimotionClientOptions clientOptions)
     {
         try
         {
+            _clientOptions = clientOptions;
+            _applicationUpdateService = _pendingUpdateService;
             Log($"[App.Init] Starting with configPath: {configPath}");
             _configPath = configPath;
 
@@ -1653,31 +1723,29 @@ public class App : Application
             taskStorageSettings = _configuration.Get<TaskStorageSettings>("TaskStorage") ?? taskStorageSettings;
 
             // Create storage factory
-            Log($"[App.Init] Creating storage factory with DefaultStoragePath={TaskStorageFactory.DefaultStoragePath}");
-            _storageFactory = new TaskStorageFactory(_configuration, _mapper, _notificationManager);
-            TaskStorageFactory.DefaultStoragePath = string.IsNullOrWhiteSpace(taskStorageSettings.Path)
+            _clientOptions.DefaultTaskStoragePath = string.IsNullOrWhiteSpace(taskStorageSettings.Path)
                 ? ResolveDefaultTaskStoragePath()
                 : taskStorageSettings.Path;
+            Log($"[App.Init] Creating storage factory with DefaultStoragePath={ResolveDefaultTaskStoragePath()}");
+            _storageFactory = new TaskStorageFactory(
+                _configuration,
+                _mapper,
+                _notificationManager,
+                ResolveDefaultTaskStoragePath);
+            _taskMoveService = new TaskMoveService(_storageFactory);
             Log("[App.Init] Storage factory created");
 
             // Create backup service
-            _backupService = new BackupViaGitService(_configuration, _notificationManager, _storageFactory);
-            BackupViaGitService.GetAbsolutePath = path => System.IO.Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Unlimotion",
-                path);
+            _backupService = new BackupViaGitService(
+                _configuration,
+                _notificationManager,
+                _storageFactory,
+                _clientOptions.GetAbsolutePath ?? GetDefaultAbsolutePath);
             Log("[App.Init] Backup service created");
 
             // Create initial storage
             Log($"[App.Init] Creating initial storage, isServerMode={isServerMode}");
-            if (isServerMode)
-            {
-                _storageFactory.CreateServerStorage(taskStorageSettings.URL);
-            }
-            else
-            {
-                _storageFactory.CreateFileStorage(taskStorageSettings.Path);
-            }
+            _storageFactory.CreateConfiguredStorage();
             Log("[App.Init] Initial storage created");
 
             // Initialize git settings
@@ -1709,46 +1777,43 @@ public class App : Application
             Log("[App.Init] Git settings initialized");
 
             // Initialize scheduler for file mode
-            if (!isServerMode)
+            var taskRepository = _storageFactory.SourceManager.ActiveStorage;
+            if (taskRepository?.TaskTreeManager.Storage is FileStorage)
             {
-                var taskRepository = _storageFactory.CurrentStorage;
-                if (taskRepository != null)
+                taskRepository.Initiated += (sender, eventArgs) =>
                 {
-                    taskRepository.Initiated += (sender, eventArgs) =>
+                    EnsureScheduler();
+                    if (_scheduler == null)
                     {
-                        EnsureScheduler();
-                        if (_scheduler == null)
-                        {
-                            return;
-                        }
+                        return;
+                    }
 
-                        var currentGitSettings = _configuration?.Get<GitSettings>("Git");
-                        if (currentGitSettings?.BackupEnabled != true)
-                        {
-                            return;
-                        }
+                    var currentGitSettings = _configuration?.Get<GitSettings>("Git");
+                    if (currentGitSettings?.BackupEnabled != true)
+                    {
+                        return;
+                    }
 
-                        var pullJob = JobBuilder.Create<GitPullJob>()
-                            .WithIdentity("GitPullJob", "Git")
-                            .Build();
-                        var pushJob = JobBuilder.Create<GitPushJob>()
-                            .WithIdentity("GitPushJob", "Git")
-                            .Build();
+                    var pullJob = JobBuilder.Create<GitPullJob>()
+                        .WithIdentity("GitPullJob", "Git")
+                        .Build();
+                    var pushJob = JobBuilder.Create<GitPushJob>()
+                        .WithIdentity("GitPushJob", "Git")
+                        .Build();
 
-                        var pullTrigger = GenerateTriggerBySecondsInterval("PullTrigger", "GitPullJob",
-                            currentGitSettings.PullIntervalSeconds);
-                        var pushTrigger = GenerateTriggerBySecondsInterval("PushTrigger", "GitPushJob",
-                            currentGitSettings.PushIntervalSeconds);
+                    var pullTrigger = GenerateTriggerBySecondsInterval("PullTrigger", "GitPullJob",
+                        currentGitSettings.PullIntervalSeconds);
+                    var pushTrigger = GenerateTriggerBySecondsInterval("PushTrigger", "GitPushJob",
+                        currentGitSettings.PushIntervalSeconds);
 
-                        _scheduler.ScheduleJob(pullJob, pullTrigger);
-                        _scheduler.ScheduleJob(pushJob, pushTrigger);
+                    _scheduler.ScheduleJob(pullJob, pullTrigger);
+                    _scheduler.ScheduleJob(pushJob, pushTrigger);
 
-                        if (currentGitSettings.BackupEnabled)
-                        {
-                            _scheduler.Start();
-                        }
-                    };
-                }
+                    if (currentGitSettings.BackupEnabled)
+                    {
+                        _scheduler.Start();
+                    }
+                };
             }
             Log("[App.Init] Completed successfully");
         }
@@ -1795,11 +1860,11 @@ public class App : Application
         taskStorageSection.GetSection(nameof(TaskStorageSettings.Path)).Set(defaultPath);
     }
 
-    private static string ResolveDefaultTaskStoragePath()
+    private string ResolveDefaultTaskStoragePath()
     {
-        if (!string.IsNullOrWhiteSpace(DefaultStoragePath))
+        if (!string.IsNullOrWhiteSpace(_clientOptions.DefaultTaskStoragePath))
         {
-            return DefaultStoragePath;
+            return _clientOptions.DefaultTaskStoragePath;
         }
 
         return Path.Combine(
@@ -1808,11 +1873,36 @@ public class App : Application
             "Tasks");
     }
 
+    private string ResolveLocalFileStoragePath(string? path) =>
+        string.IsNullOrWhiteSpace(path) ? ResolveDefaultTaskStoragePath() : path;
+
+    private string ResolveDefaultLocalFileStoragePath()
+    {
+        var defaultSourcePath = _storageFactory?.SourceManager.ConfiguredSources
+            .FirstOrDefault(source =>
+                string.Equals(source.Id, TaskSourceDescriptor.DefaultSourceId, StringComparison.Ordinal))
+            ?.Path;
+        if (!string.IsNullOrWhiteSpace(defaultSourcePath))
+        {
+            return ResolveLocalFileStoragePath(defaultSourcePath);
+        }
+
+        var legacyPath = _configuration?.Get<TaskStorageSettings>("TaskStorage")?.Path;
+        return ResolveLocalFileStoragePath(legacyPath);
+    }
+
+    private static string GetDefaultAbsolutePath(string path) =>
+        System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Unlimotion",
+            path);
+
     private static void HandleReactiveException(Exception ex)
     {
-        if (_notificationManager != null)
+        var notificationManager = (Current as App)?._notificationManager;
+        if (notificationManager != null)
         {
-            _notificationManager.ErrorToast(L10n.Format("ReactiveUnhandledError", ex.Message));
+            notificationManager.ErrorToast(L10n.Format("ReactiveUnhandledError", ex.Message));
         }
         else
         {

--- a/src/Unlimotion/FileStorage.cs
+++ b/src/Unlimotion/FileStorage.cs
@@ -36,7 +36,7 @@ namespace Unlimotion
 
         public FileStorage(string path, bool watcher = false, INotificationManagerWrapper? notificationManager = null)
         {
-            var normalizedPath = string.IsNullOrWhiteSpace(path) ? TaskStorageFactory.DefaultStoragePath : path;
+            var normalizedPath = string.IsNullOrWhiteSpace(path) ? "Tasks" : path;
             if (string.IsNullOrWhiteSpace(normalizedPath))
             {
                 normalizedPath = "Tasks";

--- a/src/Unlimotion/ServerStorage.cs
+++ b/src/Unlimotion/ServerStorage.cs
@@ -16,6 +16,7 @@ using Unlimotion.Domain;
 using Unlimotion.Interface;
 using Unlimotion.Server.ServiceModel;
 using Unlimotion.Server.ServiceModel.Molds.Tasks;
+using Unlimotion.Services;
 using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
 
@@ -45,31 +46,48 @@ public class ServerStorage : IStorage
     private HubConnection? _connection;
     private readonly IJsonServiceClient serviceClient;
     private IChatHub? _hub;
-    private ClientSettings settings;
+    private ClientSettings settings = new();
     private IConfiguration? configuration;
+    private readonly TaskSourceServerSettings? sourceServerSettings;
+    private readonly Action<TaskSourceServerSettings>? persistServerSettings;
     private IMapper? mapper;
 
     public ServerStorage(string url, IConfiguration configuration)
+        : this(url, configuration, sourceServerSettings: null, persistServerSettings: null)
+    {
+    }
+
+    public ServerStorage(
+        string url,
+        IConfiguration configuration,
+        TaskSourceServerSettings? sourceServerSettings,
+        Action<TaskSourceServerSettings>? persistServerSettings)
     {
         Url = url;
         serviceClient = new JsonServiceClient(Url);
         ServicePointManager.ServerCertificateValidationCallback +=
             (sender, cert, chain, sslPolicyErrors) => true;
         this.configuration = configuration;
+        this.sourceServerSettings = sourceServerSettings;
+        this.persistServerSettings = persistServerSettings;
 
-        try
+        if (sourceServerSettings != null)
         {
-            settings = configuration.Get<ClientSettings>("ClientSettings");
+            settings = TaskSourceSettingsAdapter.ToClientSettings(sourceServerSettings);
         }
-        catch (Exception e)
+        else
         {
-            Debug.WriteLine(e);
+            try
+            {
+                settings = configuration.Get<ClientSettings>("ClientSettings") ?? new ClientSettings();
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e);
+                settings = new ClientSettings();
+            }
         }
 
-        if (settings == null)
-        {
-            settings = new ClientSettings();
-        }
         //Создание маппера
         mapper = AppModelMapping.ConfigureMapping();
     }
@@ -139,28 +157,25 @@ public class ServerStorage : IStorage
 
                 if (!string.IsNullOrEmpty(settings.RefreshToken) && settings.ExpireTime < DateTimeOffset.Now)
                 {
-                    await RefreshToken(settings, configuration!).ConfigureAwait(false);
+                    await RefreshToken(settings).ConfigureAwait(false);
                 }
 
                 if (string.IsNullOrEmpty(settings.AccessToken))
                 {
-                    var storageSettings = configuration?.Get<TaskStorageSettings>("TaskStorage");
+                    var credentials = GetCredentials();
                     try
                     {
                         var tokens = await serviceClient.PostAsync(new AuthViaPassword
                         {
-                            Login = storageSettings?.Login ?? string.Empty,
-                            Password = storageSettings?.Password ?? string.Empty
+                            Login = credentials.Login,
+                            Password = credentials.Password
                         }).ConfigureAwait(false);
 
                         settings.AccessToken = tokens.AccessToken;
                         settings.RefreshToken = tokens.RefreshToken;
-                        settings.Login = storageSettings?.Login ?? string.Empty;
+                        settings.Login = credentials.Login;
                         serviceClient.BearerToken = tokens.AccessToken;
-                        if (configuration != null)
-                        {
-                            configuration.Set("ClientSettings", settings);
-                        }
+                        PersistSettings();
                     }
                     catch (Exception authEx)
                     {
@@ -191,10 +206,15 @@ public class ServerStorage : IStorage
 
     public async Task Disconnect()
     {
-        await SignOut();
+        await CloseConnectionAsync(clearCredentials: false, notifySignOut: false).ConfigureAwait(false);
     }
 
     public async Task SignOut()
+    {
+        await CloseConnectionAsync(clearCredentials: true, notifySignOut: true).ConfigureAwait(false);
+    }
+
+    private async Task CloseConnectionAsync(bool clearCredentials, bool notifySignOut)
     {
         try
         {
@@ -220,15 +240,22 @@ public class ServerStorage : IStorage
             _connection = null;
             _hub = null;
 
-            settings.AccessToken = string.Empty;
-            settings.RefreshToken = string.Empty;
-            if (configuration != null)
+            if (clearCredentials)
             {
-                configuration.Set("ClientSettings", settings);
+                settings.AccessToken = string.Empty;
+                settings.RefreshToken = string.Empty;
+                PersistSettings();
             }
 
             //WindowStates(WindowState.SignOut);
-            OnSignOut?.Invoke(this, EventArgs.Empty);
+            if (notifySignOut)
+            {
+                OnSignOut?.Invoke(this, EventArgs.Empty);
+            }
+            else
+            {
+                OnDisconnected?.Invoke();
+            }
         }
         catch (Exception)
         {
@@ -371,12 +398,13 @@ public class ServerStorage : IStorage
                         await RegisterUser().ConfigureAwait(false);
                         return;
                     case LogOn.LogOnStatus.ErrorExpiredToken:
-                        await RefreshToken(settings, configuration!).ConfigureAwait(false);
+                        await RefreshToken(settings).ConfigureAwait(false);
                         break;
                     case LogOn.LogOnStatus.Ok:
                         settings.UserId = data.Id;
                         settings.Login = data.UserLogin;
                         settings.ExpireTime = data.ExpireTime;
+                        PersistSettings();
 
                         OnConnected?.Invoke();
                         break;
@@ -426,9 +454,9 @@ public class ServerStorage : IStorage
         var request = new RegisterNewUser();
         try
         {
-            var storageSettings = configuration?.Get<TaskStorageSettings>("TaskStorage");
-            var login = storageSettings?.Login;
-            var password = storageSettings?.Password;
+            var credentials = GetCredentials();
+            var login = credentials.Login;
+            var password = credentials.Password;
             if (string.IsNullOrWhiteSpace(login) || string.IsNullOrWhiteSpace(password))
             {
                 //TODO показать ошибку пользователю
@@ -446,10 +474,7 @@ public class ServerStorage : IStorage
             settings.AccessToken = tokenResult.AccessToken;
             settings.RefreshToken = tokenResult.RefreshToken;
             settings.Login = login;
-            if (configuration != null)
-            {
-                configuration.Set("ClientSettings", settings);
-            }
+            PersistSettings();
             await Connect();
         }
         catch (Exception)
@@ -462,7 +487,7 @@ public class ServerStorage : IStorage
         }
     }
 
-    private async Task RefreshToken(ClientSettings settings, IConfiguration configuration)
+    private async Task RefreshToken(ClientSettings settings)
     {
         serviceClient.BearerToken = settings.RefreshToken;
         try
@@ -472,7 +497,7 @@ public class ServerStorage : IStorage
             settings.RefreshToken = tokenResult.RefreshToken;
             settings.ExpireTime = tokenResult.ExpireTime;
             serviceClient.BearerToken = settings.AccessToken;
-            configuration.Set("ClientSettings", settings);
+            PersistSettings();
             await Login();
             IsSignedIn = true;
         }
@@ -518,5 +543,28 @@ public class ServerStorage : IStorage
     protected virtual void OnUpdating(TaskStorageUpdateEventArgs e)
     {
         Updating?.Invoke(this, e);
+    }
+
+    private (string Login, string Password) GetCredentials()
+    {
+        if (sourceServerSettings != null)
+        {
+            return (sourceServerSettings.Login, sourceServerSettings.Password);
+        }
+
+        var storageSettings = configuration?.Get<TaskStorageSettings>("TaskStorage");
+        return (storageSettings?.Login ?? string.Empty, storageSettings?.Password ?? string.Empty);
+    }
+
+    private void PersistSettings()
+    {
+        if (sourceServerSettings != null)
+        {
+            TaskSourceSettingsAdapter.CopyFromClientSettings(settings, sourceServerSettings);
+            persistServerSettings?.Invoke(sourceServerSettings);
+            return;
+        }
+
+        configuration?.Set("ClientSettings", settings);
     }
 }

--- a/src/Unlimotion/Services/BackupViaGitService.cs
+++ b/src/Unlimotion/Services/BackupViaGitService.cs
@@ -56,20 +56,22 @@ public class BackupViaGitService : IRemoteBackupService
     };
 
     private static readonly object LockObject = new();
-    public static Func<string, string> GetAbsolutePath = null!;
 
     private readonly IConfiguration _configuration;
     private readonly INotificationManagerWrapper? _notificationManager;
     private readonly ITaskStorageFactory? _storageFactory;
+    private readonly Func<string, string> _getAbsolutePath;
 
     public BackupViaGitService(
         IConfiguration configuration,
         INotificationManagerWrapper? notificationManager = null,
-        ITaskStorageFactory? storageFactory = null)
+        ITaskStorageFactory? storageFactory = null,
+        Func<string, string>? getAbsolutePath = null)
     {
         _configuration = configuration;
         _notificationManager = notificationManager;
         _storageFactory = storageFactory;
+        _getAbsolutePath = getAbsolutePath ?? (path => new DirectoryInfo(path).FullName);
     }
 
     public List<string> Refs()
@@ -661,7 +663,7 @@ public class BackupViaGitService : IRemoteBackupService
                 return;
             }
 
-            var dbwatcher = _storageFactory?.CurrentWatcher;
+            var dbwatcher = _storageFactory?.SourceManager.ActiveWatcher;
 
             ShowUiMessage(L10n.Get("StartGitPush"));
             try
@@ -719,7 +721,7 @@ public class BackupViaGitService : IRemoteBackupService
     {
         lock (LockObject)
         {
-            PullCurrentRepository(notifyCurrentWatcher: true);
+            PullCurrentRepository(notifyActiveWatcher: true);
         }
     }
 
@@ -745,11 +747,11 @@ public class BackupViaGitService : IRemoteBackupService
                 EnsurePushRefSpecMatchesLocalRepository(repo, settings.git);
             }
 
-            PullCurrentRepository(notifyCurrentWatcher: false);
+            PullCurrentRepository(notifyActiveWatcher: false);
         }
     }
 
-    private void PullCurrentRepository(bool notifyCurrentWatcher)
+    private void PullCurrentRepository(bool notifyActiveWatcher)
     {
         var settings = GetSettings();
         var path = GetRepositoryPath(settings.repositoryPath);
@@ -770,7 +772,7 @@ public class BackupViaGitService : IRemoteBackupService
 
         ShowUiMessage(L10n.Get("StartGitPull"));
 
-        var dbwatcher = notifyCurrentWatcher ? _storageFactory?.CurrentWatcher : null;
+        var dbwatcher = notifyActiveWatcher ? _storageFactory?.SourceManager.ActiveWatcher : null;
         try
         {
             dbwatcher?.SetEnable(false);
@@ -2326,17 +2328,12 @@ public class BackupViaGitService : IRemoteBackupService
             PropagationFlags.None,
             AccessControlType.Allow);
 
-    private static string GetRepositoryPath(string? pathFromSettings)
+    private string GetRepositoryPath(string? pathFromSettings)
     {
         var path = string.IsNullOrWhiteSpace(pathFromSettings) ? TasksFolderName : pathFromSettings;
         if (!IsAbsolutePath(path))
         {
-            if (GetAbsolutePath == null)
-            {
-                throw new Exception(L10n.Get("CannotGetAbsolutePath"));
-            }
-
-            path = GetAbsolutePath(path);
+            path = _getAbsolutePath(path);
         }
 
         return path;
@@ -2742,13 +2739,18 @@ public class BackupViaGitService : IRemoteBackupService
 
     private string? ResolveRepositoryPathFromSettings()
     {
+        var activePath = (_storageFactory?.SourceManager.ActiveStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
+        if (!string.IsNullOrWhiteSpace(activePath))
+        {
+            return activePath;
+        }
+
         var configuredPath = _configuration.Get<TaskStorageSettings>("TaskStorage")?.Path;
         if (!string.IsNullOrWhiteSpace(configuredPath))
         {
             return configuredPath;
         }
-
-        return (_storageFactory?.CurrentStorage?.TaskTreeManager.Storage as FileStorage)?.Path;
+        return null;
     }
 
     private void ShowUiError(string message, Exception? ex = null)

--- a/src/Unlimotion/Services/ITaskStorageFactory.cs
+++ b/src/Unlimotion/Services/ITaskStorageFactory.cs
@@ -5,9 +5,10 @@ namespace Unlimotion.Services;
 
 public interface ITaskStorageFactory
 {
-    ITaskStorage? CurrentStorage { get; }
-    IDatabaseWatcher? CurrentWatcher { get; }
+    ITaskSourceManager SourceManager { get; }
+    ITaskStorage CreateConfiguredStorage();
     ITaskStorage CreateFileStorage(string? path);
+    ITaskStorage CreateDetachedFileStorage(string? path);
     ITaskStorage CreateServerStorage(string? url);
     void SwitchStorage(bool isServerMode, IConfiguration configuration);
 }

--- a/src/Unlimotion/Services/TaskMoveService.cs
+++ b/src/Unlimotion/Services/TaskMoveService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Services;
+
+public sealed class TaskMoveService(ITaskStorageFactory storageFactory)
+{
+    public async Task MoveTaskTreeToFileStorageAsync(
+        TaskItemViewModel rootTask,
+        ITaskStorage? sourceStorage,
+        string destinationPath)
+    {
+        ArgumentNullException.ThrowIfNull(rootTask);
+
+        var destinationStorage = storageFactory.CreateDetachedFileStorage(destinationPath);
+        try
+        {
+            var movedTaskIds = new HashSet<string>();
+            var queue = new Queue<TaskItemViewModel>();
+            queue.Enqueue(rootTask);
+
+            while (queue.Count > 0)
+            {
+                var task = queue.Dequeue();
+                if (!movedTaskIds.Add(task.Id))
+                {
+                    continue;
+                }
+
+                await destinationStorage.TaskTreeManager.Storage.Save(task.Model);
+                foreach (var child in task.ContainsTasks)
+                {
+                    queue.Enqueue(child);
+                }
+            }
+
+            var sourceRawStorage = sourceStorage?.TaskTreeManager.Storage;
+            if (sourceRawStorage == null)
+            {
+                return;
+            }
+
+            foreach (var id in movedTaskIds)
+            {
+                await sourceRawStorage.Remove(id);
+            }
+        }
+        finally
+        {
+            (destinationStorage as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/src/Unlimotion/Services/TaskSourceManager.cs
+++ b/src/Unlimotion/Services/TaskSourceManager.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Services;
+
+public sealed class TaskSourceManager : ITaskSourceManager
+{
+    private readonly IConfiguration _configuration;
+    private readonly ITaskStorageBuilder _storageBuilder;
+    private readonly INotificationManagerWrapper? _notificationManager;
+    private readonly Func<string?>? _defaultStoragePathProvider;
+    private readonly List<TaskSourceRuntime> _sources = new();
+    private TaskSourcesSettings _settings;
+
+    public TaskSourceManager(
+        IConfiguration configuration,
+        ITaskStorageBuilder storageBuilder,
+        INotificationManagerWrapper? notificationManager = null,
+        Func<string?>? defaultStoragePathProvider = null)
+    {
+        _configuration = configuration;
+        _storageBuilder = storageBuilder;
+        _notificationManager = notificationManager;
+        _defaultStoragePathProvider = defaultStoragePathProvider;
+        _settings = TaskSourceSettingsAdapter.LoadOrCreate(_configuration, _defaultStoragePathProvider?.Invoke());
+    }
+
+    public IReadOnlyList<TaskSourceRuntime> Sources => _sources;
+    public IReadOnlyList<TaskSourceDescriptor> ConfiguredSources => _settings.Sources;
+    public TaskSourceRuntime? ActiveSource { get; private set; }
+    public ITaskStorage? ActiveStorage => ActiveSource?.Storage;
+    public IDatabaseWatcher? ActiveWatcher => ActiveSource?.Watcher;
+
+    public TaskSourceRuntime ActivateConfiguredSource() =>
+        ActivateConfiguredSourceAsync().GetAwaiter().GetResult();
+
+    public async Task<TaskSourceRuntime> ActivateConfiguredSourceAsync()
+    {
+        var descriptor = _settings.Sources.First(source =>
+            string.Equals(source.Id, _settings.ActiveSourceId, StringComparison.Ordinal));
+        var serverSettings = descriptor.Kind == TaskSourceKind.Server
+            ? TaskSourceSettingsAdapter.EnsureServerSettings(
+                _settings,
+                descriptor.Id,
+                _configuration.Get<TaskStorageSettings>("TaskStorage"),
+                _configuration)
+            : null;
+
+        return await ActivateSourceAsync(descriptor, serverSettings).ConfigureAwait(false);
+    }
+
+    public TaskSourceRuntime ActivateSource(
+        TaskSourceDescriptor descriptor,
+        TaskSourceServerSettings? serverSettings = null) =>
+        ActivateSourceAsync(descriptor, serverSettings).GetAwaiter().GetResult();
+
+    public async Task<TaskSourceRuntime> ActivateSourceAsync(
+        TaskSourceDescriptor descriptor,
+        TaskSourceServerSettings? serverSettings = null)
+    {
+        descriptor = NormalizeDescriptor(descriptor);
+        var nextSettings = CloneSettings(_settings);
+        UpsertDescriptor(nextSettings, descriptor);
+
+        if (descriptor.Kind == TaskSourceKind.Server)
+        {
+            serverSettings ??= TaskSourceSettingsAdapter.EnsureServerSettings(
+                nextSettings,
+                descriptor.Id,
+                _configuration.Get<TaskStorageSettings>("TaskStorage"),
+                _configuration);
+            UpsertServerSettings(nextSettings, serverSettings);
+        }
+
+        var taskContext = new TaskItemViewModelContext
+        {
+            SourceId = descriptor.Id,
+            NotificationManager = _notificationManager
+        };
+        var buildResult = _storageBuilder.Build(new TaskStorageBuildRequest
+        {
+            Descriptor = descriptor,
+            ServerSettings = serverSettings,
+            PersistServerSettings = serverSettings == null ? null : PersistServerSettings,
+            TaskContext = taskContext
+        });
+        var runtime = new TaskSourceRuntime(
+            descriptor,
+            serverSettings,
+            buildResult.Storage,
+            buildResult.Watcher,
+            taskContext);
+
+        var existingIndex = _sources.FindIndex(source =>
+            string.Equals(source.Descriptor.Id, descriptor.Id, StringComparison.Ordinal));
+        var replacedSource = existingIndex >= 0 ? _sources[existingIndex] : null;
+        var previousActiveSource = ActiveSource;
+
+        if (existingIndex >= 0)
+        {
+            _sources[existingIndex] = runtime;
+        }
+        else
+        {
+            _sources.Add(runtime);
+        }
+
+        ActiveSource = runtime;
+        nextSettings.ActiveSourceId = descriptor.Id;
+        _settings = nextSettings;
+        TaskSourceSettingsAdapter.Save(_configuration, _settings);
+        TaskSourceSettingsAdapter.SyncLegacy(_configuration, _settings, descriptor);
+
+        if (replacedSource != null)
+        {
+            await DisconnectRuntimeAsync(replacedSource).ConfigureAwait(false);
+        }
+
+        if (previousActiveSource != null && !ReferenceEquals(previousActiveSource, replacedSource))
+        {
+            await DisconnectRuntimeAsync(previousActiveSource).ConfigureAwait(false);
+        }
+
+        return runtime;
+    }
+
+    public void SwitchStorage(bool isServerMode, IConfiguration configuration) =>
+        SwitchStorageAsync(isServerMode, configuration).GetAwaiter().GetResult();
+
+    public async Task SwitchStorageAsync(bool isServerMode, IConfiguration configuration)
+    {
+        var legacySettings = configuration.Get<TaskStorageSettings>("TaskStorage") ?? new TaskStorageSettings();
+        legacySettings.IsServerMode = isServerMode;
+        var descriptor = CreateDescriptorForSettingsSwitch(legacySettings);
+        var serverSettings = descriptor.Kind == TaskSourceKind.Server
+            ? PrepareServerSettingsForSwitch(descriptor, legacySettings, configuration)
+            : null;
+
+        await ActivateSourceAsync(descriptor, serverSettings).ConfigureAwait(false);
+    }
+
+    private TaskSourceDescriptor CreateDescriptorForSettingsSwitch(TaskStorageSettings legacySettings)
+    {
+        if (ActiveSource == null ||
+            string.Equals(ActiveSource.Descriptor.Id, TaskSourceDescriptor.DefaultSourceId, StringComparison.Ordinal))
+        {
+            return TaskSourceSettingsAdapter.CreateLegacyDescriptor(
+                legacySettings,
+                _defaultStoragePathProvider?.Invoke());
+        }
+
+        var activeDescriptor = ActiveSource.Descriptor;
+        return new TaskSourceDescriptor
+        {
+            Id = activeDescriptor.Id,
+            DisplayName = activeDescriptor.DisplayName,
+            Kind = legacySettings.IsServerMode ? TaskSourceKind.Server : TaskSourceKind.File,
+            Path = string.IsNullOrWhiteSpace(legacySettings.Path)
+                ? activeDescriptor.Path
+                : legacySettings.Path,
+            Url = string.IsNullOrWhiteSpace(legacySettings.URL)
+                ? activeDescriptor.Url
+                : legacySettings.URL,
+            IsEnabled = true
+        };
+    }
+
+    private TaskSourceServerSettings PrepareServerSettingsForSwitch(
+        TaskSourceDescriptor descriptor,
+        TaskStorageSettings legacySettings,
+        IConfiguration configuration)
+    {
+        var serverSettings = TaskSourceSettingsAdapter.EnsureServerSettings(
+            _settings,
+            descriptor.Id,
+            legacySettings,
+            configuration);
+        if (!string.Equals(serverSettings.Login, legacySettings.Login, StringComparison.Ordinal) ||
+            !string.Equals(serverSettings.Password, legacySettings.Password, StringComparison.Ordinal))
+        {
+            serverSettings.AccessToken = string.Empty;
+            serverSettings.RefreshToken = string.Empty;
+            serverSettings.ExpireTime = default;
+            serverSettings.UserId = string.Empty;
+        }
+
+        serverSettings.Login = legacySettings.Login;
+        serverSettings.Password = legacySettings.Password;
+        return serverSettings;
+    }
+
+    private TaskSourceDescriptor NormalizeDescriptor(TaskSourceDescriptor descriptor)
+    {
+        if (string.IsNullOrWhiteSpace(descriptor.Id))
+        {
+            descriptor.Id = TaskSourceDescriptor.DefaultSourceId;
+        }
+
+        if (string.IsNullOrWhiteSpace(descriptor.DisplayName))
+        {
+            descriptor.DisplayName = descriptor.Kind == TaskSourceKind.Server
+                ? "Server tasks"
+                : "Local tasks";
+        }
+
+        if (descriptor.Kind == TaskSourceKind.File &&
+            string.IsNullOrWhiteSpace(descriptor.Path))
+        {
+            descriptor.Path = _defaultStoragePathProvider?.Invoke() ?? string.Empty;
+        }
+
+        descriptor.IsEnabled = true;
+        return descriptor;
+    }
+
+    private void UpsertDescriptor(TaskSourceDescriptor descriptor) =>
+        UpsertDescriptor(_settings, descriptor);
+
+    private static void UpsertDescriptor(TaskSourcesSettings settings, TaskSourceDescriptor descriptor)
+    {
+        var existingIndex = settings.Sources.FindIndex(source =>
+            string.Equals(source.Id, descriptor.Id, StringComparison.Ordinal));
+        if (existingIndex >= 0)
+        {
+            settings.Sources[existingIndex] = descriptor;
+            return;
+        }
+
+        settings.Sources.Add(descriptor);
+    }
+
+    private void PersistServerSettings(TaskSourceServerSettings serverSettings)
+    {
+        TaskSourceSettingsAdapter.PersistServerSettings(_configuration, _settings, serverSettings);
+    }
+
+    private void UpsertServerSettings(TaskSourceServerSettings serverSettings) =>
+        UpsertServerSettings(_settings, serverSettings);
+
+    private static void UpsertServerSettings(TaskSourcesSettings settings, TaskSourceServerSettings serverSettings)
+    {
+        var existingIndex = settings.ServerSettings.FindIndex(candidate =>
+            string.Equals(candidate.SourceId, serverSettings.SourceId, StringComparison.Ordinal));
+        if (existingIndex >= 0)
+        {
+            settings.ServerSettings[existingIndex] = serverSettings;
+            return;
+        }
+
+        settings.ServerSettings.Add(serverSettings);
+    }
+
+    private static TaskSourcesSettings CloneSettings(TaskSourcesSettings settings) =>
+        new()
+        {
+            ActiveSourceId = settings.ActiveSourceId,
+            Sources = settings.Sources.Select(source => new TaskSourceDescriptor
+            {
+                Id = source.Id,
+                DisplayName = source.DisplayName,
+                Kind = source.Kind,
+                Path = source.Path,
+                Url = source.Url,
+                IsEnabled = source.IsEnabled
+            }).ToList(),
+            ServerSettings = settings.ServerSettings.Select(server => new TaskSourceServerSettings
+            {
+                SourceId = server.SourceId,
+                Login = server.Login,
+                Password = server.Password,
+                AccessToken = server.AccessToken,
+                RefreshToken = server.RefreshToken,
+                ExpireTime = server.ExpireTime,
+                UserId = server.UserId
+            }).ToList()
+        };
+
+    private static async Task DisconnectRuntimeAsync(TaskSourceRuntime runtime)
+    {
+        try
+        {
+            await runtime.Storage.TaskTreeManager.Storage.Disconnect().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex);
+        }
+        finally
+        {
+            (runtime.Storage as IDisposable)?.Dispose();
+        }
+    }
+}

--- a/src/Unlimotion/Services/TaskSourceRuntime.cs
+++ b/src/Unlimotion/Services/TaskSourceRuntime.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Services;
+
+public sealed class TaskStorageBuildRequest
+{
+    public TaskSourceDescriptor Descriptor { get; init; } = new();
+    public TaskSourceServerSettings? ServerSettings { get; init; }
+    public Action<TaskSourceServerSettings>? PersistServerSettings { get; init; }
+    public TaskItemViewModelContext? TaskContext { get; init; }
+    public bool EnableWatcher { get; init; } = true;
+}
+
+public sealed class TaskStorageBuildResult(ITaskStorage storage, IDatabaseWatcher? watcher)
+{
+    public ITaskStorage Storage { get; } = storage;
+    public IDatabaseWatcher? Watcher { get; } = watcher;
+}
+
+public sealed class TaskSourceRuntime(
+    TaskSourceDescriptor descriptor,
+    TaskSourceServerSettings? serverSettings,
+    ITaskStorage storage,
+    IDatabaseWatcher? watcher,
+    TaskItemViewModelContext taskContext)
+{
+    public TaskSourceDescriptor Descriptor { get; } = descriptor;
+    public TaskSourceServerSettings? ServerSettings { get; } = serverSettings;
+    public ITaskStorage Storage { get; } = storage;
+    public IDatabaseWatcher? Watcher { get; } = watcher;
+    public TaskItemViewModelContext TaskContext { get; } = taskContext;
+}
+
+public interface ITaskStorageBuilder
+{
+    TaskStorageBuildResult Build(TaskStorageBuildRequest request);
+}
+
+public interface ITaskSourceManager
+{
+    IReadOnlyList<TaskSourceRuntime> Sources { get; }
+    IReadOnlyList<TaskSourceDescriptor> ConfiguredSources { get; }
+    TaskSourceRuntime? ActiveSource { get; }
+    ITaskStorage? ActiveStorage { get; }
+    IDatabaseWatcher? ActiveWatcher { get; }
+
+    TaskSourceRuntime ActivateConfiguredSource();
+
+    TaskSourceRuntime ActivateSource(
+        TaskSourceDescriptor descriptor,
+        TaskSourceServerSettings? serverSettings = null);
+
+    Task<TaskSourceRuntime> ActivateConfiguredSourceAsync();
+
+    Task<TaskSourceRuntime> ActivateSourceAsync(
+        TaskSourceDescriptor descriptor,
+        TaskSourceServerSettings? serverSettings = null);
+
+    void SwitchStorage(bool isServerMode, Microsoft.Extensions.Configuration.IConfiguration configuration);
+
+    Task SwitchStorageAsync(bool isServerMode, Microsoft.Extensions.Configuration.IConfiguration configuration);
+}

--- a/src/Unlimotion/Services/TaskSourceSettingsAdapter.cs
+++ b/src/Unlimotion/Services/TaskSourceSettingsAdapter.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Services;
+
+public static class TaskSourceSettingsAdapter
+{
+    public static TaskSourcesSettings LoadOrCreate(IConfiguration configuration, string? defaultStoragePath)
+    {
+        var settings = Read(configuration);
+        var legacyStorage = configuration.Get<TaskStorageSettings>("TaskStorage") ?? new TaskStorageSettings();
+
+        if (settings.Sources.Count == 0)
+        {
+            var descriptor = CreateLegacyDescriptor(legacyStorage, defaultStoragePath);
+            settings.ActiveSourceId = descriptor.Id;
+            settings.Sources.Add(descriptor);
+        }
+
+        if (string.IsNullOrWhiteSpace(settings.ActiveSourceId) ||
+            settings.Sources.All(source => !string.Equals(source.Id, settings.ActiveSourceId, StringComparison.Ordinal)))
+        {
+            settings.ActiveSourceId = settings.Sources.First().Id;
+        }
+
+        var activeSource = settings.Sources.First(source =>
+            string.Equals(source.Id, settings.ActiveSourceId, StringComparison.Ordinal));
+        if (activeSource.Kind == TaskSourceKind.Server)
+        {
+            EnsureServerSettings(settings, activeSource.Id, legacyStorage, configuration);
+        }
+
+        Save(configuration, settings);
+        SyncLegacy(configuration, settings, activeSource);
+        return settings;
+    }
+
+    public static TaskSourceDescriptor CreateLegacyDescriptor(
+        TaskStorageSettings legacyStorage,
+        string? defaultStoragePath)
+    {
+        var isServerMode = legacyStorage.IsServerMode;
+        return new TaskSourceDescriptor
+        {
+            Id = TaskSourceDescriptor.DefaultSourceId,
+            DisplayName = isServerMode ? "Default server" : "Local tasks",
+            Kind = isServerMode ? TaskSourceKind.Server : TaskSourceKind.File,
+            Path = string.IsNullOrWhiteSpace(legacyStorage.Path) ? defaultStoragePath ?? string.Empty : legacyStorage.Path,
+            Url = legacyStorage.URL,
+            IsEnabled = true
+        };
+    }
+
+    public static TaskSourceServerSettings EnsureServerSettings(
+        TaskSourcesSettings settings,
+        string sourceId,
+        TaskStorageSettings? legacyStorage = null,
+        IConfiguration? configuration = null)
+    {
+        var serverSettings = settings.ServerSettings.FirstOrDefault(server =>
+            string.Equals(server.SourceId, sourceId, StringComparison.Ordinal));
+        if (serverSettings != null)
+        {
+            return serverSettings;
+        }
+
+        var isDefaultSource = string.Equals(sourceId, TaskSourceDescriptor.DefaultSourceId, StringComparison.Ordinal);
+        var legacyClient = isDefaultSource && configuration != null ? ReadClientSettings(configuration) : null;
+        serverSettings = new TaskSourceServerSettings
+        {
+            SourceId = sourceId,
+            Login = legacyStorage?.Login ?? legacyClient?.Login ?? string.Empty,
+            Password = legacyStorage?.Password ?? string.Empty,
+            AccessToken = legacyClient?.AccessToken ?? string.Empty,
+            RefreshToken = legacyClient?.RefreshToken ?? string.Empty,
+            ExpireTime = legacyClient?.ExpireTime ?? default,
+            UserId = legacyClient?.UserId ?? string.Empty
+        };
+        settings.ServerSettings.Add(serverSettings);
+        return serverSettings;
+    }
+
+    public static void Save(IConfiguration configuration, TaskSourcesSettings settings)
+    {
+        var section = configuration.GetSection(TaskSourcesSettings.SectionName);
+        section.GetSection(nameof(TaskSourcesSettings.ActiveSourceId)).Set(settings.ActiveSourceId);
+        section.GetSection("SourcesCount").Set(settings.Sources.Count);
+        section.GetSection("ServerSettingsCount").Set(settings.ServerSettings.Count);
+
+        for (var i = 0; i < settings.Sources.Count; i++)
+        {
+            var source = settings.Sources[i];
+            var entryKey = $"Source{i.ToString(CultureInfo.InvariantCulture)}";
+            section.GetSection($"SourceKey{i.ToString(CultureInfo.InvariantCulture)}").Set(source.Id);
+            var sourceSection = section.GetSection("SourceEntries").GetSection(entryKey);
+            sourceSection.GetSection(nameof(TaskSourceDescriptor.Id)).Set(source.Id);
+            sourceSection.GetSection(nameof(TaskSourceDescriptor.DisplayName)).Set(source.DisplayName);
+            sourceSection.GetSection(nameof(TaskSourceDescriptor.Kind)).Set(source.Kind.ToString());
+            sourceSection.GetSection(nameof(TaskSourceDescriptor.Path)).Set(source.Path);
+            sourceSection.GetSection(nameof(TaskSourceDescriptor.Url)).Set(source.Url);
+            sourceSection.GetSection(nameof(TaskSourceDescriptor.IsEnabled)).Set(source.IsEnabled);
+        }
+
+        for (var i = 0; i < settings.ServerSettings.Count; i++)
+        {
+            var server = settings.ServerSettings[i];
+            var entryKey = $"Server{i.ToString(CultureInfo.InvariantCulture)}";
+            section.GetSection($"ServerSettingsKey{i.ToString(CultureInfo.InvariantCulture)}").Set(server.SourceId);
+            var serverSection = section.GetSection("ServerSettingEntries").GetSection(entryKey);
+            serverSection.GetSection(nameof(TaskSourceServerSettings.SourceId)).Set(server.SourceId);
+            serverSection.GetSection(nameof(TaskSourceServerSettings.Login)).Set(server.Login);
+            serverSection.GetSection(nameof(TaskSourceServerSettings.Password)).Set(server.Password);
+            serverSection.GetSection(nameof(TaskSourceServerSettings.AccessToken)).Set(server.AccessToken);
+            serverSection.GetSection(nameof(TaskSourceServerSettings.RefreshToken)).Set(server.RefreshToken);
+            serverSection.GetSection(nameof(TaskSourceServerSettings.ExpireTime)).Set(server.ExpireTime.ToString("O", CultureInfo.InvariantCulture));
+            serverSection.GetSection(nameof(TaskSourceServerSettings.UserId)).Set(server.UserId);
+        }
+    }
+
+    public static void PersistServerSettings(
+        IConfiguration configuration,
+        TaskSourcesSettings settings,
+        TaskSourceServerSettings serverSettings)
+    {
+        var existingIndex = settings.ServerSettings.FindIndex(candidate =>
+            string.Equals(candidate.SourceId, serverSettings.SourceId, StringComparison.Ordinal));
+        if (existingIndex >= 0)
+        {
+            settings.ServerSettings[existingIndex] = serverSettings;
+        }
+        else
+        {
+            settings.ServerSettings.Add(serverSettings);
+        }
+
+        Save(configuration, settings);
+        if (string.Equals(serverSettings.SourceId, TaskSourceDescriptor.DefaultSourceId, StringComparison.Ordinal))
+        {
+            WriteClientSettings(configuration, ToClientSettings(serverSettings));
+        }
+    }
+
+    public static void SyncLegacy(
+        IConfiguration configuration,
+        TaskSourcesSettings settings,
+        TaskSourceDescriptor activeSource)
+    {
+        if (!string.Equals(activeSource.Id, TaskSourceDescriptor.DefaultSourceId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var legacyStorage = configuration.Get<TaskStorageSettings>("TaskStorage") ?? new TaskStorageSettings();
+        legacyStorage.IsServerMode = activeSource.Kind == TaskSourceKind.Server;
+        legacyStorage.Path = activeSource.Path;
+        legacyStorage.URL = activeSource.Url;
+
+        var serverSettings = settings.ServerSettings.FirstOrDefault(server =>
+            string.Equals(server.SourceId, activeSource.Id, StringComparison.Ordinal));
+        if (serverSettings != null)
+        {
+            legacyStorage.Login = serverSettings.Login;
+            legacyStorage.Password = serverSettings.Password;
+            WriteClientSettings(configuration, ToClientSettings(serverSettings));
+        }
+
+        configuration.Set("TaskStorage", legacyStorage);
+    }
+
+    public static ClientSettings ToClientSettings(TaskSourceServerSettings serverSettings) =>
+        new()
+        {
+            AccessToken = serverSettings.AccessToken,
+            RefreshToken = serverSettings.RefreshToken,
+            ExpireTime = serverSettings.ExpireTime,
+            UserId = serverSettings.UserId,
+            Login = serverSettings.Login
+        };
+
+    public static void CopyFromClientSettings(
+        ClientSettings clientSettings,
+        TaskSourceServerSettings serverSettings)
+    {
+        serverSettings.AccessToken = clientSettings.AccessToken;
+        serverSettings.RefreshToken = clientSettings.RefreshToken;
+        serverSettings.ExpireTime = clientSettings.ExpireTime;
+        serverSettings.UserId = clientSettings.UserId;
+        serverSettings.Login = clientSettings.Login;
+    }
+
+    private static TaskSourcesSettings Read(IConfiguration configuration)
+    {
+        var section = configuration.GetSection(TaskSourcesSettings.SectionName);
+        var settings = new TaskSourcesSettings
+        {
+            ActiveSourceId = section.GetSection(nameof(TaskSourcesSettings.ActiveSourceId)).Get<string>()
+                             ?? TaskSourceDescriptor.DefaultSourceId
+        };
+
+        var sourceCount = section.GetSection("SourcesCount").Get<int?>();
+        var sourceSections = ReadEntrySections(
+            section,
+            sourceCount,
+            "SourceEntries",
+            "Source",
+            "SourceKey",
+            nameof(TaskSourcesSettings.Sources));
+        foreach (var sourceSection in sourceSections)
+        {
+            var id = sourceSection.GetSection(nameof(TaskSourceDescriptor.Id)).Get<string>();
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                continue;
+            }
+
+            settings.Sources.Add(new TaskSourceDescriptor
+            {
+                Id = id,
+                DisplayName = sourceSection.GetSection(nameof(TaskSourceDescriptor.DisplayName)).Get<string>() ?? string.Empty,
+                Kind = Enum.TryParse<TaskSourceKind>(
+                    sourceSection.GetSection(nameof(TaskSourceDescriptor.Kind)).Get<string>(),
+                    ignoreCase: true,
+                    out var kind)
+                    ? kind
+                    : TaskSourceKind.File,
+                Path = sourceSection.GetSection(nameof(TaskSourceDescriptor.Path)).Get<string>() ?? string.Empty,
+                Url = sourceSection.GetSection(nameof(TaskSourceDescriptor.Url)).Get<string>() ?? string.Empty,
+                IsEnabled = sourceSection.GetSection(nameof(TaskSourceDescriptor.IsEnabled)).Get<bool?>() ?? true
+            });
+        }
+
+        var serverSettingsCount = section.GetSection("ServerSettingsCount").Get<int?>();
+        var serverSections = ReadEntrySections(
+            section,
+            serverSettingsCount,
+            "ServerSettingEntries",
+            "Server",
+            "ServerSettingsKey",
+            nameof(TaskSourcesSettings.ServerSettings));
+        foreach (var serverSection in serverSections)
+        {
+            var sourceId = serverSection.GetSection(nameof(TaskSourceServerSettings.SourceId)).Get<string>();
+            if (string.IsNullOrWhiteSpace(sourceId))
+            {
+                continue;
+            }
+
+            settings.ServerSettings.Add(new TaskSourceServerSettings
+            {
+                SourceId = sourceId,
+                Login = serverSection.GetSection(nameof(TaskSourceServerSettings.Login)).Get<string>() ?? string.Empty,
+                Password = serverSection.GetSection(nameof(TaskSourceServerSettings.Password)).Get<string>() ?? string.Empty,
+                AccessToken = serverSection.GetSection(nameof(TaskSourceServerSettings.AccessToken)).Get<string>() ?? string.Empty,
+                RefreshToken = serverSection.GetSection(nameof(TaskSourceServerSettings.RefreshToken)).Get<string>() ?? string.Empty,
+                ExpireTime = ReadDateTimeOffset(serverSection.GetSection(nameof(TaskSourceServerSettings.ExpireTime)).Get<string>()),
+                UserId = serverSection.GetSection(nameof(TaskSourceServerSettings.UserId)).Get<string>() ?? string.Empty
+            });
+        }
+
+        return settings;
+    }
+
+    private static int ReadIndex(string key) =>
+        int.TryParse(key, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index)
+            ? index
+            : int.MaxValue;
+
+    private static List<IConfigurationSection> ReadEntrySections(
+        IConfiguration section,
+        int? count,
+        string entriesSectionName,
+        string entryPrefix,
+        string keyPrefix,
+        string legacyArraySectionName)
+    {
+        if (count.HasValue)
+        {
+            return Enumerable
+                .Range(0, count.Value)
+                .Select(index =>
+                {
+                    var entryKey = $"{entryPrefix}{index.ToString(CultureInfo.InvariantCulture)}";
+                    var configuredKey = section
+                        .GetSection($"{keyPrefix}{index.ToString(CultureInfo.InvariantCulture)}")
+                        .Get<string>();
+                    return string.IsNullOrWhiteSpace(configuredKey)
+                        ? null
+                        : section.GetSection(entriesSectionName).GetSection(entryKey);
+                })
+                .Where(entry => entry != null)
+                .Cast<IConfigurationSection>()
+                .ToList();
+        }
+
+        var mapSections = section
+            .GetSection(entriesSectionName)
+            .GetChildren()
+            .OrderBy(child => child.Key, StringComparer.Ordinal)
+            .ToList();
+        if (mapSections.Count > 0)
+        {
+            return mapSections;
+        }
+
+        return section
+            .GetSection(legacyArraySectionName)
+            .GetChildren()
+            .OrderBy(child => ReadIndex(child.Key))
+            .ToList();
+    }
+
+    private static ClientSettings ReadClientSettings(IConfiguration configuration)
+    {
+        var section = configuration.GetSection("ClientSettings");
+        return new ClientSettings
+        {
+            AccessToken = section.GetSection(nameof(ClientSettings.AccessToken)).Get<string>() ?? string.Empty,
+            RefreshToken = section.GetSection(nameof(ClientSettings.RefreshToken)).Get<string>() ?? string.Empty,
+            ExpireTime = ReadDateTimeOffset(section.GetSection(nameof(ClientSettings.ExpireTime)).Get<string>()),
+            UserId = section.GetSection(nameof(ClientSettings.UserId)).Get<string>() ?? string.Empty,
+            Login = section.GetSection(nameof(ClientSettings.Login)).Get<string>() ?? string.Empty
+        };
+    }
+
+    private static void WriteClientSettings(IConfiguration configuration, ClientSettings clientSettings)
+    {
+        var section = configuration.GetSection("ClientSettings");
+        section.GetSection(nameof(ClientSettings.AccessToken)).Set(clientSettings.AccessToken);
+        section.GetSection(nameof(ClientSettings.RefreshToken)).Set(clientSettings.RefreshToken);
+        section.GetSection(nameof(ClientSettings.ExpireTime)).Set(clientSettings.ExpireTime.ToString("O", CultureInfo.InvariantCulture));
+        section.GetSection(nameof(ClientSettings.UserId)).Set(clientSettings.UserId);
+        section.GetSection(nameof(ClientSettings.Login)).Set(clientSettings.Login);
+    }
+
+    private static DateTimeOffset ReadDateTimeOffset(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return default;
+        }
+
+        return DateTimeOffset.TryParse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out var parsed)
+            ? parsed
+            : default;
+    }
+}

--- a/src/Unlimotion/Services/TaskStorageBuilder.cs
+++ b/src/Unlimotion/Services/TaskStorageBuilder.cs
@@ -1,0 +1,56 @@
+using System;
+using AutoMapper;
+using Microsoft.Extensions.Configuration;
+using Unlimotion.TaskTree;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Services;
+
+public sealed class TaskStorageBuilder(
+    IConfiguration configuration,
+    IMapper mapper,
+    INotificationManagerWrapper? notificationManager = null,
+    Func<string?>? defaultStoragePathProvider = null)
+    : ITaskStorageBuilder
+{
+    public TaskStorageBuildResult Build(TaskStorageBuildRequest request)
+    {
+        var descriptor = request.Descriptor;
+        return descriptor.Kind == TaskSourceKind.Server
+            ? BuildServerStorage(request)
+            : BuildFileStorage(request);
+    }
+
+    private TaskStorageBuildResult BuildFileStorage(TaskStorageBuildRequest request)
+    {
+        var storagePath = ResolveStoragePath(request.Descriptor.Path);
+        var fileStorage = new FileStorage(storagePath, watcher: request.EnableWatcher, notificationManager);
+        fileStorage.Watcher?.SetEnable(false);
+        var taskTreeManager = new TaskTreeManager(fileStorage);
+        var taskStorage = new UnifiedTaskStorage(taskTreeManager, request.TaskContext);
+        return new TaskStorageBuildResult(taskStorage, fileStorage.Watcher);
+    }
+
+    private TaskStorageBuildResult BuildServerStorage(TaskStorageBuildRequest request)
+    {
+        var serverStorage = new ServerStorage(
+            request.Descriptor.Url,
+            configuration,
+            request.ServerSettings,
+            request.PersistServerSettings);
+        var taskTreeManager = new TaskTreeManager(serverStorage);
+        var taskStorage = new UnifiedTaskStorage(taskTreeManager, request.TaskContext);
+        return new TaskStorageBuildResult(taskStorage, watcher: null);
+    }
+
+    private string ResolveStoragePath(string? path)
+    {
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            return path;
+        }
+
+        var defaultPath = defaultStoragePathProvider?.Invoke();
+        return string.IsNullOrWhiteSpace(defaultPath) ? "Tasks" : defaultPath;
+    }
+}

--- a/src/Unlimotion/Services/TaskStorageFactory.cs
+++ b/src/Unlimotion/Services/TaskStorageFactory.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Threading.Tasks;
 using AutoMapper;
 using Microsoft.Extensions.Configuration;
-using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
 
 namespace Unlimotion.Services;
@@ -10,68 +8,86 @@ namespace Unlimotion.Services;
 public class TaskStorageFactory : ITaskStorageFactory
 {
     private readonly IConfiguration _configuration;
-    private readonly IMapper _mapper;
-    private readonly INotificationManagerWrapper? _notificationManager;
-    
-    public static string DefaultStoragePath { get; set; } = string.Empty;
-    public static Func<string?, Task>? PrepareFileStoragePathAsync { get; set; }
-    
-    public ITaskStorage? CurrentStorage { get; private set; }
-    public IDatabaseWatcher? CurrentWatcher { get; private set; }
+    private readonly Func<string?> _defaultStoragePathProvider;
+    private readonly ITaskStorageBuilder _storageBuilder;
 
-    public TaskStorageFactory(IConfiguration configuration, IMapper mapper, INotificationManagerWrapper? notificationManager = null)
+    public TaskStorageFactory(
+        IConfiguration configuration,
+        IMapper mapper,
+        INotificationManagerWrapper? notificationManager = null,
+        Func<string?>? defaultStoragePathProvider = null)
     {
         _configuration = configuration;
-        _mapper = mapper;
-        _notificationManager = notificationManager;
+        _defaultStoragePathProvider = defaultStoragePathProvider ?? (() => string.Empty);
+        _storageBuilder = new TaskStorageBuilder(
+            configuration,
+            mapper,
+            notificationManager,
+            _defaultStoragePathProvider);
+        SourceManager = new TaskSourceManager(
+            configuration,
+            _storageBuilder,
+            notificationManager,
+            _defaultStoragePathProvider);
     }
+
+    public ITaskSourceManager SourceManager { get; }
+
+    public ITaskStorage CreateConfiguredStorage() =>
+        SourceManager.ActivateConfiguredSource().Storage;
 
     public ITaskStorage CreateFileStorage(string? path)
     {
-        var storagePath = GetStoragePath(path);
-        var fileStorage = new FileStorage(storagePath, watcher: true, _notificationManager);
-        fileStorage.Watcher?.SetEnable(false);
-        CurrentWatcher = fileStorage.Watcher;
-        var taskTreeManager = new TaskTreeManager(fileStorage);
-        var taskStorage = new UnifiedTaskStorage(taskTreeManager);
-        CurrentStorage = taskStorage;
-        return taskStorage;
+        var descriptor = TaskSourceSettingsAdapter.CreateLegacyDescriptor(
+            new TaskStorageSettings
+            {
+                Path = string.IsNullOrWhiteSpace(path) ? _defaultStoragePathProvider() ?? string.Empty : path,
+                IsServerMode = false
+            },
+            _defaultStoragePathProvider());
+        return SourceManager.ActivateSource(descriptor).Storage;
+    }
+
+    public ITaskStorage CreateDetachedFileStorage(string? path)
+    {
+        var storagePath = string.IsNullOrWhiteSpace(path) ? _defaultStoragePathProvider() ?? string.Empty : path;
+        var buildResult = _storageBuilder.Build(new TaskStorageBuildRequest
+        {
+            Descriptor = new TaskSourceDescriptor
+            {
+                Id = $"detached-file-{Guid.NewGuid():N}",
+                DisplayName = "Detached file storage",
+                Kind = TaskSourceKind.File,
+                Path = storagePath,
+                IsEnabled = true
+            },
+            TaskContext = new TaskItemViewModelContext
+            {
+                SourceId = "detached-file"
+            },
+            EnableWatcher = false
+        });
+
+        return buildResult.Storage;
     }
 
     public ITaskStorage CreateServerStorage(string? url)
     {
-        CurrentWatcher = null; // Server storage doesn't have a file watcher
-        var serverStorage = new ServerStorage(url ?? string.Empty, _configuration);
-        var taskTreeManager = new TaskTreeManager(serverStorage);
-        var taskStorage = new UnifiedTaskStorage(taskTreeManager);
-        CurrentStorage = taskStorage;
-        return taskStorage;
+        var legacySettings = _configuration.Get<TaskStorageSettings>("TaskStorage") ?? new TaskStorageSettings();
+        legacySettings.IsServerMode = true;
+        legacySettings.URL = url ?? string.Empty;
+
+        var descriptor = TaskSourceSettingsAdapter.CreateLegacyDescriptor(legacySettings, _defaultStoragePathProvider());
+        var serverSettings = TaskSourceSettingsAdapter.EnsureServerSettings(
+            TaskSourceSettingsAdapter.LoadOrCreate(_configuration, _defaultStoragePathProvider()),
+            descriptor.Id,
+            legacySettings,
+            _configuration);
+        return SourceManager.ActivateSource(descriptor, serverSettings).Storage;
     }
 
     public void SwitchStorage(bool isServerMode, IConfiguration configuration)
     {
-        var settings = configuration.Get<TaskStorageSettings>("TaskStorage");
-        
-        // Disconnect previous storage if exists
-        if (CurrentStorage != null)
-        {
-            CurrentStorage.TaskTreeManager.Storage.Disconnect();
-        }
-
-        if (isServerMode)
-        {
-            CreateServerStorage(settings?.URL);
-        }
-        else
-        {
-            CreateFileStorage(settings?.Path);
-        }
-    }
-
-    private static string GetStoragePath(string? path)
-    {
-        if (string.IsNullOrEmpty(path))
-            return DefaultStoragePath;
-        return path;
+        SourceManager.SwitchStorage(isServerMode, configuration);
     }
 }

--- a/src/Unlimotion/UnifiedTaskStorage.cs
+++ b/src/Unlimotion/UnifiedTaskStorage.cs
@@ -23,11 +23,13 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
     private const int InitialLoadBatchSize = 64;
     private const string StatusModelMigrationBackupDirectoryName = "status-model.migration.backup";
     private readonly bool isFileStorage;
+    private readonly TaskItemViewModelContext? taskContext;
     private bool disposed;
 
-    public UnifiedTaskStorage(TaskTreeManager taskTreeManager)
+    public UnifiedTaskStorage(TaskTreeManager taskTreeManager, TaskItemViewModelContext? taskContext = null)
     {
         TaskTreeManager = taskTreeManager;
+        this.taskContext = taskContext;
         isFileStorage = taskTreeManager.Storage is FileStorage;
         Tasks = new SourceCache<TaskItemViewModel, string>(item => item.Id);
         Relations = new TaskRelationsIndex();
@@ -98,7 +100,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
 
             // Initial view models subscribe immediately; keep startup hydration from saving tasks.
             var initialTaskViews = initialTasks
-                .Select(task => new TaskItemViewModel(task, this, () => false))
+                .Select(task => CreateTaskViewModel(task, () => false))
                 .ToList();
 
             new TaskRelationsIndex().Rebuild(initialTaskViews);
@@ -147,7 +149,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
             isBlocked)).ToList();
 
         var newTask = taskItemList.First(t => t.Id == createdTask.Id);
-        var vm = new TaskItemViewModel(newTask, this);
+        var vm = CreateTaskViewModel(newTask);
         Tasks.AddOrUpdate(vm);
 
         foreach (var task in taskItemList.Where(t => t.Id != createdTask.Id)) UpdateCache(task);
@@ -165,7 +167,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
             .ToList();
 
         var newTask = taskItemList.First(t => t.Id == createdTask.Id);
-        var vm = new TaskItemViewModel(newTask, this);
+        var vm = CreateTaskViewModel(newTask);
         Tasks.AddOrUpdate(vm);
 
         foreach (var task in taskItemList.Where(t => t.Id != createdTask.Id)) UpdateCache(task);
@@ -246,7 +248,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
         var last = connItemList.Last();
         if (connItemList.Count>1)
         {
-            var vm = new TaskItemViewModel(last, this);
+            var vm = CreateTaskViewModel(last);
             Tasks.AddOrUpdate(vm);
 
             foreach (var task in connItemList.SkipLast(1)) UpdateCache(task);
@@ -269,7 +271,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
         var taskItemList = (await TaskTreeManager.CloneTask(change.Model, additionalItemParents)).OrderBy(t => t.CreatedDateTime).ToList();
 
         var clone = taskItemList.Last();
-        var vm = new TaskItemViewModel(clone, this);
+        var vm = CreateTaskViewModel(clone);
         Tasks.AddOrUpdate(vm);
 
         foreach (var task in taskItemList.SkipLast(1)) UpdateCache(task);
@@ -890,10 +892,15 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
         }
         else if(create) 
         {
-            vm = new TaskItemViewModel(task, this);
+            vm = CreateTaskViewModel(task);
             Tasks.AddOrUpdate(vm.Value);
         }
     }
+
+    private TaskItemViewModel CreateTaskViewModel(
+        TaskItem task,
+        Func<bool>? isInitializedProvider = null) =>
+        new(task, this, isInitializedProvider, taskContext);
 
     private static bool ShouldForceReverseLinkRecheck(FileStorage fileStorage)
     {

--- a/src/Unlimotion/UnlimotionClientOptions.cs
+++ b/src/Unlimotion/UnlimotionClientOptions.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Unlimotion;
+
+public sealed class UnlimotionClientOptions
+{
+    public string? DefaultTaskStoragePath { get; set; }
+    public Func<string?, Task>? PrepareFileStoragePathAsync { get; set; }
+    public Func<string, string>? GetAbsolutePath { get; set; }
+}

--- a/src/Unlimotion/Views/EmojiFilterMultiSelectSearchBox.axaml.cs
+++ b/src/Unlimotion/Views/EmojiFilterMultiSelectSearchBox.axaml.cs
@@ -524,13 +524,18 @@ public partial class EmojiFilterMultiSelectSearchBox : UserControl
     private void Filter_OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (string.IsNullOrEmpty(e.PropertyName) ||
-            e.PropertyName == nameof(EmojiFilter.ShowTasks) ||
             e.PropertyName == nameof(EmojiFilter.Title) ||
             e.PropertyName == nameof(EmojiFilter.Emoji) ||
             e.PropertyName == nameof(EmojiFilter.SortText) ||
             e.PropertyName == nameof(EmojiFilter.SearchText))
         {
             ApplySearchFilter();
+            UpdateInputTextFromState();
+            return;
+        }
+
+        if (e.PropertyName == nameof(EmojiFilter.ShowTasks))
+        {
             UpdateInputTextFromState();
         }
     }

--- a/src/Unlimotion/Views/GraphControl.axaml.cs
+++ b/src/Unlimotion/Views/GraphControl.axaml.cs
@@ -2291,8 +2291,7 @@ namespace Unlimotion.Views
             return context?.FindParentDataContext<MainWindowViewModel>() ??
                    this.FindParentDataContext<MainWindowViewModel>() ??
                    (DataContext as GraphViewModel)?.MainWindowViewModel ??
-                   dc?.MainWindowViewModel ??
-                   TaskItemViewModel.MainWindowInstance;
+                   dc?.MainWindowViewModel;
         }
 
         private static bool TryGetRoadmapTaskItem(Control? control, out TaskItemViewModel taskItem)

--- a/src/Unlimotion/Views/MainControl.axaml.cs
+++ b/src/Unlimotion/Views/MainControl.axaml.cs
@@ -50,7 +50,6 @@ namespace Unlimotion.Views
         ];
 
         // Static dependencies - set once during app initialization
-        public static IDialogs? DialogsInstance { get; set; }
         private const int MaxTitleFocusRetries = 5;
         private const int MaxRelationEditorFocusRetries = 5;
         private const int MaxCompletionCriterionFocusRetries = 5;
@@ -1202,7 +1201,7 @@ namespace Unlimotion.Views
                 {
                     if (vm.CurrentTaskItem == null)
                         return;
-                    var dialogs = DialogsInstance;
+                    var dialogs = vm.Dialogs;
                     if (dialogs == null) return;
                     
                     var currentTaskStoragePath = (vm.taskRepository?.TaskTreeManager.Storage as FileStorage)?.Path;
@@ -1212,31 +1211,10 @@ namespace Unlimotion.Views
 
                     if (!string.IsNullOrWhiteSpace(path))
                     {
-                        var fileStorage = new FileStorage(path);
-                        var set = new HashSet<string>();
-                        var queue = new Queue<TaskItemViewModel>();
-                        queue.Enqueue(vm.CurrentTaskItem);
-                        while (queue.Count > 0)
+                        var moveTask = vm.MoveTaskTreeToFileStorageAsync;
+                        if (moveTask != null)
                         {
-                            var task = queue.Dequeue();
-                            if (!set.Contains(task.Id))
-                            {
-                                set.Add(task.Id);
-                                await fileStorage.Save(task.Model);
-                                foreach (var item in task.ContainsTasks)
-                                {
-                                    queue.Enqueue(item);
-                                }
-                            }
-                        }
-
-                        var currentTaskStorage = vm.taskRepository?.TaskTreeManager.Storage;
-                        if (currentTaskStorage != null)
-                        {
-                            foreach (var id in set)
-                            {
-                                await currentTaskStorage.Remove(id);
-                            }
+                            await moveTask(vm.CurrentTaskItem, vm.taskRepository, path);
                         }
                     }
                 });

--- a/tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs
+++ b/tests/Unlimotion.AppAutomation.TestHost/UnlimotionAppLaunchHost.cs
@@ -187,8 +187,11 @@ public static class UnlimotionAppLaunchHost
         IConfigurationRoot configuration = WritableJsonConfigurationFabric.Create(launchData.ConfigPath, reloadOnChange: false);
         var mapper = AppModelMapping.ConfigureMapping();
         var notificationManager = new AutomationNotificationManager();
-        var storageFactory = new TaskStorageFactory(configuration, mapper, notificationManager);
-        TaskStorageFactory.DefaultStoragePath = launchData.TasksPath;
+        var storageFactory = new TaskStorageFactory(
+            configuration,
+            mapper,
+            notificationManager,
+            () => launchData.TasksPath);
         storageFactory.CreateFileStorage(launchData.TasksPath);
 
         var backupService = new BackupViaGitService(configuration, notificationManager, storageFactory);
@@ -199,13 +202,16 @@ public static class UnlimotionAppLaunchHost
             new AppNameDefinitionService(),
             notificationManager,
             configuration,
-            () => storageFactory.CurrentStorage,
+            () => storageFactory.SourceManager.ActiveStorage,
             settingsViewModel,
             new GraphViewModel(),
             TaskTreeExpansionStateStore.GetDefaultPath(launchData.ConfigPath));
 
-        TaskItemViewModel.NotificationManagerInstance = notificationManager;
-        TaskItemViewModel.MainWindowInstance = vm;
+        var activeSource = storageFactory.SourceManager.ActiveSource;
+        if (activeSource != null)
+        {
+            activeSource.TaskContext.MainWindow = vm;
+        }
 
         return vm;
     }


### PR DESCRIPTION
## Summary
- Isolate the client task-storage runtime from static/singleton hooks that block multiple task sources.
- Preserve current single-source local/server behavior while adding source-scoped runtime/settings boundaries.
- Fix post-review defects found after rebase: transactional source activation, active-storage error routing, default file command routing, detached task move storage, completed/archived projection refresh, and paste-outline autosave race.

## Changes
- Add `TaskSourceManager`, `TaskSourceRuntime`, `TaskStorageBuilder`, `TaskMoveService`, source settings adapters, and source-scoped VM context.
- Keep active runtime access behind `ITaskSourceManager.ActiveStorage` / `ActiveWatcher`; expose read-only configured descriptors for default-source compatibility commands.
- Build a candidate source runtime before mutating active/persisted state, so failed activation leaves the previous source alive.
- Route server connection errors from the actual connected storage instead of legacy `TaskStorage.IsServerMode`.
- Resolve backup/migrate/resave detached local commands from the configured `default` file source, with legacy fallback only for compatibility.
- Move `MainControl` move-to-path file writes into `TaskMoveService` using detached file storage with watcher disabled.
- Add projection auto-refresh for `CompletedDateTime` / `ArchiveDateTime` and suppress reactive autosave during initial paste-outline task creation before explicit update.
- Update approved spec and post-EXEC review evidence: `specs/2026-06-16-client-multi-source-refactor.md`.

## Validation
- Rebased onto current `origin/main` `91d42be42d650fac739647a82979823e85cd8426`; new PR head is `05da3dc88f6466e44a0564f86f34790416dd6a03`.
- `dotnet build src/Unlimotion.Desktop/Unlimotion.Desktop.csproj -c Debug -p:UseSharedCompilation=false` -> passed, warnings only.
- `dotnet build src/Unlimotion.Browser/Unlimotion.Browser.csproj -c Debug -p:UseSharedCompilation=false` -> passed, warnings only.
- `dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug --no-restore -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --output Detailed` -> 552/552 passed. Initial sandboxed attempt was blocked before tests by Avalonia BuildServices writing `%LOCALAPPDATA%`; rerun outside sandbox passed.
- `dotnet restore tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj` -> passed after sandboxed NuGet SSL/auth retry.
- `dotnet run --project tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj -c Debug --no-restore -- --maximum-parallel-tests 1 --output Detailed` -> 31/31 passed. Local SDK `10.0.301` rejects this project via `dotnet test` because `global.json` selects Microsoft.Testing.Platform while the project is classified as VSTest; direct TUnit/MTP runner was used for local smoke.
- `git diff --check origin/main...HEAD` -> passed.
- GitHub checks on `05da3dc` -> passed: `Unlimotion Tests / All tests`, `Unlimotion AndroidPkg / android-build`, `CodeQL Advanced` (`Analyze (actions)`, `Analyze (csharp)`, `Analyze (javascript-typescript)`).
- UI video evidence: not applicable because this is architectural/plumbing refactor without visible UI flow changes; next-best evidence is the full local TUnit run plus headless UI smoke above.

## Risks / Rollback
- Risk: this creates the runtime boundary but does not add a visible multi-source selector UI; that remains a follow-up product feature.
- Risk: local Android compile still requires SDK workload restoration; GitHub `android-build` passed and is the authoritative Android evidence for this PR.
- Rollback: revert the single refactor commit; persisted settings additions are additive and existing local storage defaults remain compatible.

## Links
- Spec: `specs/2026-06-16-client-multi-source-refactor.md`