### PR TITLE
fix(roadmap): localize map controls

### DIFF
--- a/specs/2026-06-16-roadmap-map-controls-localization-theme.md
+++ b/specs/2026-06-16-roadmap-map-controls-localization-theme.md
@@ -1,0 +1,310 @@
+# Локализация и theme-aware оформление элементов управления картой
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; `dotnet-desktop-client` + `ui-automation-testing`; context: `testing-dotnet`, `session-insights-context`.
+- Владелец: Codex / пользователь.
+- Масштаб: small.
+- Целевая модель: gpt-5.5.
+- Целевой релиз / ветка: текущая рабочая ветка.
+- Ограничения: до подтверждения менять только эту спецификацию; после подтверждения не менять публичный API и не менять поведение навигации карты.
+- Связанные ссылки: центральный `C:\Users\Kibnet\.codex\agents\AGENTS.md`, локальный `AGENTS.override.md`.
+
+Если секция не применима, явно укажите `Не применимо` и короткую причину, вместо заполнения нерелевантными деталями.
+
+## 1. Overview / Цель
+Локализовать элементы управления картой Roadmap и привести их overlay-оформление к теме приложения вместо жестко заданной темной палитры.
+
+Outcome contract:
+- Success means: все видимые/доступные подписи контролов карты берутся из localization resources; overlay-кнопки, панель управления, индикатор обновления и миникарта используют theme-aware ресурсы; существующие команды zoom/pan/fit/reset/collapse/expand работают как раньше.
+- Итоговый артефакт / output: код UI + ресурсы локализации + headless UI regression test.
+- Stop rules: остановиться, если найдено несколько несовместимых UX-вариантов без явно лучшего; если targeted UI tests не запускаются из-за окружения, зафиксировать blocker и next-best evidence.
+
+## 2. Текущее состояние (AS-IS)
+- Основной UI карты находится в `src/Unlimotion/Views/GraphControl.axaml`, логика overlay-команд находится в `src/Unlimotion/Views/GraphControl.axaml.cs`.
+- Ресурсные строки живут в `src/Unlimotion.ViewModel/Resources/Strings.resx` и `src/Unlimotion.ViewModel/Resources/Strings.ru.resx`; `App.axaml.cs` публикует ключи в `Application.Resources`, поэтому XAML использует `DynamicResource`.
+- В `GraphControl.axaml` фильтры карты уже локализованы через `DynamicResource`, но viewport/minimap controls используют английские tooltips: `Zoom in`, `Zoom out`, `Fit`, `Reset`, `Pan up/down/left/right`, `Hide graph controls`, `Show graph controls`, `Hide minimap`, `Show minimap`.
+- В этих же контролах используются грубые текстовые символы `[]`, `T`, `M`, `x`, `^`, `<`, `>`, `v`; они выглядят как debug UI и плохо масштабируются визуально.
+- Overlay-панели и кнопки карты жестко задают цвета `#3A3A3A`, `#707070`, `White`, `#CC1E1E1E`, `#E61E1E1E`, `#202020`, `#808080`, `#B0B0B0`, поэтому UI не следует светлой/темной теме.
+- Существующие headless UI tests для overlay карты находятся в `src/Unlimotion.Test/RoadmapGraphUiTests.cs`: `RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls` и `RoadmapGraph_ViewportOverlays_CollapseToCompactButtonsAndRestore`.
+
+## 3. Проблема
+Элементы управления картой выглядят неаккуратно, частично англоязычны в русской локали и используют фиксированную темную палитру, из-за чего нарушают единый UI-контракт приложения.
+
+## 4. Цели дизайна
+- Разделение ответственности: строки в resx, визуальный стиль в XAML styles, поведение команд без изменений.
+- Повторное использование: использовать существующий `DynamicResource` localization pipeline и существующие `Theme*Brush` ресурсы Avalonia/Fluent.
+- Тестируемость: расширить существующие Avalonia.Headless/TUnit tests, не вводя новый test harness.
+- Консистентность: сохранить `AutomationProperties.AutomationId`; добавить/проверить `AutomationProperties.Name` через локализованные строки.
+- Обратная совместимость: не менять binding, команды, persisted state и selection/viewport алгоритмы.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не меняем алгоритмы layout карты, zoom, pan, fit, reset, selection, minimap binding.
+- Не меняем структуру `GraphViewModel` и не добавляем persisted settings.
+- Не меняем global theme system и не создаем новый icon package.
+- Не трогаем фильтры Roadmap, кроме случайной совместимости со стилями, если она потребуется.
+- Не создаем крупные video artifacts в репозитории.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `src/Unlimotion.ViewModel/Resources/Strings.resx` -> английские строки действий карты.
+- `src/Unlimotion.ViewModel/Resources/Strings.ru.resx` -> русские строки действий карты.
+- `src/Unlimotion/Views/GraphControl.axaml` -> theme-aware brush resources, локализованные tooltips/names, аккуратные icon/content controls.
+- `src/Unlimotion.Test/RoadmapGraphUiTests.cs` -> headless assertions для локализации, accessibility names и theme resource bindings.
+
+### 6.2 Детальный дизайн
+- Добавить ключи вида `RoadmapZoomIn`, `RoadmapZoomOut`, `RoadmapFitViewport`, `RoadmapResetViewport`, `RoadmapPanUp`, `RoadmapPanDown`, `RoadmapPanLeft`, `RoadmapPanRight`, `RoadmapHideGraphControls`, `RoadmapShowGraphControls`, `RoadmapHideMinimap`, `RoadmapShowMinimap`.
+- Для каждой кнопки overlay поставить `ToolTip.Tip="{DynamicResource ...}"` и `AutomationProperties.Name="{DynamicResource ...}"`.
+- Заменить `Content="[]"`, `Content="T"`, `Content="M"`, `Content="x"` на компактные `PathIcon` внутри существующих кнопок. Для `+`, `-` и стрелок допустимы текстовые символы только если они визуально стабильны и имеют локализованный accessible name; предпочтительно также перевести pan/fit/collapse/expand на `PathIcon`, чтобы UI выглядел единообразно.
+- Стили `roadmapViewportButton` и `roadmapOverlayButton` должны использовать theme resources: `ThemeControlLowBrush`, `ThemeControlMidBrush`, `ThemeControlHighBrush`/`ThemeForegroundBrush` там, где ресурс доступен в текущем проекте. Не использовать hard-coded dark background/white foreground для основного overlay UI.
+- Панели `RoadmapViewportToolbar`, `RoadmapMinimapPanel` и `RoadmapBuildIndicator` должны использовать `DynamicResource` theme brushes с легкой рамкой и прежними размерами, чтобы не ломать layout.
+- `RoadmapMinimap` и его item template должны уйти от фиксированной темной палитры к theme-aware brushes; допустимо оставить только минимальные accent/selection colors, если они соответствуют существующим app resources.
+- Visual planning artifact для UI-facing изменений:
+
+```text
+Roadmap surface
+┌──────────────────────────────────────────────┐
+│ [localized filter/search toolbar unchanged]  │
+│                                              │
+│                                              │
+│ ┌ controls panel, themed ┐     ┌ minimap ┐   │
+│ │ + - fit reset   ↑      │     │ themed  │   │
+│ │              ←     →   │     │ nodes   │   │
+│ │                 ↓  x   │     │      x  │   │
+│ └───────────────────────┘     └─────────┘   │
+│ collapsed state: [controls icon] [map icon]  │
+└──────────────────────────────────────────────┘
+```
+
+- UI/video evidence:
+  - Записать `before` baseline до изменения кода через skill `record-app-screen`, focused на окне desktop-приложения Unlimotion.
+  - Записать `after` после реализации тем же способом, с тем же размером окна и тем же сценарием.
+  - Сценарий записи: открыть Roadmap, показать overlay controls и minimap, выполнить zoom/pan/reset, свернуть/развернуть controls и minimap.
+  - Видео не коммитить по умолчанию; вернуть absolute paths в итоговом отчете и указать duration/FPS/caveats.
+  - Fallback допустим только если запись окна технически невозможна: `ffmpeg` недоступен, окно приложения не запускается/не находится, recorder script отсутствует или захват небезопасен. Тогда указать причину, команду проверки и next-best evidence.
+- Границы сохранения поведения: `AutomationId`, command handlers, click behavior, compact collapsed button size <= 40 и viewport/minimap bindings сохраняются.
+- Обработка ошибок: новые resource keys должны существовать в обеих resx; отсутствующий key считается тестовым failure.
+- Производительность: XAML style/resource lookup не должен менять графовый build path; дополнительных подписок или таймеров не добавлять.
+
+## 7. Бизнес-правила / Алгоритмы (если есть)
+- Для русской локали пользовательские подписи должны быть русскими и не содержать случайного English UI copy.
+- Для английской локали fallback-строки должны оставаться английскими.
+- Доступность: кнопки с icon-only content обязаны иметь `AutomationProperties.Name`.
+
+## 8. Точки интеграции и триггеры
+- `GraphControl.axaml` использует `DynamicResource` и автоматически получает новые значения после обновления application resources при смене языка.
+- `RoadmapZoomIn_OnClick`, `RoadmapZoomOut_OnClick`, `RoadmapFit_OnClick`, `RoadmapResetViewport_OnClick`, `RoadmapPan*`, collapse/expand handlers остаются без изменения.
+- Headless tests создают `App`, `MainControl` и Roadmap tab, затем проверяют реальные controls по stable automation ids.
+
+## 9. Изменения модели данных / состояния
+- Новых persisted или calculated state fields нет.
+- В хранилище задач, настройках пользователя и view models изменений нет.
+
+## 10. Миграция / Rollout / Rollback
+- Первый запуск: новые строки подхватываются из resx без миграции.
+- Обратная совместимость: отсутствие изменений в persisted data и публичных командах.
+- Rollback: revert изменений в `GraphControl.axaml`, двух resx и тесте.
+
+## 11. Тестирование и критерии приёмки
+- Acceptance Criteria:
+  - В `GraphControl.axaml` не остается английских hard-coded tooltip для Roadmap overlay controls.
+  - У icon-only overlay buttons есть локализованные `ToolTip.Tip` и `AutomationProperties.Name`.
+  - Overlay controls и minimap/progress panels используют `DynamicResource` theme brushes вместо фиксированной темной палитры для background/border/foreground.
+  - Существующие zoom/pan/reset/collapse/expand сценарии проходят без изменения поведения.
+  - Русские и английские resource keys добавлены симметрично.
+- Какие тесты добавить/изменить:
+  - Обновить `RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls`: проверить локализованные names/tooltips для основных buttons и сохранить проверки zoom/pan/reset.
+  - Обновить `RoadmapGraph_ViewportOverlays_CollapseToCompactButtonsAndRestore`: проверить localized names/tooltips для collapse/expand minimap/controls, размеры collapsed buttons и восстановление панелей.
+  - При необходимости добавить helper для чтения `AutomationProperties.Name` и `ToolTip.Tip`.
+- Characterization tests / contract checks для текущего поведения: существующие assertions по `ViewportZoom`, `ViewportLocation`, collapse/restore и minimap binding остаются.
+- Visual acceptance для UI-facing изменений: overlay должен соответствовать wireframe: icon-only buttons, компактные панели, без debug text `[]`/`T`/`M`/`x`, theme-aware colors.
+- UI video evidence для UI-facing фич/багфиксов:
+  - `before`: `artifacts/roadmap-map-controls-localization-theme/roadmap-controls-before.mp4`, записать до правок.
+  - `after`: `artifacts/roadmap-map-controls-localization-theme/roadmap-controls-after.mp4`, записать после правок.
+  - Команда: использовать `record-app-screen` / `scripts/record_app_window.ps1` с `-WindowTitle` или `-ProcessName` для окна Unlimotion, duration около 20 секунд, без audio.
+  - Проверка: `Get-Item` для nonzero size; `ffprobe`, если доступен, для duration/dimensions.
+  - Fallback: только при технической невозможности записи, с явной причиной и next-best evidence.
+- Базовые замеры до/после для performance tradeoff: Не применимо, нет performance-sensitive path.
+- Команды для проверки:
+
+```powershell
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_ViewportOverlay_*" --no-progress
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_ViewportOverlays_*" --no-progress
+dotnet build src\Unlimotion.Desktop\Unlimotion.Desktop.csproj --no-restore
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj
+git diff --check
+```
+
+- Stop rules для test/retrieval/tool/validation loops: если targeted UI tests падают, фиксить до PASS; если full run занимает непропорционально долго или упирается в known environment failure, отчет должен явно отделить targeted evidence от неполного full evidence.
+
+## 12. Риски и edge cases
+- Риск: выбранный theme brush отсутствует в текущей Fluent/Nodify resource dictionary. Смягчение: использовать только уже встречающиеся в проекте `ThemeControlLowBrush`, `ThemeControlMidBrush`, `ThemeBackgroundBrush` или проверить через headless render/resource lookup.
+- Риск: `DynamicResource` в `AutomationProperties.Name` не обновится так, как ожидается. Смягчение: тестировать через реально созданный `App` и текущий localization resource pipeline.
+- Риск: icon-only content ухудшит понятность. Смягчение: stable tooltips/accessibility names и знакомые pictograms; не менять command placement.
+- Риск: изменение hard-coded colors может слегка поменять контраст. Смягчение: использовать стандартные theme resources и проверить светлую/темную тему, если доступно в headless.
+
+## 13. План выполнения
+1. Добавить resource keys в обе resx.
+2. Обновить `GraphControl.axaml`: локализованные tooltips/names, аккуратные icon content, theme-aware brushes.
+3. Обновить `RoadmapGraphUiTests.cs`: assertions по localization/accessibility/theme style и сохранить behavioral assertions.
+4. Запустить targeted UI tests.
+5. Запустить build, затем full test command или явно зафиксировать объективный blocker.
+6. Выполнить post-EXEC review-loop и исправить однозначные findings.
+
+## 14. Открытые вопросы
+Нет блокирующих вопросов.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client`, `ui-automation-testing`.
+- Выполненные требования профиля:
+  - SPEC фиксирует UI visual planning artifact.
+  - План включает Avalonia.Headless UI tests.
+  - План сохраняет stable `AutomationId`.
+  - План включает `dotnet build`, targeted UI tests и full test attempt/evidence.
+  - Video evidence планируется через `record-app-screen`; fallback допустим только при технической невозможности записи окна.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion/Views/GraphControl.axaml` | Локализованные names/tooltips, theme-aware brushes, аккуратные icon-only controls | Основной UI дефект |
+| `src/Unlimotion.ViewModel/Resources/Strings.resx` | Английские ключи действий Roadmap overlay | Localization fallback |
+| `src/Unlimotion.ViewModel/Resources/Strings.ru.resx` | Русские ключи действий Roadmap overlay | Русская локализация |
+| `src/Unlimotion.Test/RoadmapGraphUiTests.cs` | Headless UI regression assertions | Обязательное UI coverage |
+| `specs/2026-06-16-roadmap-map-controls-localization-theme.md` | QUEST рабочая спецификация | Governance gate |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Tooltips | Hard-coded English | `DynamicResource` EN/RU |
+| Accessibility names | Частично отсутствуют на icon/debug buttons | Локализованные `AutomationProperties.Name` |
+| Button content | `[]`, `T`, `M`, `x`, raw arrows | Аккуратные icon/symbol controls с labels в tooltip/name |
+| Colors | Fixed dark palette | Theme resources |
+| Tests | Проверяли только поведение overlay | Проверяют поведение + localization/accessibility/theme contract |
+
+## 18. Альтернативы и компромиссы
+- Вариант: оставить текстовые символы, только локализовать tooltips.
+- Плюсы: минимальный diff.
+- Минусы: UI остается неаккуратным и часть проблемы пользователя не решена.
+- Почему выбранное решение лучше в контексте этой задачи: замена debug-like content на icon-only controls с локализованными names закрывает и polish, и доступность, не меняя behavior.
+
+- Вариант: добавить новый icon package.
+- Плюсы: единая библиотека иконок.
+- Минусы: лишняя dependency для маленькой UI правки.
+- Почему выбранное решение лучше в контексте этой задачи: локальные `PathIcon` уже используются в проекте и достаточны для узкого Roadmap overlay.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, проблема, цели и Non-Goals зафиксированы. |
+| B. Качество дизайна | 6-10 | PASS | Ответственность, интеграция, state, rollback и visual artifact описаны. |
+| C. Безопасность изменений | 11-13 | PASS | Нет data migration; rollback простой; риски и edge cases перечислены. |
+| D. Проверяемость | 14-16 | PASS | Acceptance criteria, UI tests и команды проверки указаны. |
+| E. Готовность к автономной реализации | 17-19 | PASS | План, соответствия и альтернативы достаточны; открытых вопросов нет. |
+| F. Соответствие профилю | 20 | PASS | `dotnet-desktop-client` и `ui-automation-testing` требования отражены. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Одна корневая UI-проблема, явные Non-Goals. |
+| 2. Понимание текущего состояния | 5 | Указаны конкретные файлы, текущие hard-coded strings/colors и существующие тесты. |
+| 3. Конкретность целевого дизайна | 5 | Есть key list, XAML contract, theme strategy и wireframe. |
+| 4. Безопасность (миграция, откат) | 5 | Нет persisted data; rollback ограничен четырьмя рабочими файлами. |
+| 5. Тестируемость | 5 | Acceptance criteria связаны с headless UI tests и командами. |
+| 6. Готовность к автономной реализации | 5 | Открытых вопросов нет; план и stop rules заданы. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Post-SPEC Review
+- Статус: PASS
+- Scope reviewed: `specs/2026-06-16-roadmap-map-controls-localization-theme.md`, instruction stack (`model-behavior-baseline`, `quest-governance`, `quest-mode`, `collaboration-baseline`, `testing-baseline`, `testing-dotnet`, `dotnet-desktop-client`, `ui-automation-testing`, `session-insights-context`, local override), selected profile `dotnet-desktop-client` + `ui-automation-testing`, open questions, planned changed files.
+- Decision: можно запрашивать подтверждение.
+- Review passes:
+  - Scope/Evidence pass: просмотрены central/local instructions, `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `App.axaml`, test csproj, localization/resource search results.
+  - Contract pass: spec не разрешает код до approval, содержит UI visual artifact, UI tests, validation commands, Non-Goals и `before`/`after` video evidence plan.
+  - Adversarial risk pass: проверены риски отсутствующих theme resources, неработающего DynamicResource для automation name, ухудшения контраста и drift от поведения карты.
+  - Re-review after fixes / Fix and re-review: не требовалось, блокирующих findings нет.
+  - Stop decision: PASS, можно передать пользователю на утверждение.
+- Evidence inspected: hard-coded Roadmap overlay strings/colors in `GraphControl.axaml`; existing Roadmap overlay tests; existing theme resource usage in nearby XAML; TUnit package in test project; central QUEST/UI automation docs.
+- Depth checklist:
+  - Scope drift / unrelated changes: planned files ограничены Roadmap overlay localization/theme/test/spec.
+  - Acceptance criteria: проверяемые и связаны с тестами.
+  - Validation evidence: до EXEC только inspected evidence; после EXEC обязателен targeted UI test/build/full attempt.
+  - Unsupported claims: video evidence не подменяет UI tests; fallback ограничен техническими blockers записи окна.
+  - Regression / edge case: covered by preserving command handlers and existing behavioral assertions.
+  - Comments/docs/changelog: comments не планируются; changelog не нужен для small UI fix.
+  - Hidden contract change: stable `AutomationId` сохранены; accessible names добавляются.
+  - Manual-review challenge: вероятная ручная находка была бы "цвета все еще hard-coded" или "английский tooltip остался"; это вынесено в acceptance.
+- No-findings justification: spec покрывает governance, UI plan, tests, rollback и не оставляет блокирующих открытых вопросов.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | evidence | Video evidence зависит от запуска desktop app и доступности recorder/ffmpeg, а не от Avalonia.Headless runner | Во время EXEC записать `before`/`after` через `record-app-screen`; fallback использовать только при техническом blocker | accepted-risk |
+
+- Fixed before continuing: Не применимо.
+- Checks rerun: ручная self-check по spec-linter/spec-rubric/review-loop.
+- Needs human: требуется фраза `Спеку подтверждаю`.
+- Residual risks / follow-ups: возможна дополнительная визуальная проверка screenshot после EXEC, если headless assertions не дают достаточного confidence по contrast/polish.
+
+### Post-EXEC Review
+- Статус: PASS с validation caveat по unrelated full-suite failure
+- Scope reviewed: `GraphControl.axaml`, `Strings.resx`, `Strings.ru.resx`, `RoadmapGraphUiTests.cs`, generated evidence artifacts, validation logs.
+- Decision: изменение соответствует утвержденной SPEC; блокирующих findings по Roadmap localization/theme нет.
+- Review passes:
+  - Scope/Evidence pass: diff ограничен Roadmap overlay XAML, EN/RU resources, Roadmap UI tests и этой SPEC.
+  - Contract pass: `AutomationId` сохранены; command handlers не менялись; persisted state/view model/data model не затронуты.
+  - Adversarial risk pass: проверено отсутствие старых hard-coded tooltip/content/colors в `GraphControl.axaml`; theme brushes проверены headless-тестами через отсутствие прежних fixed colors.
+  - Re-review after fixes / Fix and re-review: self-review усилил тест, добавив assertions для всех `RoadmapPan*Button`, затем affected targeted test повторно прошел.
+  - Stop decision: PASS; можно завершать задачу без дополнительных правок.
+- Evidence inspected: diff, `rg` по старым Roadmap overlay strings/colors, targeted TUnit output, desktop build output, full test output, `before`/`after` MP4 metadata.
+- Depth checklist:
+  - Scope drift / unrelated changes: нет unrelated edits в tracked files; video/log artifacts лежат в `artifacts/` и не коммитятся по умолчанию.
+  - Acceptance criteria: закрыты локализация tooltips/names, icon-only content, theme-aware brushes, сохранение поведения zoom/pan/reset/collapse/expand.
+  - Validation evidence: targeted Roadmap UI tests PASS; build PASS; `git diff --check` PASS с CRLF warnings; full run выполнен и имеет unrelated failure.
+  - Unsupported claims: visual polish подтвержден `after` video; theme contract подтвержден XAML diff и headless assertions против прежних fixed colors.
+  - Regression / edge case: command handlers и bindings сохранены; collapse/restore/minimap binding covered by existing behavioral assertions.
+  - Comments/docs/changelog: новых code comments не требуется; changelog не нужен для scoped UI fix.
+  - Hidden contract change: `AutomationProperties.AutomationId` сохранены, добавлены только localized `AutomationProperties.Name`.
+  - Manual-review challenge: вероятный вопрос "все ли pan-кнопки локализованы" закрыт дополнительными assertions по up/left/right/down.
+- No-findings justification: self-review не нашел blocking/medium issues; единственная validation caveat относится к существующему `MainControlTaskCardLayoutUiTests`, не к Roadmap overlay.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | validation | Full suite failed in unrelated `MainControlTaskCardLayoutUiTests.CurrentTaskCard_DesktopLayout_ExposesSectionsAndKeyControls`; Roadmap targeted tests passed | Не блокировать этот scoped fix; при необходимости разбирать layout test отдельно | residual-risk |
+
+- Fixed before final report: усилен `RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls` assertions для `RoadmapPanUpButton`, `RoadmapPanLeftButton`, `RoadmapPanRightButton`, `RoadmapPanDownButton`.
+- Checks rerun:
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_ViewportOverlay_*" --no-progress` -> PASS, 1/1, 5s439ms после усиления теста.
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_ViewportOverlays_*" --no-progress` -> PASS, 1/1, 5s085ms.
+  - `dotnet build src\Unlimotion.Desktop\Unlimotion.Desktop.csproj --no-restore -v:minimal` -> PASS, 0 errors, existing CRLF warnings.
+  - `git diff --check` -> PASS, existing CRLF warnings only.
+  - `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --no-progress` -> FAIL unrelated: total 531, succeeded 530, failed 1, duration 5m37s426ms.
+- Validation evidence:
+  - `artifacts/roadmap-map-controls-localization-theme/roadmap-controls-before.mp4`: 204896 bytes, 2880x1498, 24.000s.
+  - `artifacts/roadmap-map-controls-localization-theme/roadmap-controls-after.mp4`: 246073 bytes, 2880x1498, 23.900s.
+- Unrelated changes: tracked unrelated changes не обнаружены; внешний `dotnet test ... -c Release --no-restore` процесс был найден, но не запускался в рамках этой задачи и не останавливался.
+- Needs human: нет.
+- Residual risks / follow-ups: full-suite layout failure стоит разобрать отдельной задачей, если нужен полностью зеленый локальный прогон.
+
+## Approval
+Получено: пользователь написал "Спеку подтверждаю".
+
+## 20. Журнал действий агента
+Заполняется инкрементально после каждого значимого блока работ. Одна строка = один завершённый значимый блок.
+
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Сбор instruction stack и памяти | 0.9 | Нет | Инспектировать текущий Roadmap UI и тесты | Нет | Нет | Central stack требует SPEC-first; память подсказала релевантный Roadmap test surface, затем проверено в workspace | `AGENTS.md`, `AGENTS.override.md`, memory index |
+| SPEC | Инспекция AS-IS | 0.9 | Нет | Сформировать SPEC | Нет | Нет | Найдены hard-coded English tooltips/debug content/theme colors и существующие overlay UI tests | `GraphControl.axaml`, `GraphControl.axaml.cs`, `RoadmapGraphUiTests.cs`, `App.axaml`, `Unlimotion.Test.csproj` |
+| SPEC | Создание и self-review спецификации | 0.9 | Нет | Запросить подтверждение пользователя | Да | Да, требуется фраза `Спеку подтверждаю` | SPEC содержит design, visual artifact, acceptance, test plan и post-SPEC review | `specs/2026-06-16-roadmap-map-controls-localization-theme.md` |
+| SPEC | Уточнение video evidence | 0.95 | Нет | Запросить подтверждение пользователя | Да | Да, пользователь указал на доступные video skills; требуется фраза `Спеку подтверждаю` | Исправлен слишком слабый fallback: `before`/`after` video теперь обязательный EXEC-план через `record-app-screen`, fallback только при техническом blocker | `specs/2026-06-16-roadmap-map-controls-localization-theme.md` |
+| EXEC | Получение approval | 1.0 | Нет | Записать `before` video до изменений кода | Нет | Да, пользователь написал `Спеку подтверждаю` | SPEC gate открыт; baseline video должен быть снят до первого изменения реализации | `specs/2026-06-16-roadmap-map-controls-localization-theme.md` |
+| EXEC | Запись baseline video | 0.9 | Нет | Изменить XAML/resources/tests | Нет | Нет | До правок кода записано `before` MP4: 24s, 30 FPS, 2880x1498, isolated config, scripted Roadmap overlay hover/click flow | `artifacts/roadmap-map-controls-localization-theme/roadmap-controls-before.mp4` |
+| EXEC | Реализация и targeted UI tests | 0.9 | Нет | Собрать desktop и записать `after` video | Нет | Нет | Добавлены EN/RU resource keys, icon-only Roadmap controls, локальные theme brushes и assertions по localization/accessibility/theme; два targeted Roadmap overlay теста прошли | `GraphControl.axaml`, `Strings.resx`, `Strings.ru.resx`, `RoadmapGraphUiTests.cs` |
+| EXEC | Запись `after` video | 0.95 | Нет | Запустить build/full validation и self-review | Нет | Нет | После реализации записано `after` MP4 с тем же Roadmap overlay flow; `ffprobe` подтвердил 2880x1498 и 23.9s | `artifacts/roadmap-map-controls-localization-theme/roadmap-controls-after.mp4` |
+| EXEC | Валидация | 0.9 | Full suite имеет unrelated failure | Выполнить post-EXEC review и финальный отчет | Нет | Нет | Scoped Roadmap tests прошли; desktop build и diff check прошли; full run дал 530/531 PASS и один unrelated layout failure | `full-test.out.log`, `RoadmapGraphUiTests.cs`, `Unlimotion.Desktop.csproj` |
+| EXEC | Post-EXEC review | 0.95 | Нет | Завершить задачу | Нет | Нет | Self-review не нашел Roadmap blockers; тест усилен для всех pan-кнопок и повторно прошел | `specs/2026-06-16-roadmap-map-controls-localization-theme.md`, `RoadmapGraphUiTests.cs` |

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,6 +21,7 @@ using Unlimotion;
 using Unlimotion.Domain;
 using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
+using Unlimotion.ViewModel.Localization;
 using Unlimotion.Views;
 using Unlimotion.Views.Graph;
 
@@ -848,177 +850,209 @@ public class RoadmapGraphUiTests
     [Test]
     public async Task RoadmapGraph_ViewportOverlay_ProvidesMinimapAndControls()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.DispatchAsync(async () =>
+        await RunWithRussianLocalizationAsync(async () =>
         {
-            var fixture = new MainWindowViewModelFixture();
-            Window? window = null;
-
-            try
+            await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await session.DispatchAsync(async () =>
             {
-                var vm = fixture.MainWindowViewModelTest;
-                await vm.Connect();
-                vm.AllTasksMode = false;
-                vm.GraphMode = true;
+                var fixture = new MainWindowViewModelFixture();
+                Window? window = null;
 
-                var view = new MainControl { DataContext = vm };
-                window = CreateWindow(view);
-                window.Show();
-                Dispatcher.UIThread.RunJobs();
-
-                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
-                await Assert.That(graphControl).IsNotNull();
-
-                var nodesReady = WaitFor(() => graphControl!.RoadmapNodes.Count > 0);
-                await Assert.That(nodesReady).IsTrue();
-
-                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
-                var minimap = WaitForAutomationControl<Control>(view, "RoadmapMinimap");
-                var toolbar = WaitForAutomationControl<Control>(view, "RoadmapViewportToolbar");
-                var zoomInButton = WaitForAutomationControl<Button>(view, "RoadmapZoomInButton");
-                var panRightButton = WaitForAutomationControl<Button>(view, "RoadmapPanRightButton");
-                var resetButton = WaitForAutomationControl<Button>(view, "RoadmapResetViewportButton");
-
-                await Assert.That(editor.GetType().Name).IsEqualTo("NodifyEditor");
-                await Assert.That(minimap.GetType().Name).IsEqualTo("Minimap");
-                await Assert.That(toolbar).IsNotNull();
-
-                var zoomProperty = editor.GetType().GetProperty("ViewportZoom")!;
-                var locationProperty = editor.GetType().GetProperty("ViewportLocation")!;
-                var initialZoom = (double)zoomProperty.GetValue(editor)!;
-
-                zoomInButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                var zoomed = WaitFor(() => (double)zoomProperty.GetValue(editor)! > initialZoom);
-                await Assert.That(zoomed).IsTrue();
-
-                var initialLocation = (Avalonia.Point)locationProperty.GetValue(editor)!;
-                panRightButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                var panned = WaitFor(() =>
-                    ((Avalonia.Point)locationProperty.GetValue(editor)!).X > initialLocation.X);
-                await Assert.That(panned).IsTrue();
-
-                resetButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
-                var reset = WaitFor(() =>
+                try
                 {
-                    var zoom = (double)zoomProperty.GetValue(editor)!;
-                    var location = (Avalonia.Point)locationProperty.GetValue(editor)!;
+                    var vm = fixture.MainWindowViewModelTest;
+                    await vm.Connect();
+                    vm.AllTasksMode = false;
+                    vm.GraphMode = true;
 
-                    return Math.Abs(zoom - 1) < 0.001 &&
-                           Math.Abs(location.X) < 0.001 &&
-                           Math.Abs(location.Y) < 0.001;
-                });
-                await Assert.That(reset).IsTrue();
-            }
-            finally
-            {
-                window?.Close();
-                fixture.CleanTasks();
-            }
-        }, CancellationToken.None);
+                    var view = new MainControl { DataContext = vm };
+                    window = CreateWindow(view);
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+
+                    var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                    await Assert.That(graphControl).IsNotNull();
+
+                    var nodesReady = WaitFor(() => graphControl!.RoadmapNodes.Count > 0);
+                    await Assert.That(nodesReady).IsTrue();
+
+                    var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                    var minimap = WaitForAutomationControl<Control>(view, "RoadmapMinimap");
+                    var toolbar = WaitForAutomationControl<Border>(view, "RoadmapViewportToolbar");
+                    var buildIndicator = WaitForAutomationControl<Border>(view, "RoadmapBuildIndicator");
+                    var zoomInButton = WaitForAutomationControl<Button>(view, "RoadmapZoomInButton");
+                    var zoomOutButton = WaitForAutomationControl<Button>(view, "RoadmapZoomOutButton");
+                    var fitButton = WaitForAutomationControl<Button>(view, "RoadmapFitButton");
+                    var panUpButton = WaitForAutomationControl<Button>(view, "RoadmapPanUpButton");
+                    var panLeftButton = WaitForAutomationControl<Button>(view, "RoadmapPanLeftButton");
+                    var panRightButton = WaitForAutomationControl<Button>(view, "RoadmapPanRightButton");
+                    var panDownButton = WaitForAutomationControl<Button>(view, "RoadmapPanDownButton");
+                    var resetButton = WaitForAutomationControl<Button>(view, "RoadmapResetViewportButton");
+
+                    await Assert.That(editor.GetType().Name).IsEqualTo("NodifyEditor");
+                    await Assert.That(minimap.GetType().Name).IsEqualTo("Minimap");
+                    await Assert.That(toolbar).IsNotNull();
+
+                    await AssertRoadmapIconButton(zoomInButton, "Увеличить карту");
+                    await AssertRoadmapIconButton(zoomOutButton, "Уменьшить карту");
+                    await AssertRoadmapIconButton(fitButton, "Вписать карту в область");
+                    await AssertRoadmapIconButton(panUpButton, "Сдвинуть карту вверх");
+                    await AssertRoadmapIconButton(panLeftButton, "Сдвинуть карту влево");
+                    await AssertRoadmapIconButton(panRightButton, "Сдвинуть карту вправо");
+                    await AssertRoadmapIconButton(panDownButton, "Сдвинуть карту вниз");
+                    await AssertRoadmapIconButton(resetButton, "Сбросить вид карты");
+                    await AssertBrushDoesNotUseColor(toolbar.Background, Color.Parse("#CC1E1E1E"));
+                    await AssertBrushDoesNotUseColor(toolbar.BorderBrush, Color.Parse("#666666"));
+                    await AssertBrushDoesNotUseColor(buildIndicator.Background, Color.Parse("#E61E1E1E"));
+                    await AssertBrushDoesNotUseColor(zoomInButton.Background, Color.Parse("#3A3A3A"));
+
+                    var zoomProperty = editor.GetType().GetProperty("ViewportZoom")!;
+                    var locationProperty = editor.GetType().GetProperty("ViewportLocation")!;
+                    var initialZoom = (double)zoomProperty.GetValue(editor)!;
+
+                    zoomInButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                    var zoomed = WaitFor(() => (double)zoomProperty.GetValue(editor)! > initialZoom);
+                    await Assert.That(zoomed).IsTrue();
+
+                    var initialLocation = (Avalonia.Point)locationProperty.GetValue(editor)!;
+                    panRightButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                    var panned = WaitFor(() =>
+                        ((Avalonia.Point)locationProperty.GetValue(editor)!).X > initialLocation.X);
+                    await Assert.That(panned).IsTrue();
+
+                    resetButton.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+                    var reset = WaitFor(() =>
+                    {
+                        var zoom = (double)zoomProperty.GetValue(editor)!;
+                        var location = (Avalonia.Point)locationProperty.GetValue(editor)!;
+
+                        return Math.Abs(zoom - 1) < 0.001 &&
+                               Math.Abs(location.X) < 0.001 &&
+                               Math.Abs(location.Y) < 0.001;
+                    });
+                    await Assert.That(reset).IsTrue();
+                }
+                finally
+                {
+                    window?.Close();
+                    fixture.CleanTasks();
+                }
+            }, CancellationToken.None);
+        });
     }
 
     [Test]
     public async Task RoadmapGraph_ViewportOverlays_CollapseToCompactButtonsAndRestore()
     {
-        await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
-        await session.DispatchAsync(async () =>
+        await RunWithRussianLocalizationAsync(async () =>
         {
-            var fixture = new MainWindowViewModelFixture();
-            Window? window = null;
-
-            try
+            await using var session = HeadlessUnitTestSession.StartNew(typeof(App));
+            await session.DispatchAsync(async () =>
             {
-                var vm = fixture.MainWindowViewModelTest;
-                await vm.Connect();
-                vm.AllTasksMode = false;
-                vm.GraphMode = true;
+                var fixture = new MainWindowViewModelFixture();
+                Window? window = null;
 
-                var view = new MainControl { DataContext = vm };
-                window = CreateWindow(view, 420, 520);
-                window.Show();
-                Dispatcher.UIThread.RunJobs();
-
-                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
-                await Assert.That(graphControl).IsNotNull();
-
-                var nodesReady = WaitFor(() => graphControl!.RoadmapNodes.Count > 0);
-                await Assert.That(nodesReady).IsTrue();
-
-                var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
-                var toolbar = WaitForAutomationControl<Control>(view, "RoadmapViewportToolbar");
-                var minimapPanel = WaitForAutomationControl<Control>(view, "RoadmapMinimapPanel");
-                var minimap = WaitForAutomationControl<Control>(view, "RoadmapMinimap");
-                var toolbarCollapseButton = WaitForAutomationControl<Button>(view, "RoadmapViewportToolbarCollapseButton");
-                var minimapCollapseButton = WaitForAutomationControl<Button>(view, "RoadmapMinimapCollapseButton");
-
-                await Assert.That(IsVisibleAndArranged(toolbar)).IsTrue();
-                await Assert.That(IsVisibleAndArranged(minimapPanel)).IsTrue();
-                await Assert.That(IsVisibleAndArranged(minimap)).IsTrue();
-
-                await ClickControlAsync(window, minimapCollapseButton);
-                var minimapCollapsed = WaitFor(() => !minimapPanel.IsVisible);
-                await Assert.That(minimapCollapsed).IsTrue();
-
-                var minimapExpandButton = WaitForAutomationControl<Button>(view, "RoadmapMinimapExpandButton");
-                await Assert.That(IsVisibleAndArranged(minimapExpandButton)).IsTrue();
-                await Assert.That(minimapExpandButton.Bounds.Width).IsLessThanOrEqualTo(40);
-                await Assert.That(minimapExpandButton.Bounds.Height).IsLessThanOrEqualTo(40);
-                await Assert.That(IsVisibleAndArranged(toolbar)).IsTrue();
-
-                var locationProperty = editor.GetType().GetProperty("ViewportLocation")!;
-                var panRightButton = WaitForAutomationControl<Button>(view, "RoadmapPanRightButton");
-                var locationBeforePan = (Avalonia.Point)locationProperty.GetValue(editor)!;
-
-                await ClickControlAsync(window, panRightButton);
-                var toolbarClickable = WaitFor(() =>
-                    ((Avalonia.Point)locationProperty.GetValue(editor)!).X > locationBeforePan.X);
-                await Assert.That(toolbarClickable).IsTrue();
-
-                await ClickControlAsync(window, toolbarCollapseButton);
-                var toolbarCollapsed = WaitFor(() => !toolbar.IsVisible);
-                await Assert.That(toolbarCollapsed).IsTrue();
-
-                var toolbarExpandButton = WaitForAutomationControl<Button>(view, "RoadmapViewportToolbarExpandButton");
-                await Assert.That(IsVisibleAndArranged(toolbarExpandButton)).IsTrue();
-                await Assert.That(toolbarExpandButton.Bounds.Width).IsLessThanOrEqualTo(40);
-                await Assert.That(toolbarExpandButton.Bounds.Height).IsLessThanOrEqualTo(40);
-
-                await ClickControlAsync(window, toolbarExpandButton);
-                var toolbarExpanded = WaitFor(() => IsVisibleAndArranged(toolbar));
-                await Assert.That(toolbarExpanded).IsTrue();
-
-                await ClickControlAsync(window, minimapExpandButton);
-                var minimapExpanded = WaitFor(() =>
-                    IsVisibleAndArranged(minimapPanel) &&
-                    IsVisibleAndArranged(minimap));
-                await Assert.That(minimapExpanded).IsTrue();
-
-                var zoomProperty = editor.GetType().GetProperty("ViewportZoom")!;
-                var initialZoom = (double)zoomProperty.GetValue(editor)!;
-                var zoomInButton = WaitForAutomationControl<Button>(view, "RoadmapZoomInButton");
-                await ClickControlAsync(window, zoomInButton);
-                var zoomed = WaitFor(() => (double)zoomProperty.GetValue(editor)! > initialZoom);
-                await Assert.That(zoomed).IsTrue();
-
-                var expectedLocation = new Avalonia.Point(123, 45);
-                locationProperty.SetValue(editor, expectedLocation);
-                Dispatcher.UIThread.RunJobs();
-
-                var minimapLocationProperty = minimap.GetType().GetProperty("ViewportLocation")!;
-                var minimapBound = WaitFor(() =>
+                try
                 {
-                    var actual = (Avalonia.Point)minimapLocationProperty.GetValue(minimap)!;
-                    return Math.Abs(actual.X - expectedLocation.X) < 0.001 &&
-                           Math.Abs(actual.Y - expectedLocation.Y) < 0.001;
-                });
-                await Assert.That(minimapBound).IsTrue();
-            }
-            finally
-            {
-                window?.Close();
-                fixture.CleanTasks();
-            }
-        }, CancellationToken.None);
+                    var vm = fixture.MainWindowViewModelTest;
+                    await vm.Connect();
+                    vm.AllTasksMode = false;
+                    vm.GraphMode = true;
+
+                    var view = new MainControl { DataContext = vm };
+                    window = CreateWindow(view, 420, 520);
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+
+                    var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                    await Assert.That(graphControl).IsNotNull();
+
+                    var nodesReady = WaitFor(() => graphControl!.RoadmapNodes.Count > 0);
+                    await Assert.That(nodesReady).IsTrue();
+
+                    var editor = WaitForAutomationControl<Control>(view, "RoadmapZoomBorder");
+                    var toolbar = WaitForAutomationControl<Border>(view, "RoadmapViewportToolbar");
+                    var minimapPanel = WaitForAutomationControl<Border>(view, "RoadmapMinimapPanel");
+                    var minimap = WaitForAutomationControl<Control>(view, "RoadmapMinimap");
+                    var toolbarCollapseButton = WaitForAutomationControl<Button>(view, "RoadmapViewportToolbarCollapseButton");
+                    var minimapCollapseButton = WaitForAutomationControl<Button>(view, "RoadmapMinimapCollapseButton");
+
+                    await Assert.That(IsVisibleAndArranged(toolbar)).IsTrue();
+                    await Assert.That(IsVisibleAndArranged(minimapPanel)).IsTrue();
+                    await Assert.That(IsVisibleAndArranged(minimap)).IsTrue();
+                    await AssertRoadmapIconButton(toolbarCollapseButton, "Скрыть элементы управления картой");
+                    await AssertRoadmapIconButton(minimapCollapseButton, "Скрыть миникарту");
+                    await AssertBrushDoesNotUseColor(minimapPanel.Background, Color.Parse("#CC1E1E1E"));
+                    await AssertBrushDoesNotUseColor(minimapPanel.BorderBrush, Color.Parse("#666666"));
+                    await AssertBrushDoesNotUseColor(GetBackgroundBrush(minimap), Color.Parse("#202020"));
+
+                    await ClickControlAsync(window, minimapCollapseButton);
+                    var minimapCollapsed = WaitFor(() => !minimapPanel.IsVisible);
+                    await Assert.That(minimapCollapsed).IsTrue();
+
+                    var minimapExpandButton = WaitForAutomationControl<Button>(view, "RoadmapMinimapExpandButton");
+                    await Assert.That(IsVisibleAndArranged(minimapExpandButton)).IsTrue();
+                    await Assert.That(minimapExpandButton.Bounds.Width).IsLessThanOrEqualTo(40);
+                    await Assert.That(minimapExpandButton.Bounds.Height).IsLessThanOrEqualTo(40);
+                    await AssertRoadmapIconButton(minimapExpandButton, "Показать миникарту");
+                    await Assert.That(IsVisibleAndArranged(toolbar)).IsTrue();
+
+                    var locationProperty = editor.GetType().GetProperty("ViewportLocation")!;
+                    var panRightButton = WaitForAutomationControl<Button>(view, "RoadmapPanRightButton");
+                    var locationBeforePan = (Avalonia.Point)locationProperty.GetValue(editor)!;
+
+                    await ClickControlAsync(window, panRightButton);
+                    var toolbarClickable = WaitFor(() =>
+                        ((Avalonia.Point)locationProperty.GetValue(editor)!).X > locationBeforePan.X);
+                    await Assert.That(toolbarClickable).IsTrue();
+
+                    await ClickControlAsync(window, toolbarCollapseButton);
+                    var toolbarCollapsed = WaitFor(() => !toolbar.IsVisible);
+                    await Assert.That(toolbarCollapsed).IsTrue();
+
+                    var toolbarExpandButton = WaitForAutomationControl<Button>(view, "RoadmapViewportToolbarExpandButton");
+                    await Assert.That(IsVisibleAndArranged(toolbarExpandButton)).IsTrue();
+                    await Assert.That(toolbarExpandButton.Bounds.Width).IsLessThanOrEqualTo(40);
+                    await Assert.That(toolbarExpandButton.Bounds.Height).IsLessThanOrEqualTo(40);
+                    await AssertRoadmapIconButton(toolbarExpandButton, "Показать элементы управления картой");
+
+                    await ClickControlAsync(window, toolbarExpandButton);
+                    var toolbarExpanded = WaitFor(() => IsVisibleAndArranged(toolbar));
+                    await Assert.That(toolbarExpanded).IsTrue();
+
+                    await ClickControlAsync(window, minimapExpandButton);
+                    var minimapExpanded = WaitFor(() =>
+                        IsVisibleAndArranged(minimapPanel) &&
+                        IsVisibleAndArranged(minimap));
+                    await Assert.That(minimapExpanded).IsTrue();
+
+                    var zoomProperty = editor.GetType().GetProperty("ViewportZoom")!;
+                    var initialZoom = (double)zoomProperty.GetValue(editor)!;
+                    var zoomInButton = WaitForAutomationControl<Button>(view, "RoadmapZoomInButton");
+                    await ClickControlAsync(window, zoomInButton);
+                    var zoomed = WaitFor(() => (double)zoomProperty.GetValue(editor)! > initialZoom);
+                    await Assert.That(zoomed).IsTrue();
+
+                    var expectedLocation = new Avalonia.Point(123, 45);
+                    locationProperty.SetValue(editor, expectedLocation);
+                    Dispatcher.UIThread.RunJobs();
+
+                    var minimapLocationProperty = minimap.GetType().GetProperty("ViewportLocation")!;
+                    var minimapBound = WaitFor(() =>
+                    {
+                        var actual = (Avalonia.Point)minimapLocationProperty.GetValue(minimap)!;
+                        return Math.Abs(actual.X - expectedLocation.X) < 0.001 &&
+                               Math.Abs(actual.Y - expectedLocation.Y) < 0.001;
+                    });
+                    await Assert.That(minimapBound).IsTrue();
+                }
+                finally
+                {
+                    window?.Close();
+                    fixture.CleanTasks();
+                }
+            }, CancellationToken.None);
+        });
     }
 
     [Test]
@@ -2909,6 +2943,47 @@ public class RoadmapGraphUiTests
         }
     }
 
+    private static async Task RunWithRussianLocalizationAsync(Func<Task> body)
+    {
+        var previousLocalization = LocalizationService.Current;
+        var culture = CultureSnapshot.Capture();
+
+        try
+        {
+            var localization = new LocalizationService(new FakeSystemCultureProvider("ru-RU"));
+            LocalizationService.Current = localization;
+            localization.SetLanguage(LocalizationService.RussianLanguage);
+
+            await body();
+        }
+        finally
+        {
+            LocalizationService.Current = previousLocalization;
+            culture.Restore();
+        }
+    }
+
+    private static async Task AssertRoadmapIconButton(Button button, string expectedText)
+    {
+        await Assert.That(AutomationProperties.GetName(button)).IsEqualTo(expectedText);
+        await Assert.That(ToolTip.GetTip(button)?.ToString()).IsEqualTo(expectedText);
+        await Assert.That(button.Content).IsAssignableTo<PathIcon>();
+    }
+
+    private static async Task AssertBrushDoesNotUseColor(IBrush? brush, Color unexpectedColor)
+    {
+        await Assert.That(brush).IsNotNull();
+        if (brush is ISolidColorBrush solidColorBrush)
+        {
+            await Assert.That(solidColorBrush.Color == unexpectedColor).IsFalse();
+        }
+    }
+
+    private static IBrush? GetBackgroundBrush(Control control)
+    {
+        return control.GetType().GetProperty("Background")?.GetValue(control) as IBrush;
+    }
+
     private static Window CreateWindow(Control content)
     {
         return new Window
@@ -3786,6 +3861,42 @@ public class RoadmapGraphUiTests
         TaskItemViewModel Root,
         TaskItemViewModel[] Chain,
         TaskItemViewModel[] Fillers);
+
+    private sealed class FakeSystemCultureProvider : ILocalizationSystemCultureProvider
+    {
+        public FakeSystemCultureProvider(string cultureName)
+        {
+            SystemUICulture = CultureInfo.GetCultureInfo(cultureName);
+        }
+
+        public CultureInfo SystemUICulture { get; }
+    }
+
+    private sealed class CultureSnapshot
+    {
+        private readonly CultureInfo _currentCulture;
+        private readonly CultureInfo _currentUICulture;
+        private readonly CultureInfo? _defaultThreadCurrentCulture;
+        private readonly CultureInfo? _defaultThreadCurrentUICulture;
+
+        private CultureSnapshot()
+        {
+            _currentCulture = CultureInfo.CurrentCulture;
+            _currentUICulture = CultureInfo.CurrentUICulture;
+            _defaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentCulture;
+            _defaultThreadCurrentUICulture = CultureInfo.DefaultThreadCurrentUICulture;
+        }
+
+        public static CultureSnapshot Capture() => new();
+
+        public void Restore()
+        {
+            CultureInfo.DefaultThreadCurrentCulture = _defaultThreadCurrentCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = _defaultThreadCurrentUICulture;
+            CultureInfo.CurrentCulture = _currentCulture;
+            CultureInfo.CurrentUICulture = _currentUICulture;
+        }
+    }
 
     private sealed class StubTaskStorage : ITaskStorage
     {

--- a/src/Unlimotion.ViewModel/Resources/Strings.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.resx
@@ -181,7 +181,19 @@
   <data name="FieldConflictResolutionComplete" xml:space="preserve"><value>Selected conflict fields resolved.</value></data>
   <data name="InvalidConflictPath" xml:space="preserve"><value>Invalid conflict path: {0}</value></data>
   <data name="GraphOnlyUnlocked" xml:space="preserve"><value>Only Unlocked</value></data>
+  <data name="RoadmapFitViewport" xml:space="preserve"><value>Fit map to view</value></data>
+  <data name="RoadmapHideGraphControls" xml:space="preserve"><value>Hide map controls</value></data>
+  <data name="RoadmapHideMinimap" xml:space="preserve"><value>Hide minimap</value></data>
+  <data name="RoadmapPanDown" xml:space="preserve"><value>Move map down</value></data>
+  <data name="RoadmapPanLeft" xml:space="preserve"><value>Move map left</value></data>
+  <data name="RoadmapPanRight" xml:space="preserve"><value>Move map right</value></data>
+  <data name="RoadmapPanUp" xml:space="preserve"><value>Move map up</value></data>
   <data name="RoadmapRebuilding" xml:space="preserve"><value>Updating roadmap...</value></data>
+  <data name="RoadmapResetViewport" xml:space="preserve"><value>Reset map view</value></data>
+  <data name="RoadmapShowGraphControls" xml:space="preserve"><value>Show map controls</value></data>
+  <data name="RoadmapShowMinimap" xml:space="preserve"><value>Show minimap</value></data>
+  <data name="RoadmapZoomIn" xml:space="preserve"><value>Zoom in</value></data>
+  <data name="RoadmapZoomOut" xml:space="preserve"><value>Zoom out</value></data>
   <data name="Importance" xml:space="preserve"><value>Importance</value></data>
   <data name="InvalidRelation" xml:space="preserve"><value>The selected relation cannot be added.</value></data>
   <data name="LanguageEnglish" xml:space="preserve"><value>English</value></data>

--- a/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
+++ b/src/Unlimotion.ViewModel/Resources/Strings.ru.resx
@@ -181,7 +181,19 @@
   <data name="FieldConflictResolutionComplete" xml:space="preserve"><value>Выбранные поля конфликта исправлены.</value></data>
   <data name="InvalidConflictPath" xml:space="preserve"><value>Некорректный путь конфликтующего файла: {0}</value></data>
   <data name="GraphOnlyUnlocked" xml:space="preserve"><value>Только разблокированные</value></data>
+  <data name="RoadmapFitViewport" xml:space="preserve"><value>Вписать карту в область</value></data>
+  <data name="RoadmapHideGraphControls" xml:space="preserve"><value>Скрыть элементы управления картой</value></data>
+  <data name="RoadmapHideMinimap" xml:space="preserve"><value>Скрыть миникарту</value></data>
+  <data name="RoadmapPanDown" xml:space="preserve"><value>Сдвинуть карту вниз</value></data>
+  <data name="RoadmapPanLeft" xml:space="preserve"><value>Сдвинуть карту влево</value></data>
+  <data name="RoadmapPanRight" xml:space="preserve"><value>Сдвинуть карту вправо</value></data>
+  <data name="RoadmapPanUp" xml:space="preserve"><value>Сдвинуть карту вверх</value></data>
   <data name="RoadmapRebuilding" xml:space="preserve"><value>Обновление карты...</value></data>
+  <data name="RoadmapResetViewport" xml:space="preserve"><value>Сбросить вид карты</value></data>
+  <data name="RoadmapShowGraphControls" xml:space="preserve"><value>Показать элементы управления картой</value></data>
+  <data name="RoadmapShowMinimap" xml:space="preserve"><value>Показать миникарту</value></data>
+  <data name="RoadmapZoomIn" xml:space="preserve"><value>Увеличить карту</value></data>
+  <data name="RoadmapZoomOut" xml:space="preserve"><value>Уменьшить карту</value></data>
   <data name="Importance" xml:space="preserve"><value>Важность</value></data>
   <data name="InvalidRelation" xml:space="preserve"><value>Нельзя добавить выбранную связь.</value></data>
   <data name="LanguageEnglish" xml:space="preserve"><value>Английский</value></data>

--- a/src/Unlimotion/Views/GraphControl.axaml
+++ b/src/Unlimotion/Views/GraphControl.axaml
@@ -17,6 +17,11 @@
              AutomationProperties.AutomationId="RoadmapRoot"
              Focusable="True">
     <UserControl.Resources>
+        <SolidColorBrush x:Key="RoadmapOverlayBackgroundBrush" Color="{DynamicResource SystemChromeLowColor}" />
+        <SolidColorBrush x:Key="RoadmapOverlayBorderBrush" Color="{DynamicResource SystemBaseMediumColor}" />
+        <SolidColorBrush x:Key="RoadmapOverlayForegroundBrush" Color="{DynamicResource SystemBaseHighColor}" />
+        <SolidColorBrush x:Key="RoadmapOverlayAccentBrush" Color="{DynamicResource SystemAccentColor}" />
+        <SolidColorBrush x:Key="RoadmapOverlayMutedBrush" Color="{DynamicResource SystemBaseLowColor}" />
         <DataTemplate x:Key="TaskStatusOptionDropDownTemplate" DataType="viewModel:TaskStatusOption">
             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8" MinHeight="24">
                 <unlimotion:TaskStatusIcon Status="{Binding Status}"
@@ -142,9 +147,14 @@
             <Setter Property="Padding" Value="0" />
             <Setter Property="HorizontalContentAlignment" Value="Center" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
-            <Setter Property="Background" Value="#3A3A3A" />
-            <Setter Property="BorderBrush" Value="#707070" />
-            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Background" Value="{DynamicResource RoadmapOverlayBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource RoadmapOverlayBorderBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource RoadmapOverlayForegroundBrush}" />
+            <Setter Property="CornerRadius" Value="4" />
+        </Style>
+        <Style Selector="Button.roadmapViewportButton:pointerover">
+            <Setter Property="Background" Value="{DynamicResource RoadmapOverlayMutedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource RoadmapOverlayAccentBrush}" />
         </Style>
         <Style Selector="Button.roadmapOverlayButton">
             <Setter Property="Width" Value="28" />
@@ -154,9 +164,18 @@
             <Setter Property="Padding" Value="0" />
             <Setter Property="HorizontalContentAlignment" Value="Center" />
             <Setter Property="VerticalContentAlignment" Value="Center" />
-            <Setter Property="Background" Value="#3A3A3A" />
-            <Setter Property="BorderBrush" Value="#707070" />
-            <Setter Property="Foreground" Value="White" />
+            <Setter Property="Background" Value="{DynamicResource RoadmapOverlayBackgroundBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource RoadmapOverlayBorderBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource RoadmapOverlayForegroundBrush}" />
+            <Setter Property="CornerRadius" Value="4" />
+        </Style>
+        <Style Selector="Button.roadmapOverlayButton:pointerover">
+            <Setter Property="Background" Value="{DynamicResource RoadmapOverlayMutedBrush}" />
+            <Setter Property="BorderBrush" Value="{DynamicResource RoadmapOverlayAccentBrush}" />
+        </Style>
+        <Style Selector="PathIcon.roadmapViewportIcon">
+            <Setter Property="Width" Value="15" />
+            <Setter Property="Height" Value="15" />
         </Style>
         <Style Selector="Grid.RoadmapFilterToolbar">
             <Setter Property="Margin" Value="0,0,0,10" />
@@ -401,8 +420,8 @@
                     Margin="10"
                     Padding="8"
                     CornerRadius="4"
-                    Background="#E61E1E1E"
-                    BorderBrush="#666666"
+                    Background="{DynamicResource RoadmapOverlayBackgroundBrush}"
+                    BorderBrush="{DynamicResource RoadmapOverlayBorderBrush}"
                     BorderThickness="1"
                     IsVisible="{Binding RoadmapGraphBuildInProgress, ElementName=Root}"
                     IsHitTestVisible="False"
@@ -410,13 +429,13 @@
                 <Grid RowDefinitions="Auto,6,Auto"
                       ColumnDefinitions="*,Auto">
                     <TextBlock Text="{DynamicResource RoadmapRebuilding}"
-                               Foreground="White"
+                               Foreground="{DynamicResource RoadmapOverlayForegroundBrush}"
                                FontWeight="SemiBold"
                                VerticalAlignment="Center" />
                     <TextBlock Grid.Column="1"
                                Margin="12,0,0,0"
                                Text="{Binding RoadmapGraphBuildProgressText, ElementName=Root}"
-                               Foreground="#E0E0E0"
+                               Foreground="{DynamicResource RoadmapOverlayForegroundBrush}"
                                VerticalAlignment="Center"
                                AutomationProperties.AutomationId="RoadmapBuildProgressText" />
                     <ProgressBar Grid.Row="2"
@@ -425,8 +444,8 @@
                                  Maximum="100"
                                  Height="4"
                                  Value="{Binding RoadmapGraphBuildProgress, ElementName=Root}"
-                                 Foreground="#2F80ED"
-                                 Background="#505050"
+                                 Foreground="{DynamicResource RoadmapOverlayAccentBrush}"
+                                 Background="{DynamicResource RoadmapOverlayBorderBrush}"
                                  AutomationProperties.AutomationId="RoadmapBuildProgressBar" />
                 </Grid>
             </Border>
@@ -436,8 +455,8 @@
                     Margin="0"
                     Padding="0"
                     CornerRadius="4"
-                    Background="#CC1E1E1E"
-                    BorderBrush="#666666"
+                    Background="{DynamicResource RoadmapOverlayBackgroundBrush}"
+                    BorderBrush="{DynamicResource RoadmapOverlayBorderBrush}"
                     BorderThickness="1"
                     IsVisible="{Binding IsRoadmapViewportToolbarExpanded, ElementName=Root}"
                     AutomationProperties.AutomationId="RoadmapViewportToolbar">
@@ -445,25 +464,33 @@
                     <Grid ColumnDefinitions="Auto,8,Auto" RowDefinitions="Auto">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                             <Button Classes="roadmapViewportButton"
-                                    Content="+"
                                     Click="RoadmapZoomIn_OnClick"
-                                    ToolTip.Tip="Zoom in"
-                                    AutomationProperties.AutomationId="RoadmapZoomInButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapZoomIn}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapZoomIn}"
+                                    AutomationProperties.AutomationId="RoadmapZoomInButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M11,5 L13,5 L13,11 L19,11 L19,13 L13,13 L13,19 L11,19 L11,13 L5,13 L5,11 L11,11 Z" />
+                            </Button>
                             <Button Classes="roadmapViewportButton"
-                                    Content="-"
                                     Click="RoadmapZoomOut_OnClick"
-                                    ToolTip.Tip="Zoom out"
-                                    AutomationProperties.AutomationId="RoadmapZoomOutButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapZoomOut}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapZoomOut}"
+                                    AutomationProperties.AutomationId="RoadmapZoomOutButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M5,11 L19,11 L19,13 L5,13 Z" />
+                            </Button>
                             <Button Classes="roadmapViewportButton"
-                                    Content="[]"
                                     Click="RoadmapFit_OnClick"
-                                    ToolTip.Tip="Fit"
-                                    AutomationProperties.AutomationId="RoadmapFitButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapFitViewport}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapFitViewport}"
+                                    AutomationProperties.AutomationId="RoadmapFitButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M5,5 L11,5 L11,7 L7,7 L7,11 L5,11 Z M13,5 L19,5 L19,11 L17,11 L17,7 L13,7 Z M5,13 L7,13 L7,17 L11,17 L11,19 L5,19 Z M17,13 L19,13 L19,19 L13,19 L13,17 L17,17 Z" />
+                            </Button>
                             <Button Classes="roadmapViewportButton"
-                                    Content="0"
                                     Click="RoadmapResetViewport_OnClick"
-                                    ToolTip.Tip="Reset"
-                                    AutomationProperties.AutomationId="RoadmapResetViewportButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapResetViewport}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapResetViewport}"
+                                    AutomationProperties.AutomationId="RoadmapResetViewportButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M17.65,6.35 C16.2,4.9 14.21,4 12,4 C7.58,4 4,7.58 4,12 C4,16.42 7.58,20 12,20 C15.73,20 18.84,17.45 19.73,14 L17.65,14 C16.82,16.33 14.61,18 12,18 C8.69,18 6,15.31 6,12 C6,8.69 8.69,6 12,6 C13.66,6 15.14,6.69 16.22,7.78 L13,11 L20,11 L20,4 Z" />
+                            </Button>
                         </StackPanel>
 
                         <Grid Grid.Column="2"
@@ -474,41 +501,51 @@
                             <Button Grid.Row="0"
                                     Grid.Column="1"
                                     Classes="roadmapViewportButton"
-                                    Content="^"
                                     Click="RoadmapPanUp_OnClick"
-                                    ToolTip.Tip="Pan up"
-                                    AutomationProperties.AutomationId="RoadmapPanUpButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapPanUp}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapPanUp}"
+                                    AutomationProperties.AutomationId="RoadmapPanUpButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M12,5 L18,11 L14,11 L14,19 L10,19 L10,11 L6,11 Z" />
+                            </Button>
                             <Button Grid.Row="1"
                                     Grid.Column="0"
                                     Classes="roadmapViewportButton"
-                                    Content="&lt;"
                                     Click="RoadmapPanLeft_OnClick"
-                                    ToolTip.Tip="Pan left"
-                                    AutomationProperties.AutomationId="RoadmapPanLeftButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapPanLeft}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapPanLeft}"
+                                    AutomationProperties.AutomationId="RoadmapPanLeftButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M5,12 L11,6 L11,10 L19,10 L19,14 L11,14 L11,18 Z" />
+                            </Button>
                             <Button Grid.Row="1"
                                     Grid.Column="2"
                                     Classes="roadmapViewportButton"
-                                    Content="&gt;"
                                     Click="RoadmapPanRight_OnClick"
-                                    ToolTip.Tip="Pan right"
-                                    AutomationProperties.AutomationId="RoadmapPanRightButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapPanRight}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapPanRight}"
+                                    AutomationProperties.AutomationId="RoadmapPanRightButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M19,12 L13,18 L13,14 L5,14 L5,10 L13,10 L13,6 Z" />
+                            </Button>
                             <Button Grid.Row="2"
                                     Grid.Column="1"
                                     Classes="roadmapViewportButton"
-                                    Content="v"
                                     Click="RoadmapPanDown_OnClick"
-                                    ToolTip.Tip="Pan down"
-                                    AutomationProperties.AutomationId="RoadmapPanDownButton" />
+                                    ToolTip.Tip="{DynamicResource RoadmapPanDown}"
+                                    AutomationProperties.Name="{DynamicResource RoadmapPanDown}"
+                                    AutomationProperties.AutomationId="RoadmapPanDownButton">
+                                <PathIcon Classes="roadmapViewportIcon" Data="M12,19 L6,13 L10,13 L10,5 L14,5 L14,13 L18,13 Z" />
+                            </Button>
                         </Grid>
                     </Grid>
 
                     <Button Classes="roadmapOverlayButton"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Bottom"
-                            Content="x"
                             Click="RoadmapViewportToolbarCollapse_OnClick"
-                            ToolTip.Tip="Hide graph controls"
-                            AutomationProperties.AutomationId="RoadmapViewportToolbarCollapseButton" />
+                            ToolTip.Tip="{DynamicResource RoadmapHideGraphControls}"
+                            AutomationProperties.Name="{DynamicResource RoadmapHideGraphControls}"
+                            AutomationProperties.AutomationId="RoadmapViewportToolbarCollapseButton">
+                        <PathIcon Classes="roadmapViewportIcon" Data="M6,5 L19,18 L18,19 L5,6 Z M18,5 L19,6 L6,19 L5,18 Z" />
+                    </Button>
                 </Grid>
             </Border>
 
@@ -516,11 +553,13 @@
                     VerticalAlignment="Bottom"
                     Margin="0"
                     Classes="roadmapOverlayButton"
-                    Content="T"
                     Click="RoadmapViewportToolbarExpand_OnClick"
                     IsVisible="{Binding !IsRoadmapViewportToolbarExpanded, ElementName=Root}"
-                    ToolTip.Tip="Show graph controls"
-                    AutomationProperties.AutomationId="RoadmapViewportToolbarExpandButton" />
+                    ToolTip.Tip="{DynamicResource RoadmapShowGraphControls}"
+                    AutomationProperties.Name="{DynamicResource RoadmapShowGraphControls}"
+                    AutomationProperties.AutomationId="RoadmapViewportToolbarExpandButton">
+                <PathIcon Classes="roadmapViewportIcon" Data="M4,6 L20,6 L20,8 L4,8 Z M4,11 L20,11 L20,13 L4,13 Z M4,16 L20,16 L20,18 L4,18 Z" />
+            </Button>
 
             <Border HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
@@ -529,8 +568,8 @@
                     Margin="0"
                     Padding="0"
                     CornerRadius="4"
-                    Background="#CC1E1E1E"
-                    BorderBrush="#666666"
+                    Background="{DynamicResource RoadmapOverlayBackgroundBrush}"
+                    BorderBrush="{DynamicResource RoadmapOverlayBorderBrush}"
                     BorderThickness="1"
                     IsVisible="{Binding IsRoadmapMinimapExpanded, ElementName=Root}"
                     AutomationProperties.AutomationId="RoadmapMinimapPanel">
@@ -542,11 +581,11 @@
                                     ViewportSize="{Binding ViewportSize, ElementName=RoadmapEditor}"
                                     ResizeToViewport="True"
                                     Zoom="RoadmapMinimap_OnZoom"
-                                    Background="#202020">
+                                    Background="{DynamicResource RoadmapOverlayMutedBrush}">
                         <nodify:Minimap.ItemTemplate>
                             <DataTemplate DataType="{x:Type local:RoadmapNode}">
-                                <Border Background="#808080"
-                                        BorderBrush="#B0B0B0"
+                                <Border Background="{DynamicResource RoadmapOverlayBorderBrush}"
+                                        BorderBrush="{DynamicResource RoadmapOverlayForegroundBrush}"
                                         BorderThickness="1"
                                         CornerRadius="1" />
                             </DataTemplate>
@@ -565,21 +604,25 @@
                     <Button Classes="roadmapOverlayButton"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Bottom"
-                            Content="x"
                             Click="RoadmapMinimapCollapse_OnClick"
-                            ToolTip.Tip="Hide minimap"
-                            AutomationProperties.AutomationId="RoadmapMinimapCollapseButton" />
+                            ToolTip.Tip="{DynamicResource RoadmapHideMinimap}"
+                            AutomationProperties.Name="{DynamicResource RoadmapHideMinimap}"
+                            AutomationProperties.AutomationId="RoadmapMinimapCollapseButton">
+                        <PathIcon Classes="roadmapViewportIcon" Data="M6,5 L19,18 L18,19 L5,6 Z M18,5 L19,6 L6,19 L5,18 Z" />
+                    </Button>
                 </Grid>
             </Border>
 
             <Button HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
                     Classes="roadmapOverlayButton"
-                    Content="M"
                     Click="RoadmapMinimapExpand_OnClick"
                     IsVisible="{Binding !IsRoadmapMinimapExpanded, ElementName=Root}"
-                    ToolTip.Tip="Show minimap"
-                    AutomationProperties.AutomationId="RoadmapMinimapExpandButton" />
+                    ToolTip.Tip="{DynamicResource RoadmapShowMinimap}"
+                    AutomationProperties.Name="{DynamicResource RoadmapShowMinimap}"
+                    AutomationProperties.AutomationId="RoadmapMinimapExpandButton">
+                <PathIcon Classes="roadmapViewportIcon" Data="M5,5 L19,5 L19,19 L5,19 Z M7,7 L7,17 L17,17 L17,7 Z M9,9 L11,9 L11,11 L9,11 Z M13,13 L15,13 L15,15 L13,15 Z" />
+            </Button>
         </Grid>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- Локализует элементы управления Roadmap-картой и их accessibility names.
- Заменяет debug-like текстовые кнопки на icon-only controls.
- Переводит overlay/minimap/build indicator на theme-aware brushes.

## Changes
- Добавлены EN/RU resource keys для zoom, pan, fit, reset, collapse/expand Roadmap controls.
- `GraphControl.axaml` теперь использует `DynamicResource` для tooltip/name и локальные theme-aware overlay brushes.
- Roadmap UI tests расширены проверками русской локализации, icon-only content, theme contract и сохранения zoom/pan/reset/collapse/restore поведения.
- Добавлена QUEST spec с EXEC журналом и evidence.

## Validation
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_ViewportOverlay_*" --no-progress` -> PASS, 1/1.
- `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --treenode-filter "/*/*/RoadmapGraphUiTests/RoadmapGraph_ViewportOverlays_*" --no-progress` -> PASS, 1/1.
- `dotnet build src\Unlimotion.Desktop\Unlimotion.Desktop.csproj --no-restore -v:minimal` -> PASS.
- `git diff --check` and `git diff --cached --check` -> PASS.
- Full run: `dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -- --no-progress` -> 530/531 passed, 1 unrelated failure in `MainControlTaskCardLayoutUiTests.CurrentTaskCard_DesktopLayout_ExposesSectionsAndKeyControls`.
- Before video: `C:\Users\Kibnet\.codex\worktrees\8625\Unlimotion\artifacts\roadmap-map-controls-localization-theme\roadmap-controls-before.mp4` (2880x1498, 24.000s).
- After video: `C:\Users\Kibnet\.codex\worktrees\8625\Unlimotion\artifacts\roadmap-map-controls-localization-theme\roadmap-controls-after.mp4` (2880x1498, 23.900s).

## Risks / Rollback
- Risk: visual contrast depends on system theme resources; covered by headless assertions against old fixed dark colors and video evidence.
- Rollback: revert commit `755ef6a`.

## Links
- Не связано с issue.
