### PR TITLE
fix(tests): await fixture lifecycle cleanup

### DIFF
--- a/specs/2026-07-17-test-fixture-lifecycle.md
+++ b/specs/2026-07-17-test-fixture-lifecycle.md
@@ -3,7 +3,7 @@
 ## 0. Метаданные
 - Тип (профиль): CI / .NET test infrastructure / TUnit lifecycle.
 - Владелец: Unlimotion maintainers.
-- Масштаб: medium — одна корневая гонка, минимальный internal producer barrier в ViewModel и 147 consumer call sites в 21 test file.
+- Масштаб: medium — корневая гонка fixture cleanup/save, минимальный internal producer barrier в ViewModel, 147 consumer call sites в 21 test file и обнаруженный при валидации false-await в Headless test wrapper.
 - Целевое семейство / behavior baseline: Не применимо — задача не меняет model/prompt behavior.
 - Поверхность: Codex implementation, Microsoft.Testing.Platform/TUnit local runner и GitHub Actions `All tests`.
 - Effective runtime: `global.json` minimum .NET SDK `10.0.100` с `rollForward=latestFeature`; фактически локально и в проверенном CI run resolved `10.0.302`; `net10.0`; TUnit `1.44.0`; Microsoft.Testing.Platform; `windows-latest`; `--maximum-parallel-tests 1`.
@@ -11,7 +11,8 @@
   - PR #274 run `29584922060`, attempt 1, job `87899423421`: 600 total, 599 succeeded, 1 отдельный UI failure, затем три unobserved `FileNotFoundException` из удалённых `MainWindowViewModelFixture_*`; длительность 6m26s;
   - тот же run, attempt 2, job `87902291442`: test assembly стартовала, assertion output отсутствовал, job отменён по 30-minute timeout; это согласуется с lifecycle race, но самостоятельно не доказывает ту же причину;
   - в текущей рабочей сессии локальный full-suite прогон на том же head вошёл в low-CPU/no-output hang; discovery, одиночный тест и класс отдельного UI failure завершались; durable log этого локального наблюдения не сохранён, поэтому оно не используется как самостоятельное доказательство root cause;
-  - source inventory: 147 вызовов `CleanTasks()` в 21 файле.
+  - source inventory: 147 вызовов `CleanTasks()` в 21 файле;
+  - post-implementation residual gate выявил 18 небезопасных `.Dispatch(async ...)` source call sites (17 Roadmap + 1 Settings), которые создавали 20 незавершённых test instances/fixture directories из-за параметризованного Roadmap test.
 - Целевой релиз / ветка: base `origin/main@5aebebcb34eabe35fcdb7a47ff76ffdc2a7e16dd`; branch `fix/test-fixture-lifecycle`; отдельный PR в `main` до повторного CI/merge PR #274.
 - Ограничения:
   - до отдельной точной approval-фразы изменялась только эта spec; gate пройден 2026-07-18;
@@ -35,6 +36,8 @@ Outcome contract:
   - каталог и task file существуют, пока controlled save заблокирован, и удалены после его release;
   - старых синхронных `CleanTasks()` call sites нет;
   - targeted test проходит 20 последовательных запусков;
+  - safe Headless wrapper ждёт завершение inner async callback; небезопасных `.Dispatch(async ...)` вне намеренного regression нет;
+  - после targeted/UI/full runs отсутствуют `MainWindowViewModelFixture_*` directories;
   - full `Unlimotion.Test` и `Unlimotion.UiTests.Headless` проходят serially без `Unobserved task exception` и без timeout;
   - отдельный PR green/ready/merged; затем PR #274 обновлён от `main`, повторно green/ready/merged.
 - Итоговый артефакт / output: узкий lifecycle diff (`TaskItemViewModel` internal barrier + test fixture/consumers), deterministic regressions, local validation logs, green GitHub Actions evidence и PR body с root-cause/rollback.
@@ -44,7 +47,7 @@ Outcome contract:
   - STOP и отдельная диагностика, если post-fix full suite сохраняет hang/unobserved exceptions при GREEN targeted regression;
   - unrelated `Toolbar_EmojiFilters_AllItemTogglesEveryEmojiFilter` failure не исправляется в этом package и не выдаётся за lifecycle evidence.
 
-## 2. Текущее состояние (AS-IS)
+## 2. Исходное состояние до EXEC (AS-IS snapshot)
 - `src/Unlimotion.Test/MainWindowViewModelFixture.cs:143-167` реализует синхронный `CleanTasks()`:
   1. выставляет `isCleaned`;
   2. синхронно вызывает `MainWindowViewModel.Dispose()` и storage/config dispose;
@@ -63,6 +66,7 @@ Outcome contract:
 - `.github/workflows/tests.yml` уже выполняет `Unlimotion.Test` и Headless serially с `--maximum-parallel-tests 1`; повышение timeout или уменьшение parallelism не исправляет отсутствующий await.
 - Синхронный cleanup используется 147 раз в 21 test file. `BaseModelTests` реализует `IDisposable`; два call sites в `LocalizationDisplayDefinitionTests` предварительно dispose ViewModel вручную и затем вызывают fixture cleanup.
 - TUnit `1.44.0` штатно вызывает `IAsyncDisposable.DisposeAsync()` и распространяет cleanup exception; локальные package XML/API подтверждают async disposer contract.
+- У `Avalonia.Headless.HeadlessUnitTestSession` нет overload `Dispatch(Func<Task>)`: старый wrapper выбирал generic overload с `TResult=Task` и ждал только outer task. Поэтому source выглядел awaited, но async callback продолжал работу после teardown. Исправление требует явного `Dispatch<bool>(Func<Task<bool>>)` и отдельного regression.
 
 CI evidence interpretation:
 - Attempt 1 напрямую подтверждает минимум три чтения из уже удалённых fixture directories.
@@ -102,11 +106,15 @@ Test fixture удаляет принадлежащие ей файлы до за
   - закрывает VM-side producers, atomically seals task saves и ждёт returned snapshots до storage dispose/delete;
   - выполняет bounded retry удаления и не скрывает terminal failure.
 - `BaseModelTests`:
-  - реализует `IAsyncDisposable` вместо `IDisposable`;
-  - awaits fixture cleanup через TUnit async lifecycle.
+  - использует явный `[After(HookType.Test)] async Task CleanupFixtureAsync()`;
+  - обнуляет owned fixture references до `await`, затем завершает cleanup после каждого test.
 - Каждый direct fixture owner:
   - awaits `CleanTasksAsync()` в своём `finally`;
   - для Headless сохраняет cleanup внутри dispatcher scope и завершает его до session dispose.
+- `SafeHeadlessUnitTestSession`:
+  - unwraps async callback через явный `Dispatch<bool>(Func<Task<bool>>)`;
+  - возвращает task, которая завершается только после inner callback;
+  - имеет regressions на ожидание callback и сохранение UI thread после `await`.
 - `MainWindowViewModelFixtureLifecycleTests`:
   - владеет controlled-save regression и idempotency assertions.
 - `TaskItemViewModel`:
@@ -147,7 +155,7 @@ Test fixture удаляет принадлежащие ей файлы до за
   3. snapshot task view models;
   4. synchronously seal every task and capture returned pending tasks;
   5. await every captured task, including already completed/faulted;
-  6. storage `IDisposable.Dispose()`;
+  6. fixture-owned storage `IDisposable.Dispose()` (тот же instance, который получает `MainWindowViewModel`);
   7. configuration dispose;
   8. config file delete;
   9. expansion-state file delete;
@@ -161,10 +169,11 @@ Test fixture удаляет принадлежащие ей файлы до за
 #### Consumer migration
 - Все 147 `fixture.CleanTasks()`/`projectionFixture.CleanTasks()` call sites заменяются на awaited `CleanTasksAsync()`.
 - Существующие async test methods/lambdas сохраняются async; synchronous consumer при необходимости становится `async Task`.
-- `BaseModelTests.Dispose()` заменяется на `ValueTask DisposeAsync()`.
+- `BaseModelTests.Dispose()` заменяется на явный `[After(HookType.Test)] async Task CleanupFixtureAsync()`; hook обнуляет ссылки до await и не полагается на наследуемый disposer contract.
 - `RunWithTreeProjectionAsync` awaits `projectionFixture.CleanTasksAsync()` внутри `session.DispatchAsync`, затем outer finally awaits headless session dispose.
 - Nullable fixture cleanup использует явный null-check; null-conditional await не вводится.
-- Для fixture без `Connect()` `taskRepository == null`: cleanup пропускает snapshot/seal/drain/storage-dispose, но ровно один раз dispose MainWindow/config и удаляет temp paths.
+- Для fixture без `Connect()` `taskRepository == null`: cleanup пропускает snapshot/seal/drain, но всё равно ровно один раз dispose принадлежащий fixture storage, MainWindow/config и удаляет temp paths.
+- Snapshot/seal является fail-closed barrier для filesystem deletion: если snapshot не получен полностью или хотя бы один `SealPendingSaves()` бросил exception, cleanup выполняет best-effort resource shutdown, сохраняет исходную ошибку и не удаляет ни один fixture path.
 - В четырёх callers, где после cleanup обязательно восстанавливается global state (две localization, application font resources, requested theme), restore помещается во вложенный `finally`, чтобы cleanup fault его не пропустил.
 
 #### Deterministic regression
@@ -206,7 +215,8 @@ Test fixture удаляет принадлежащие ей файлы до за
 | Current state | Trigger | Expected transition/result | Empty/error/disabled/concurrent case | Notes |
 | --- | --- | --- | --- | --- |
 | No cleanup started, no pending saves | First `CleanTasksAsync` | dispose producers -> atomic seal -> dispose storage/config -> delete -> completed | Empty repository allowed | No blocking adapter |
-| Fixture created, `Connect()` не вызван | First cleanup | skip task seal/drain, dispose config/VM, delete paths | `taskRepository == null` | Dedicated regression |
+| Fixture created, `Connect()` не вызван | First cleanup | skip task seal/drain, dispose owned storage/config/VM, delete paths | `taskRepository == null` | Dedicated regression |
+| Snapshot/seal barrier завершён не полностью | First cleanup | best-effort dispose, surface barrier failure, preserve every fixture path | `filesystemDeletionSafe == false` | Dedicated regression |
 | No cleanup started, pending save active | First cleanup | waits; files stay present | Save failure recorded, cleanup still releases resources | Core regression |
 | Cleanup running | Second cleanup | returns same task | No second dispose/delete | Reference equality asserted |
 | Cleanup completed | Later cleanup | returns same completed task | No-op observable as same result | Idempotent |
@@ -232,7 +242,8 @@ Test fixture удаляет принадлежащие ей файлы до за
 | Contract area | Current source of truth | Expected change | Compatibility / migration | Verification |
 | --- | --- | --- | --- | --- |
 | Test lifecycle | `MainWindowViewModelFixture.CleanTasks()` | async shared cleanup task | all test callers migrated atomically | build + zero old calls |
-| TUnit instance cleanup | `BaseModelTests : IDisposable` | `IAsyncDisposable` | TUnit 1.44 supported | base-class tests + full suite |
+| TUnit instance cleanup | `BaseModelTests : IDisposable` | explicit `[After(HookType.Test)] async Task` | TUnit 1.44 hook contract; owned refs cleared before await | base-class tests + full suite |
+| Headless async dispatch | generic overload мог вернуть outer `Task<Task>` | explicit `Dispatch<bool>` unwraps и awaits inner callback | unsafe source call sites migrated to `DispatchAsync` | 2 wrapper regressions + static gate |
 | Save admission | `TaskItemViewModel.ExecuteSaveCommand()` + `_pendingSavesLock` | internal same-lock `_acceptingSaves`/`SealPendingSaves()` | normal runtime flag stays true; seam доступен только friend test assembly | producer-barrier regression |
 | Pending saves | `TaskItemViewModel.WaitForPendingSavesAsync()` | existing API unchanged; fixture uses sealed one-time snapshot | no data/schema change | controlled real-storage regression |
 | File cleanup | silent `Try(Action)` | bounded async retry + surfaced path | test temp paths only | mandatory injected delete-failure tests + full suite |
@@ -249,18 +260,19 @@ Lifecycle invariants:
 6. Cleanup failure никогда не становится success из-за retry exhaustion/swallow.
 7. Save cancellation не используется как способ ускорить teardown.
 8. Normal production autosave и workflow settings не меняются; internal seal вызывается только test fixture.
+9. Возврат `SafeHeadlessUnitTestSession.DispatchAsync()` означает завершение inner async callback, включая его cleanup/fault.
 
 Atomic seal algorithm:
 1. Capture repository reference and dispose MainWindow-side subscriptions.
-2. If repository is null, skip task/storage branch and continue resource deletion.
+2. If repository is null, skip task snapshot/seal/drain, но всё равно dispose fixture-owned storage перед resource deletion.
 3. Snapshot task view models.
 4. Under each task's `_pendingSavesLock`, set `_acceptingSaves = false` and capture `Task.WhenAll` over all current saves, including completed/faulted.
 5. Create one outer `drainTask = Task.WhenAll(sealedSnapshots)`, await it once, and on fault retain every `drainTask.Exception!.Flatten().InnerExceptions` entry once.
-6. Dispose storage/config and delete paths; retain cleanup failures.
+6. Dispose owned storage/config; delete paths только если snapshot/seal barrier полностью завершён; retain cleanup failures.
 7. Throw the single retained error or one `AggregateException` without duplicate entries.
 
 ## 8. Точки интеграции и триггеры
-- TUnit test-class teardown вызывает `BaseModelTests.DisposeAsync()`.
+- TUnit test-class teardown вызывает явный `BaseModelTests.CleanupFixtureAsync()` через `[After(HookType.Test)]`.
 - Direct test `finally` blocks вызывают `await fixture.CleanTasksAsync()`.
 - Headless dispatcher lambdas выполняют awaited cleanup до `SafeHeadlessUnitTestSession.DisposeAsync()`.
 - `TaskItemViewModel.ExecuteSaveCommand()` и internal `SealPendingSaves()` используют один `_pendingSavesLock` как admission/join barrier.
@@ -298,11 +310,11 @@ Atomic seal algorithm:
 - **TF-AC-01:** `CleanTasksAsync()`/`DisposeAsync()` используют одну shared core task; concurrent mixed `CleanTasksAsync()` + `DisposeAsync().AsTask()`, repeated-after-success и repeated-after-failure caller не запускают второй dispose/delete и получают тот же completion/fault; две прямые `CleanTasksAsync()` references и `DisposeAsync().AsTask()` reference равны.
 - **TF-AC-02:** Same-lock seal линейризуется с `ExecuteSaveCommand`: controlled in-flight status save остаётся pending; post-seal status mutation не запускает вторую command; до release files существуют; после release controlled command выполняет реальный `repository.Update(task)`, cleanup завершается и directories отсутствуют.
 - **TF-AC-03:** Минимум два captured in-flight save failures из разных sealed snapshots и boundary-observable delete failure не скрываются; terminal delete failure содержит operation/path; combined failures дают один aggregate с каждой из трёх причин ровно один раз; existing inner `DisposableList.Dispose()` swallowing не расширяется этой spec и явно остаётся accepted limitation.
-- **TF-AC-04:** `BaseModelTests` использует TUnit async disposal; Headless cleanup остаётся внутри dispatcher до session disposal; четыре global-state restoration path выполнены во вложенном `finally` даже при cleanup fault.
-- **TF-AC-05:** Fixture без `Connect()`/repository очищается успешно, повторно идемпотентна и удаляет config/tasks/fixture paths.
+- **TF-AC-04:** `BaseModelTests` использует явный TUnit `[After(HookType.Test)]` async hook; Headless cleanup остаётся внутри dispatcher до session disposal; четыре global-state restoration path выполнены во вложенном `finally` даже при cleanup fault.
+- **TF-AC-05:** Fixture без `Connect()`/repository dispose-ит созданный owned storage, очищается успешно, повторно идемпотентна и удаляет config/tasks/fixture paths; неполный snapshot/seal barrier, напротив, явно падает и сохраняет все fixture paths.
 - **TF-AC-06:** Все 147 старых `.CleanTasks()` call sites в 21 файле мигрированы; `rg -n "\.CleanTasks\(\)" src/Unlimotion.Test` не находит совпадений; два manual pre-dispose удалены.
-- **TF-AC-07:** New lifecycle class содержит минимум три обязательных regression и проходит targeted run и 20 последовательных запусков с `--maximum-parallel-tests 1`.
-- **TF-AC-08:** Full `Unlimotion.Test` выполняет минимум 603 tests, а `Unlimotion.UiTests.Headless` — минимум 31 test; оба serial suites PASS в существующем 30-minute CI budget, bounded local runs не timeout и logs не содержат fixture `FileNotFoundException`/`Unobserved task exception`.
+- **TF-AC-07:** New lifecycle class содержит минимум четыре обязательных regression и проходит targeted run и 20 последовательных запусков с `--maximum-parallel-tests 1`.
+- **TF-AC-08:** Full `Unlimotion.Test` выполняет минимум 606 tests, а `Unlimotion.UiTests.Headless` — минимум 31 test; дополнительно Safe Headless 2/2, Roadmap 31/31 и Settings 12/12 проходят с нулём residual fixture directories; оба serial suites укладываются в существующий 30-minute CI budget, bounded local runs не timeout и logs не содержат fixture `FileNotFoundException`/`Unobserved task exception`.
 - **TF-AC-09:** Diff ограничен этой spec, `src/Unlimotion.Test/**`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs` и новым `src/Unlimotion.ViewModel/AssemblyInfo.cs`; workflow, UI behavior и unrelated emoji assertion не меняются.
 - **TF-AC-10:** Fix PR green/ready/merged; PR #274 body обновлён точной root cause/validation/link на fix PR, branch обновлена от merge, required checks green, PR ready/merged до Stage 2 production EXEC.
 
@@ -310,10 +322,15 @@ Atomic seal algorithm:
 - New `MainWindowViewModelFixtureLifecycleTests`:
   - `CleanTasksAsync_ConcurrentCallersWaitForInFlightSaveBeforeDirectoryDeletion`;
   - `CleanTasksAsync_RepeatedCallAfterSaveAndDeleteFailuresReturnsSameAggregate`: два controlled saves на разных task VM сигнализируют `started` и остаются pending до seal, затем после общего `release` faulted двумя различимыми exceptions; injected test-only delete operation исчерпывает все три попытки; test проверяет ровно три причины без потерь/дублей, operation/path, один cleanup task и отсутствие повторного delete при повторном caller;
+  - `CleanTasksAsync_SnapshotBarrierFailurePreservesOwnedPaths`: injected snapshot failure доказывает fail-closed barrier — resource shutdown выполняется, delete boundary не вызывается, config/tasks/fixture paths сохраняются, repeated caller получает тот же fault;
   - `CleanTasksAsync_UnconnectedFixtureDeletesOwnedPathsOnce`.
 - Failure injection обязателен и остаётся внутри fixture/test assembly: cleanup operations/deletion delegate можно заменить в regression, normal constructor использует real filesystem.
 - Каждая controlled replacement `ReactiveCommand` имеет test-owned `ThrownExceptions` subscription; subscription и command dispose только после bounded observation всех её invocations.
-- Update all direct cleanup consumers and `BaseModelTests` lifecycle signatures.
+- Update all direct cleanup consumers и явный `BaseModelTests` After(Test) lifecycle hook.
+- New `SafeHeadlessUnitTestSessionTests`:
+  - `Dispatch_AwaitsAsyncCallbackBeforeReturning`;
+  - `DispatchAsync_PreservesUiThreadAcrossAwait`.
+- Migrate 18 unsafe Headless `.Dispatch(async ...)` call sites to `DispatchAsync`; one intentional raw call remains only inside the wrapper regression.
 - No new FlaUI/video test: no production UI behavior change.
 
 ### Characterization baseline
@@ -321,9 +338,12 @@ Atomic seal algorithm:
 - PR #274 run attempt 1: 600 total, 599 pass, 1 unrelated UI failure, three fixture `FileNotFoundException` unobserved exceptions.
 - PR #274 run attempt 2: no assertion result, 30m timeout after assembly start.
 - В текущей сессии baseline Headless run прошёл 31 test; durable log не сохранён, поэтому `--minimum-expected-tests 31` заново подтверждает count в EXEC evidence.
+- Pre-fix residual gate обнаружил 20 fixture directories, точно соответствовавших 18 unsafe Headless source call sites; это отдельный infrastructure finding, обнаруженный после первоначального 604-test false-green run.
 - Unchanged workflow already serializes tests.
 
 ### Commands
+Ниже приведён canonical reproducible rerun recipe. Он формирует 26 timestamped green run names и по два файла на run (`stdout`/`stderr`), то есть canonical manifest из 52 путей. Это контракт для повторного запуска, а не описание фактически сохранённых в EXEC имён. Фактический final evidence manifest из восьми stdout logs перечислен отдельно в Post-EXEC Review; прочие исторические logs в marker gate не входят.
+
 Evidence directory, bounded process helper и restore:
 
 ```powershell
@@ -369,6 +389,24 @@ function Invoke-BoundedDotnetTest {
     }
 }
 
+$fixtureRoot = [IO.Path]::GetFullPath(
+    (Join-Path (Get-Location) 'src/Unlimotion.Test/bin/Debug/net10.0'))
+function Assert-NoResidualFixtures([string] $Phase) {
+    $residualFixtures = @(
+        Get-ChildItem -LiteralPath $fixtureRoot `
+            -Directory `
+            -Filter 'MainWindowViewModelFixture_*' `
+            -ErrorAction SilentlyContinue
+    )
+    if ($residualFixtures.Count -ne 0) {
+        $residualFixtures.FullName
+        throw "Residual fixture directories after ${Phase}: $($residualFixtures.Count)"
+    }
+}
+
+$validationRunId = 'final-' + (Get-Date -Format 'yyyyMMdd-HHmmss')
+$greenRunNames = [Collections.Generic.List[string]]::new()
+
 dotnet restore src/Unlimotion.Test/Unlimotion.Test.csproj
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 dotnet restore tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj
@@ -408,56 +446,105 @@ if (-not (Select-String -LiteralPath $redLog -SimpleMatch 'cleanup completed bef
 Targeted lifecycle GREEN после implementation:
 
 ```powershell
+$targetedGreenName = "$validationRunId-targeted-green"
+Assert-NoResidualFixtures 'targeted-green pre-run'
 Invoke-BoundedDotnetTest `
-  -Name 'targeted-green' `
+  -Name $targetedGreenName `
   -TimeoutSeconds 180 `
   -Arguments @(
       'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
       '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
       '--treenode-filter', '/*/*/MainWindowViewModelFixtureLifecycleTests/*',
-      '--minimum-expected-tests', '3',
+      '--minimum-expected-tests', '4',
       '--maximum-parallel-tests', '1', '--output', 'Detailed')
+$greenRunNames.Add($targetedGreenName)
+Assert-NoResidualFixtures 'targeted-green'
 ```
 
 Stress:
 
 ```powershell
 1..20 | ForEach-Object {
+    $stressName = '{0}-stress-{1:D2}' -f $validationRunId, $_
+    Assert-NoResidualFixtures "$stressName pre-run"
     Invoke-BoundedDotnetTest `
-      -Name ('stress-{0:D2}' -f $_) `
+      -Name $stressName `
       -TimeoutSeconds 180 `
       -Arguments @(
           'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
           '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
           '--treenode-filter', '/*/*/MainWindowViewModelFixtureLifecycleTests/*',
-          '--minimum-expected-tests', '3',
+          '--minimum-expected-tests', '4',
           '--maximum-parallel-tests', '1', '--output', 'Detailed')
+    $greenRunNames.Add($stressName)
+    Assert-NoResidualFixtures $stressName
+}
+```
+
+Headless-dispatch и восстановленные UI consumers:
+
+```powershell
+$targetedConsumers = @(
+    @('headless-dispatch', '/*/*/SafeHeadlessUnitTestSessionTests/*', 2, 180),
+    @('roadmap', '/*/*/RoadmapGraphUiTests/RoadmapGraph_*', 31, 300),
+    @('settings', '/*/*/SettingsControlResponsiveUiTests/*', 12, 180)
+)
+
+foreach ($target in $targetedConsumers) {
+    $name = "$validationRunId-$($target[0])"
+    Assert-NoResidualFixtures "$name pre-run"
+    Invoke-BoundedDotnetTest `
+      -Name $name `
+      -TimeoutSeconds $target[3] `
+      -Arguments @(
+          'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
+          '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
+          '--treenode-filter', $target[1],
+          '--minimum-expected-tests', [string]$target[2],
+          '--maximum-parallel-tests', '1', '--output', 'Detailed')
+    $greenRunNames.Add($name)
+    Assert-NoResidualFixtures $name
 }
 ```
 
 Full workflow equivalent:
 
 ```powershell
+$fullUnlimotionName = "$validationRunId-full-unlimotion"
+Assert-NoResidualFixtures 'full-unlimotion pre-run'
 Invoke-BoundedDotnetTest `
-  -Name 'full-unlimotion' `
+  -Name $fullUnlimotionName `
   -TimeoutSeconds 1200 `
   -Arguments @(
       'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
       '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
-      '--minimum-expected-tests', '603',
+      '--minimum-expected-tests', '606',
       '--maximum-parallel-tests', '1', '--output', 'Detailed')
+$greenRunNames.Add($fullUnlimotionName)
+Assert-NoResidualFixtures 'full-unlimotion'
 
+$fullHeadlessName = "$validationRunId-full-headless"
 Invoke-BoundedDotnetTest `
-  -Name 'full-headless' `
+  -Name $fullHeadlessName `
   -TimeoutSeconds 300 `
   -Arguments @(
       'test', 'tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj',
       '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
       '--minimum-expected-tests', '31',
       '--maximum-parallel-tests', '1', '--output', 'Detailed')
+$greenRunNames.Add($fullHeadlessName)
+Assert-NoResidualFixtures 'full-headless'
 
-$greenLogs = Get-ChildItem $evidenceDir -Filter '*.log' |
-    Where-Object Name -Match '^(targeted-green|stress-\d+|full-(unlimotion|headless))\.(stdout|stderr)\.log$'
+$requiredGreenLogs = @($greenRunNames | ForEach-Object {
+    Join-Path $evidenceDir "$_.stdout.log"
+    Join-Path $evidenceDir "$_.stderr.log"
+})
+$missingGreenLogs = @($requiredGreenLogs | Where-Object { -not (Test-Path -LiteralPath $_) })
+if ($missingGreenLogs.Count -ne 0) {
+    $missingGreenLogs
+    throw 'Required final validation logs are missing.'
+}
+$greenLogs = Get-Item -LiteralPath $requiredGreenLogs
 $greenLogText = ($greenLogs | ForEach-Object {
     Get-Content -LiteralPath $_.FullName -Raw
 }) -join "`n"
@@ -478,6 +565,30 @@ if ($oldCleanupExit -eq 0) {
 }
 if ($oldCleanupExit -ne 1) {
     throw "rg inventory failed with exit code $oldCleanupExit"
+}
+
+$unsafeDispatch = @(
+    rg -n --pcre2 '\.Dispatch\s*\(\s*async\b' `
+        src/Unlimotion.Test `
+        --glob '*.cs' `
+        --glob '!SafeHeadlessUnitTestSessionTests.cs'
+)
+$unsafeDispatchExit = $LASTEXITCODE
+if ($unsafeDispatchExit -eq 0) {
+    $unsafeDispatch
+    throw 'Unsafe Headless Dispatch(async ...) call sites remain.'
+}
+if ($unsafeDispatchExit -ne 1) {
+    throw "Unsafe dispatch inventory failed with exit code $unsafeDispatchExit"
+}
+
+$intentionalDispatch = @(
+    rg -n --pcre2 '\.Dispatch\s*\(\s*async\b' `
+        src/Unlimotion.Test/SafeHeadlessUnitTestSessionTests.cs
+)
+if ($LASTEXITCODE -ne 0 -or $intentionalDispatch.Count -ne 1) {
+    $intentionalDispatch
+    throw 'Expected exactly one intentional raw Dispatch(async ...) regression call.'
 }
 
 $allowedPatterns = @(
@@ -524,6 +635,12 @@ if ($LASTEXITCODE -ne 0) { throw 'Committed path inventory failed.' }
 Assert-Allowlisted -Paths $committedPaths
 git diff --check origin/main...HEAD
 if ($LASTEXITCODE -ne 0) { throw 'Committed diff check failed.' }
+$dirtyAfterCommit = @(git status --porcelain --untracked-files=all)
+if ($LASTEXITCODE -ne 0) { throw 'Post-commit git status failed.' }
+if ($dirtyAfterCommit.Count -gt 0) {
+    $dirtyAfterCommit
+    throw 'Post-commit worktree is not clean.'
+}
 ```
 
 Expected `rg` result: exit code 1/no matches; exit 0 и infrastructure error fail closed. Allowlist проверяет tracked, untracked, staged и committed paths: this spec, `src/Unlimotion.Test/**`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs`, `src/Unlimotion.ViewModel/AssemblyInfo.cs`.
@@ -542,11 +659,11 @@ Test loop stop rules:
 | TF-AC-01 | concurrent/success/failure idempotency tests | inspect shared-task implementation | targeted log | — |
 | TF-AC-02 | controlled real-storage in-flight save + post-seal mutation | RED/GREEN comparison | `targeted-red/green` logs | — |
 | TF-AC-03 | mandatory combined save/delete failure regression | inspect aggregate entries/path | targeted log + diff | Existing inner `DisposableList` swallowing is documented limitation |
-| TF-AC-04 | affected base/Headless tests + nested-finally source assertions | inspect dispatcher/global-state ordering | full logs | — |
+| TF-AC-04 | explicit After(Test), Safe Headless 2/2, affected Headless tests + nested-finally source assertions | inspect dispatcher/global-state ordering | targeted/full logs | — |
 | TF-AC-05 | unconnected fixture regression | inspect null-repository branch | targeted log | — |
 | TF-AC-06 | build + zero-match `rg` | compare expected 147/21 inventory | static-check output | — |
 | TF-AC-07 | targeted + 20x stress with minimum count | bounded elapsed time | `stress-*.log` | — |
-| TF-AC-08 | two bounded full serial runs with minimum counts | search logs for lifecycle markers | full logs + Actions URL | — |
+| TF-AC-08 | Safe 2/2, Roadmap 31/31, Settings 12/12 and two bounded full serial runs | search exact final-log manifest for lifecycle markers; residual gate after every relevant run | targeted/full logs + Actions URL | — |
 | TF-AC-09 | pre/post-commit scope gates | allowlist review | Post-EXEC review | — |
 | TF-AC-10 | GitHub required checks + PR #274 body/ancestry | inspect root-cause/link/check states | two PR URLs/check summaries | — |
 
@@ -554,9 +671,12 @@ Test loop stop rules:
 - Delayed producer может попытаться сохранить после cleanup start. Mitigation: same-lock atomic seal; post-seal mutation regression.
 - 147 mechanical conversions могут оставить один unawaited finally. Mitigation: zero-match `rg`, compile, full suite.
 - `async void` может появиться при неверной конверсии lambda/method. Mitigation: signatures review; разрешены только `async Task`/`ValueTask` lifecycle paths.
-- Cleanup exception в прямом C# `finally` может заменить body exception. Mitigation: accepted limitation явно указан; cleanup errors сохраняются внутри своего aggregate, а global state восстанавливается nested `finally`. TUnit `IAsyncDisposable` path отдельно проверяется.
+- Cleanup exception в прямом C# `finally` может заменить body exception. Mitigation: accepted limitation явно указан; cleanup errors сохраняются внутри своего aggregate, global state восстанавливается nested `finally`, а shared base fixture завершается явным `After(Test)` hook.
 - Delete retry может удлинить teardown. Mitigation: bounded three attempts, async backoff, path-specific failure.
 - Headless session может быть disposed раньше fixture. Mitigation: cleanup остаётся внутри dispatcher; explicit regression/review.
+- Generic Headless overload может снова принять async lambda как `TResult=Task`. Mitigation: explicit `Dispatch<bool>` wrapper, 2 regressions и zero-match static gate вне intentional test.
+- Roadmap background build может пережить per-test dispatcher reset. Mitigation: изменяющий граф CreateMenu test обнуляет DataContext и ждёт одновременно progress flag и active-build count до fixture cleanup; best-effort retry в `finally` не маскирует исходную ошибку.
+- UI test с названием CreateMenu может ложно пройти при прямом вызове ViewModel command. Mitigation: сценарий открывает реальный `MenuFlyout`, находит каждый `MenuItem` по AutomationId, требует visible/enabled state и поднимает `MenuItem.ClickEvent`; outcome assertions проверяют фактическую binding.
 - Attempt-2 timeout может иметь другую причину. Mitigation: не заявлять доказанную идентичность; требовать deterministic regression и полный post-fix green suite.
 - Unrelated emoji UI flake может снова сделать required check red. Mitigation: isolate and address only через отдельную approved package; не ослаблять assertion в этом diff.
 - Production source switch имеет похожий потенциальный risk. Mitigation: отдельный follow-up spec/evidence, без scope expansion здесь.
@@ -585,13 +705,14 @@ Test loop stop rules:
 2. Freshness gate: fetch, проверить `origin/main` base/branch, clean tree, PR #274 state.
 3. Добавить deterministic regression и минимальный compile seam; зафиксировать ожидаемый RED.
 4. Реализовать same-lock atomic producer seal в `TaskItemViewModel`, friend-only internal seam, shared async cleanup owner и dispose/delete error contract.
-5. Перевести `BaseModelTests` и все 147 call sites; удалить manual pre-dispose, сохранить unconnected-fixture path и вложенное восстановление четырёх global-state owners.
-6. Запустить build, bounded targeted GREEN, 20x stress, minimum-count/static/log-marker gates.
-7. Запустить full `Unlimotion.Test` и Headless serially; разобрать любой failure без scope masking.
-8. Выполнить Post-EXEC review и independent re-review после fixes.
-9. Commit/push; открыть draft PR с Summary/Changes/Validation/Risks-Rollback/Links; дождаться green checks, перевести ready и merge.
-10. Обновить body PR #274 точной root cause, validation evidence и ссылкой на merged fix PR; обновить branch от merged `main`, проверить ancestry и rerun required checks; только green PR перевести ready и merge.
-11. Вернуться на `fix/status-availability-contract`, rebase на новый `origin/main`, повторить Stage 2 baseline и начать уже утверждённый Stage 2 EXEC.
+5. Перевести `BaseModelTests` на explicit After(Test) hook и все 147 call sites; удалить manual pre-dispose, сохранить unconnected-fixture path и вложенное восстановление четырёх global-state owners.
+6. Исправить обнаруженный Headless false-await: explicit generic unwrap, 18 consumer migrations, 2 regressions и Roadmap/Settings test-only teardown/interaction repairs; CreateMenu должен проходить через реальные menu items, а не прямой ViewModel command.
+7. Запустить build, bounded targeted GREEN, 20x stress, Safe/Roadmap/Settings minimum-count, residual/static/log-marker gates.
+8. Запустить full `Unlimotion.Test` и Headless serially; разобрать любой failure без scope masking.
+9. Выполнить Post-EXEC review и independent re-review после fixes.
+10. Commit/push; открыть draft PR с Summary/Changes/Validation/Risks-Rollback/Links; дождаться green checks, перевести ready и merge.
+11. Обновить body PR #274 точной root cause, validation evidence и ссылкой на merged fix PR; обновить branch от merged `main`, проверить ancestry и rerun required checks; только green PR перевести ready и merge.
+12. Вернуться на `fix/status-availability-contract`, rebase на новый `origin/main`, повторить Stage 2 baseline и начать уже утверждённый Stage 2 EXEC.
 
 ## 14. Открытые вопросы
 Нет открытых design/product вопросов. Обязательная отдельная approval-фраза `Спеку подтверждаю` получена 2026-07-18.
@@ -618,11 +739,15 @@ Test loop stop rules:
 | `src/Unlimotion.ViewModel/AssemblyInfo.cs` (new) | `InternalsVisibleTo("Unlimotion.Test")` | Ограничить lifecycle seam тестовой assembly |
 | `src/Unlimotion.Test/MainWindowViewModelFixture.cs` | async shared cleanup, seal/drain, null-repository branch, injected delete boundary, surfaced failures, `IAsyncDisposable` | Root fix и детерминированные regressions |
 | `src/Unlimotion.Test/MainWindowViewModelFixtureLifecycleTests.cs` (new) | Controlled RED/GREEN lifecycle tests | Deterministic proof |
-| `src/Unlimotion.Test/MainWindowViewModelTests.cs` | `BaseModelTests : IAsyncDisposable`; awaited projection cleanup; remaining direct calls | TUnit lifecycle owner |
+| `src/Unlimotion.Test/MainWindowViewModelTests.cs` | explicit `[After(HookType.Test)]` cleanup hook; awaited projection cleanup; remaining direct calls | TUnit lifecycle owner |
+| `src/Unlimotion.Test/HeadlessSessionExtensions.cs` | explicit `Dispatch<bool>` unwrapping и awaited inner callback | Устранить false-await overload |
+| `src/Unlimotion.Test/SafeHeadlessUnitTestSessionTests.cs` (new) | 2 regressions: await inner callback и UI-thread affinity | Не допустить возврат false-await |
 | `src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs` | awaited cleanup; remove manual pre-dispose; nested culture restore | Single owner и guaranteed global-state restore |
 | `src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs` | awaited cleanup и nested application-font restore | Global-state restore even on cleanup fault |
 | `src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs` | awaited cleanup и nested requested-theme restore | Global-state restore even on cleanup fault |
-| 19 consumer files below, кроме `MainWindowViewModelTests.cs` и `LocalizationDisplayDefinitionTests.cs`; два из 19 раскрыты отдельными строками выше | mechanical awaited cleanup migration | Remove all synchronous callers |
+| `src/Unlimotion.Test/RoadmapGraphUiTests.cs` | 17 `DispatchAsync` migrations, real MenuFlyout/MenuItem create flow, interaction repairs и explicit background-build drain в CreateMenu teardown | Устранить false-await, ложное command-level UI coverage и per-test dispatcher leak |
+| `src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs` | `DispatchAsync` migration и viewport-safe click helper | Устранить false-await и восстановить реальный click flow |
+| 19 consumer files ниже, кроме отдельно перечисленных `MainWindowViewModelTests` и `LocalizationDisplayDefinitionTests` | mechanical awaited cleanup migration; четыре сложных UI-файла также детализированы отдельными строками выше | Remove all synchronous callers |
 
 Exact remaining consumer inventory:
 - `BreadcrumbEmojiUiTests.cs`
@@ -659,8 +784,8 @@ Explicitly unchanged:
 | Pending saves | API exists but teardown ignores it | one cached sealed snapshot полностью awaited before delete |
 | Repeated cleanup | bool early return, second caller cannot await first | same shared task/result/fault |
 | Delete failure | swallowed after three sleeps | bounded async retry then explicit path error |
-| TUnit teardown | `IDisposable` | `IAsyncDisposable` |
-| Headless order | sync cleanup in finally | awaited cleanup in dispatcher before session dispose |
+| TUnit teardown | `IDisposable` | explicit async `[After(HookType.Test)]` hook |
+| Headless order | sync cleanup / generic false-await | awaited cleanup и explicit inner callback unwrap before session dispose |
 | CI response | retry/timeout ambiguity | deterministic regression + unchanged full workflow proof |
 | Production behavior | autosave has no teardown admission state | normal autosave remains unchanged; only friend test fixture invokes internal seal |
 
@@ -696,7 +821,7 @@ Explicitly unchanged:
 | E. Готовность к автономной реализации | 17-19 | PASS | Independent reviews закрыты; commands, sequencing и stop conditions однозначны; approval — отдельный governance gate |
 | F. Соответствие профилю | 20 | PASS | TUnit/.NET/Headless/CI governance отражены |
 
-Итог: `ГОТОВО`. Production EXEC остаётся запрещён только до отдельной точной approval-фразы.
+Итог: `ГОТОВО`. Отдельная approval-фраза получена 2026-07-18; local EXEC и validation выполнены в утверждённом scope.
 
 ### SPEC Rubric Result
 
@@ -710,7 +835,7 @@ Explicitly unchanged:
 | 6. Готовность к автономной реализации | 5 | Independent fix/re-review PASS; exact commands/evidence/delivery handoff заданы |
 
 Итоговый балл: 30 / 30
-Зона: готово к автономному выполнению после обязательного approval gate.
+Зона: готово; обязательный approval gate пройден 2026-07-18.
 
 ### Role-Based Review Result
 
@@ -725,7 +850,7 @@ Explicitly unchanged:
 ### Post-SPEC Review
 - Статус: PASS
 - Scope reviewed: final spec, source/callsite inventory, delayed producer paths, TUnit package contract, PR #274 CI attempts, validation commands и delivery sequencing
-- Decision: запросить отдельную user approval; EXEC до неё не начинать
+- Decision на момент Post-SPEC review: запросить отдельную user approval; gate позднее пройден 2026-07-18
 - Review passes:
   - Scope/Evidence pass: self-review PASS
   - Contract pass: independent architect review PASS
@@ -756,29 +881,62 @@ Explicitly unchanged:
 | LOW | audit metadata | Linter/rubric/journal описывали старый test-only design | Согласовать §19/журнал с final contract | fixed |
 
 - Fixed before continuing: все initial independent findings исправлены; каждая substantive правка прошла повторное review
-- Checks rerun: 22 обязательных H2 section, 14 fences, 10 AC, 7 PowerShell blocks без parse errors, zero trailing whitespace/tabs, stale-term scan и untracked-file whitespace check
-- Needs human: только точная approval-фраза для child EXEC
-- Residual risks / follow-ups: production source-switch drain; unrelated emoji flake
+- Checks rerun: 22 обязательных H2 section, 16 fence lines, 10 AC, 8 PowerShell blocks без parse errors, zero trailing whitespace/tabs, stale-term scan и untracked-file whitespace check
+- Needs human: нет для local EXEC; GitHub merge остаётся gated зелёными required checks
+- Residual risks / follow-ups: cleanup не является общим barrier для произвольной уже запущенной `ITaskStorage` operation; production source-switch drain; уже запущенный callback `TaskTreeExpansionStateStore` timer не имеет отдельного join-контракта; unrelated emoji flake
 
 ### Post-EXEC Review
-- Статус: Не выполнен до EXEC
-- Scope reviewed: Не применимо
-- Decision: Не применимо до approval/EXEC
-- Review passes: Не применимо
-- Evidence inspected: Не применимо
-- Depth checklist: Не применимо
-- No-findings justification: Не применимо
+- Статус: PASS для local implementation/validation; GitHub delivery по TF-AC-10 выполняется следующим шагом
+- Scope reviewed: все 28 allowlisted paths, production seal seam, fixture owner/error semantics, четыре lifecycle regression, 147 consumer migrations, Headless false-await regressions, Roadmap/Settings test-only repairs, full unit/Headless evidence и post-commit gate
+- Decision: разрешить intentional staging/commit и draft PR; merge только после green required checks
+- Review passes:
+  - architect initial verdict `NEEDS-FIX`: два MEDIUM — fail-open snapshot/seal barrier и undisposed owned storage без `Connect()`;
+  - delivery initial verdict `NEEDS-FIX`: post-commit gate не требовал clean worktree;
+  - tester initial verdict `PASS` по consumer migration и lifecycle regressions, затем migration re-review обнаружил недостаточный Roadmap build drain, masking в best-effort teardown и прямой command bypass в CreateMenu test;
+  - после исправлений architect re-review `PASS`, migration/Headless/Roadmap/Settings final re-review `PASS`; final delivery re-review выполняется на committed gate/evidence перед publish;
+  - self-review/static scope `PASS`.
+- Evidence inspected:
+  - deterministic RED: expected marker `cleanup completed before controlled save release`;
+  - final build `Unlimotion.Test`: PASS, 0 errors; Headless project build: PASS, 0 errors;
+  - targeted lifecycle GREEN: 4/4; stress: 20/20 runs, каждый 4/4 и residual 0;
+  - Safe Headless wrapper: 2/2; Settings: 12/12; Roadmap: 31/31; отдельный real CreateMenu flow: 1/1;
+  - exact final full `Unlimotion.Test`: 606/606, 0 failed, 11m58s;
+  - exact final full `Unlimotion.UiTests.Headless`: 31/31, 0 failed, 58s;
+  - actual final evidence manifest (ровно 8 stdout logs; historical/failed logs исключены):
+    - `artifacts/test-fixture-lifecycle/final-targeted-green-20260718.stdout.log`;
+    - `artifacts/test-fixture-lifecycle/final-stress-20260718.stdout.log`;
+    - `artifacts/test-fixture-lifecycle/final-headless-dispatch-20260718.stdout.log`;
+    - `artifacts/test-fixture-lifecycle/final-settings-20260718.stdout.log`;
+    - `artifacts/test-fixture-lifecycle/final-roadmap-create-menu-20260718.stdout.log`;
+    - `artifacts/test-fixture-lifecycle/final-roadmap-20260718-05.stdout.log`;
+    - `artifacts/test-fixture-lifecycle/final-full-unit-20260718-03.stdout.log`;
+    - `artifacts/test-fixture-lifecycle/final-full-headless-20260718.stdout.log`;
+  - marker scan только этого actual manifest: lifecycle markers 0; residual fixture directories 0;
+  - static gates: 28/28 allowlisted paths, old `.CleanTasks()` 0, awaited consumer cleanup 147/147, unsafe `.Dispatch(async ...)` outside regression 0, intentional raw regression 1, unconsumed `DispatchAsync` 0, added `async void` 0, `SealPendingSaves()` production caller только fixture, `git diff --check` PASS.
+- Depth checklist:
+  - Scope drift / unrelated changes: none; workflows, production UI и emoji assertion untouched
+  - Acceptance criteria: TF-AC-01..09 locally satisfied; TF-AC-10 pending GitHub delivery
+  - Unsupported claims: no timeout-causation claim added beyond attempt-1 direct evidence
+  - Regression / edge case: shared caller, in-flight real write, post-seal no-op, multi-save/delete aggregate, fail-closed snapshot barrier, unconnected owned storage, nullable/dispatcher/global-state paths, Headless inner-task await, Roadmap active-build drain и real menu binding
+  - Comments/docs/changelog: child spec updated; README/release notes/UI video N/A for this internal fix
+- No-findings justification: architecture/ownership, false-await, Roadmap isolation и menu-fidelity findings исправлены code+regressions и получили independent re-review `PASS`; exact final full suites и fail-closed static/log gates зелёные; delivery clean-worktree finding внесён в executable post-commit gate.
 
 | Severity | Area | Finding | Required action | Status |
 | --- | --- | --- | --- | --- |
-| LOW | phase | EXEC не начат | Выполнить полный Post-EXEC review после implementation/validation | follow-up |
+| MEDIUM | architecture | Snapshot/seal barrier позволял deletion после частичного seal | При неполном barrier сохранить paths и явно вернуть fault | fixed; regression + architect re-review PASS |
+| MEDIUM | ownership | Созданный storage не dispose-ился без `Connect()` | Хранить один owned storage и dispose в shared cleanup task | fixed; architect re-review PASS |
+| HIGH | validation | Headless wrapper ждал outer `Task<Task>`, давая false green и 20 residual fixture directories | Явно unwrap async callback, мигрировать 18 source call sites и добавить 2 regressions | fixed; Safe 2/2, full 606/606, reviewer PASS |
+| MEDIUM | test integration | Планировавшийся у BaseModel inherited `IAsyncDisposable` не обеспечил однозначный фактический TUnit owner | Использовать явный `[After(HookType.Test)] async Task CleanupFixtureAsync()` | fixed; 147/147 awaited consumer calls |
+| MEDIUM | test isolation | CreateMenu оставлял Roadmap build активным после dispatcher reset | Обнулить graph DataContext и ждать progress flag плюс active-build count; не маскировать body failure в `finally` | fixed; Roadmap 31/31 + reviewer PASS |
+| MEDIUM | test fidelity | CreateMenu test вызывал ViewModel command напрямую и мог пропустить отсутствующую/disabled/wrong binding | Открывать `MenuFlyout`, находить visible/enabled `MenuItem` по AutomationId и поднимать Click | fixed; focused 1/1 + Roadmap 31/31 + reviewer PASS |
+| MEDIUM | delivery | Post-commit allowlist мог пройти при забытых untracked files | Fail closed на непустом `git status --porcelain --untracked-files=all` | fixed; final execution после commit обязателен |
 
-- Fixed before final report: Не применимо
-- Checks rerun: Не применимо
-- Validation evidence: Не применимо
-- Unrelated changes: Не применимо
-- Needs human: approval child spec
-- Residual risks / follow-ups: перечислены выше
+- Fixed before final report: все findings исправлены; четвёртый lifecycle regression и два Headless regressions добавлены без расширения user-visible production scope
+- Checks rerun: builds, targeted lifecycle 4/4, stress 20×4/4, Safe 2/2, Settings 12/12, Roadmap 31/31, real CreateMenu 1/1, exact full 606/606, Headless 31/31, exact-manifest markers, residual/path/callsite/static gates
+- Validation evidence: восемь exact paths из actual final manifest выше (ignored local evidence; historical/failed logs исключены, итоговые counts переносятся в PR body)
+- Unrelated changes: none
+- Needs human: нет; текущая approval покрывает exact child scope
+- Residual risks / follow-ups: cleanup гарантирует drain зарегистрированных `TaskItemViewModel` saves, но не является универсальным barrier для произвольной уже запущенной `ITaskStorage` operation; production source-switch drain; already-running expansion-state timer callback without strict join; unrelated emoji flake
 
 ## Approval
 Получена отдельная точная фраза `Спеку подтверждаю` 2026-07-18. Статус: APPROVED FOR EXEC.
@@ -796,3 +954,9 @@ Approval master roadmap, Stage 1 или Stage 2 не распространяе�
 | SPEC | Fix and re-review | 1.00 | Нет | Провести повторные architect и delivery/validation reviews | Нет | Оба independent verdict `PASS` | Same-lock/cached seal, multi-fault aggregation и delivery gates подтверждены | Эта spec |
 | SPEC | Final adversarial consistency audit | 1.00 | Нет | Исправить RED masking, ReactiveCommand observer, AC mapping и fail-closed scope gates; повторить audit | Нет | Final verdict `PASS` | Исполняемый test/delivery contract проверен после последних правок | Эта spec, source, commands |
 | SPEC | Approval gate | 1.00 | Нет | Перейти к EXEC в exact allowlist | Да | Пользователь: `Спеку подтверждаю` | Roadmap-required child approval получен 2026-07-18 | Эта spec |
+| EXEC | Deterministic RED и implementation | 1.00 | Нет | Реализовать same-lock seal, shared cleanup и 147 migrations | Нет | Не применимо | RED упал только на ожидаемом old-order marker; targeted GREEN подтвердил новый порядок | ViewModel seam, fixture, consumers, lifecycle tests |
+| EXEC | Initial Post-EXEC reviews | 0.98 | Нужна была проверка edge ownership | Исправить fail-open barrier, unconnected storage ownership и clean-worktree gate | Нет | Architect/delivery `NEEDS-FIX`, tester `PASS` | Findings затрагивали false-success deletion/delivery, поэтому исправлены до full suites | Fixture, lifecycle regression, spec gate |
+| EXEC | Fix and re-review | 1.00 | Нет | Повторить targeted/stress/full validation | Нет | Architect/tester re-review `PASS` | Fail-closed barrier получил отдельный regression; owned storage единый | Fixture, lifecycle tests |
+| EXEC | Headless false-await diagnosis | 1.00 | Нет | Исправить wrapper, 18 source call sites и добавить regressions | Нет | Independent migration review | Correct residual gate связал false green с 20 незавершёнными callbacks/directories | Headless wrapper, Safe tests, Roadmap, Settings |
+| EXEC | Roadmap isolation and fidelity | 1.00 | Нет | Drain active builds, сохранить исходную ошибку и пройти через реальные menu items | Нет | Reviewer findings accepted; final verdict `PASS` | Order-dependent Drop failure и direct command bypass получили focused fixes без production UI change | Roadmap UI tests |
+| EXEC | Full local validation | 1.00 | Только GitHub required checks | Commit/push/draft PR, затем green/ready/merge | Нет | Не применимо | 20×4/4, Safe 2/2, Settings 12/12, Roadmap 31/31, unit 606/606, Headless 31/31, marker/residual/scope gates PASS | 8 final evidence logs, 28 allowlisted paths |

--- a/specs/2026-07-17-test-fixture-lifecycle.md
+++ b/specs/2026-07-17-test-fixture-lifecycle.md
@@ -1,0 +1,798 @@
+# Асинхронный lifecycle тестовой fixture
+
+## 0. Метаданные
+- Тип (профиль): CI / .NET test infrastructure / TUnit lifecycle.
+- Владелец: Unlimotion maintainers.
+- Масштаб: medium — одна корневая гонка, минимальный internal producer barrier в ViewModel и 147 consumer call sites в 21 test file.
+- Целевое семейство / behavior baseline: Не применимо — задача не меняет model/prompt behavior.
+- Поверхность: Codex implementation, Microsoft.Testing.Platform/TUnit local runner и GitHub Actions `All tests`.
+- Effective runtime: `global.json` minimum .NET SDK `10.0.100` с `rollForward=latestFeature`; фактически локально и в проверенном CI run resolved `10.0.302`; `net10.0`; TUnit `1.44.0`; Microsoft.Testing.Platform; `windows-latest`; `--maximum-parallel-tests 1`.
+- Eval baseline / evidence:
+  - PR #274 run `29584922060`, attempt 1, job `87899423421`: 600 total, 599 succeeded, 1 отдельный UI failure, затем три unobserved `FileNotFoundException` из удалённых `MainWindowViewModelFixture_*`; длительность 6m26s;
+  - тот же run, attempt 2, job `87902291442`: test assembly стартовала, assertion output отсутствовал, job отменён по 30-minute timeout; это согласуется с lifecycle race, но самостоятельно не доказывает ту же причину;
+  - в текущей рабочей сессии локальный full-suite прогон на том же head вошёл в low-CPU/no-output hang; discovery, одиночный тест и класс отдельного UI failure завершались; durable log этого локального наблюдения не сохранён, поэтому оно не используется как самостоятельное доказательство root cause;
+  - source inventory: 147 вызовов `CleanTasks()` в 21 файле.
+- Целевой релиз / ветка: base `origin/main@5aebebcb34eabe35fcdb7a47ff76ffdc2a7e16dd`; branch `fix/test-fixture-lifecycle`; отдельный PR в `main` до повторного CI/merge PR #274.
+- Ограничения:
+  - до отдельной точной approval-фразы изменялась только эта spec; gate пройден 2026-07-18;
+  - EXEC меняет `src/Unlimotion.Test`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs` и новый `src/Unlimotion.ViewModel/AssemblyInfo.cs`; другие paths запрещены без повторной review/approval;
+  - production storage/model/workflow semantics не меняются; единственное production-assembly изменение — internal save-shutdown seam в `TaskItemViewModel` и friend-assembly declaration для тестов;
+  - child-spec является sequencing prerequisite, а не Stage 2 implementation.
+- Связанные ссылки:
+  - master roadmap: `specs/2026-07-17-readme-reliability-roadmap.md` в PR #274;
+  - PR #274: <https://github.com/Kibnet/Unlimotion/pull/274>;
+  - failing/timed-out run: <https://github.com/Kibnet/Unlimotion/actions/runs/29584922060>;
+  - attempt-1 job: <https://github.com/Kibnet/Unlimotion/actions/runs/29584922060/job/87899423421>;
+  - attempt-2 job: <https://github.com/Kibnet/Unlimotion/actions/runs/29584922060/job/87902291442>.
+
+## 1. Overview / Цель
+Сделать владельцем завершения фоновых test-fixture writes один awaitable cleanup contract: атомарно запретить регистрацию новых saves, дождаться уже зарегистрированных, затем ровно один раз dispose/delete и явно сообщить об ошибках. Это устраняет наблюдаемую гонку `delayed save/enumeration -> fixture directory deletion`, не меняя обычное production behavior.
+
+Outcome contract:
+- Success means:
+  - детерминированный lifecycle regression сначала RED на старом порядке и GREEN после исправления;
+  - два конкурентных/повторных cleanup caller ждут одну и ту же task;
+  - каталог и task file существуют, пока controlled save заблокирован, и удалены после его release;
+  - старых синхронных `CleanTasks()` call sites нет;
+  - targeted test проходит 20 последовательных запусков;
+  - full `Unlimotion.Test` и `Unlimotion.UiTests.Headless` проходят serially без `Unobserved task exception` и без timeout;
+  - отдельный PR green/ready/merged; затем PR #274 обновлён от `main`, повторно green/ready/merged.
+- Итоговый артефакт / output: узкий lifecycle diff (`TaskItemViewModel` internal barrier + test fixture/consumers), deterministic regressions, local validation logs, green GitHub Actions evidence и PR body с root-cause/rollback.
+- Stop rules:
+  - approval `Спеку подтверждаю` получен 2026-07-18; EXEC разрешён в утверждённом scope;
+  - STOP и новая design review, если требуется production change шире утверждённого internal save-shutdown seam;
+  - STOP и отдельная диагностика, если post-fix full suite сохраняет hang/unobserved exceptions при GREEN targeted regression;
+  - unrelated `Toolbar_EmojiFilters_AllItemTogglesEveryEmojiFilter` failure не исправляется в этом package и не выдаётся за lifecycle evidence.
+
+## 2. Текущее состояние (AS-IS)
+- `src/Unlimotion.Test/MainWindowViewModelFixture.cs:143-167` реализует синхронный `CleanTasks()`:
+  1. выставляет `isCleaned`;
+  2. синхронно вызывает `MainWindowViewModel.Dispose()` и storage/config dispose;
+  3. сразу удаляет config, expansion-state, tasks directory и fixture directory.
+- `MainWindowViewModelFixture.Try(Action)` делает три попытки с `Thread.Sleep(100)`, а последнюю ошибку молча теряет. Поэтому leaked directory или delete race могут выглядеть как успешный cleanup.
+- `TaskItemViewModel.ExecuteSaveCommand()` запускает `SaveItemCommand.Execute().ToTask()` fire-and-forget, но сохраняет task в `_pendingSaves`; `WaitForPendingSavesAsync()` уже является API для ожидания snapshot.
+- Save producer не имеют shutdown barrier:
+  - common property autosave проходит через `.Throttle(PropertyChangedThrottleTimeSpanDefault)`;
+  - repeater autosave проходит через `.Throttle(TimeSpan.FromSeconds(2))`;
+  - predicate `IsInitialized` вычисляется до throttle, поэтому смена provider после постановки события не отменяет отложенный callback.
+- Status save проходит через `TaskTreeManager.CanTransitionToStatus()`, который перечисляет весь graph через `Storage.GetAll()`.
+- `FileTaskStorage.GetAll()` читает каждый file внутри `Task.Run`; удаление fixture directory во время незавершённого enumeration/read даёт `FileNotFoundException`.
+- Initial load не является обнаруженным владельцем утечки:
+  - `MainWindowViewModel.Connect()` awaits `taskStorage.Init()`;
+  - `UnifiedTaskStorage.Init()` awaits `BuildInitialTaskViewsAsync()` и cache fill.
+- `.github/workflows/tests.yml` уже выполняет `Unlimotion.Test` и Headless serially с `--maximum-parallel-tests 1`; повышение timeout или уменьшение parallelism не исправляет отсутствующий await.
+- Синхронный cleanup используется 147 раз в 21 test file. `BaseModelTests` реализует `IDisposable`; два call sites в `LocalizationDisplayDefinitionTests` предварительно dispose ViewModel вручную и затем вызывают fixture cleanup.
+- TUnit `1.44.0` штатно вызывает `IAsyncDisposable.DisposeAsync()` и распространяет cleanup exception; локальные package XML/API подтверждают async disposer contract.
+
+CI evidence interpretation:
+- Attempt 1 напрямую подтверждает минимум три чтения из уже удалённых fixture directories.
+- Единственный assertion failure в attempt 1 относится к responsive emoji toolbar и не объясняет три lifecycle exceptions.
+- Attempt 2 подтверждает 30-minute no-result timeout после загрузки assembly. Он повышает приоритет lifecycle fix, но без стека не считается независимым доказательством одной и той же причины.
+
+## 3. Проблема
+Test fixture удаляет принадлежащие ей файлы до завершения фоновой работы, которая всё ещё использует эти файлы, а затем скрывает delete failures. Из-за отсутствия единого awaitable owner cleanup становится вероятностным: одиночные тесты проходят, а полный suite может оставить unobserved exceptions или зависнуть на finalization/teardown.
+
+## 4. Цели дизайна
+- Один async owner для drain, dispose и delete.
+- Детерминированная идемпотентность: все caller получают одну cleanup task и один результат/exception.
+- Atomic producer seal под тем же lock, который допускает и регистрирует save.
+- Drain единственного snapshot всех уже зарегистрированных pending saves до storage dispose/delete, включая completed/faulted tasks.
+- Явное распространение save/dispose/delete failures вместо ложного success.
+- Полная миграция test consumers на awaitable cleanup.
+- Сохранение normal production behavior, persistence schema, UI и CI topology; internal seam вызывается только fixture.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не менять `MainWindowViewModel`, `UnifiedTaskStorage`, `TaskTreeManager`, `FileTaskStorage` или `TaskSourceManager`.
+- Не менять normal autosave behavior `TaskItemViewModel`; разрешены только `_acceptingSaves` under-lock gate и internal seal API, вызываемый тестовой fixture.
+- Не добавлять cancellation pending save: cleanup после старта должен завершить write или явно упасть.
+- Не подавлять `TaskScheduler.UnobservedTaskException`.
+- Не ловить глобально `FileNotFoundException` и не ослаблять storage validation.
+- Не увеличивать GitHub Actions timeout и не менять test parallelism.
+- Не исправлять `Toolbar_EmojiFilters_AllItemTogglesEveryEmojiFilter` или любой другой unrelated assertion.
+- Не решать потенциальный production source-switch drain. Это отдельный MEDIUM follow-up без доказанной пользовательской потери данных.
+- Не менять README, master roadmap или Stage 2 contract в этом PR.
+- Не создавать UI video: production UI и user flow не меняются.
+
+## 6. Предлагаемое решение (TO-BE)
+
+### 6.1 Распределение ответственности
+- `MainWindowViewModelFixture`:
+  - реализует `IAsyncDisposable`;
+  - выдаёт один `Task CleanTasksAsync()` на весь lifecycle;
+  - закрывает VM-side producers, atomically seals task saves и ждёт returned snapshots до storage dispose/delete;
+  - выполняет bounded retry удаления и не скрывает terminal failure.
+- `BaseModelTests`:
+  - реализует `IAsyncDisposable` вместо `IDisposable`;
+  - awaits fixture cleanup через TUnit async lifecycle.
+- Каждый direct fixture owner:
+  - awaits `CleanTasksAsync()` в своём `finally`;
+  - для Headless сохраняет cleanup внутри dispatcher scope и завершает его до session dispose.
+- `MainWindowViewModelFixtureLifecycleTests`:
+  - владеет controlled-save regression и idempotency assertions.
+- `TaskItemViewModel`:
+  - под `_pendingSavesLock` атомарно проверяет `_acceptingSaves`, запускает и регистрирует save;
+  - internal seal под тем же lock запрещает новые saves и возвращает один snapshot всех зарегистрированных tasks.
+- `Unlimotion.ViewModel/AssemblyInfo.cs`:
+  - открывает internal lifecycle seam только assembly `Unlimotion.Test`.
+- GitHub Actions:
+  - остаётся без изменений и выступает delivery verifier.
+
+### 6.2 Детальный дизайн
+
+#### Async ownership и идемпотентность
+- У fixture появляется private lock и nullable `Task cleanupTask`.
+- `CleanTasksAsync()` не является `async` wrapper: под lock он один раз создаёт `CleanTasksCoreAsync()` и возвращает тот же object всем caller.
+- `DisposeAsync()` возвращает/awaits тот же cleanup operation.
+- Повторный caller после success получает completed task; после failure — ту же faulted task. Cleanup не запускается повторно и не превращает failure в success.
+- Старые `isCleaned` и public synchronous `CleanTasks()` удаляются после полной consumer migration; blocking `.GetAwaiter().GetResult()` adapter не сохраняется.
+
+#### Producer barrier и drain contract
+- `TaskItemViewModel` получает private `_acceptingSaves = true` под существующим `_pendingSavesLock`.
+- `ExecuteSaveCommand()` под этим lock:
+  1. возвращается без save, если `_acceptingSaves == false`;
+  2. иначе создаёт `SaveItemCommand.Execute().ToTask()` и добавляет task в `_pendingSaves` до release lock;
+  3. после lock запускает existing completion observer.
+- Internal `SealPendingSaves()` под тем же lock ставит `_acceptingSaves = false`, один раз создаёт и кэширует `Task.WhenAll(_pendingSaves.ToArray())` либо `Task.CompletedTask`, а повторно возвращает тот же sealed snapshot task.
+- Операции линейризуемы относительно одного lock: save либо зарегистрирован до seal и входит в returned snapshot, либо приходит после seal и становится no-op. Вероятностные `Yield`/quiet-window/sleep не используются.
+- Cleanup получает repository reference и синхронно вызывает `MainWindowViewModelTest.Dispose()`, закрывая VM-side producers, но оставляя task/storage живыми для завершения writes.
+- Затем снимается snapshot `taskRepository.Tasks.Items`; для каждого task синхронно вызывается `SealPendingSaves()`, из всех returned tasks ровно один раз создаётся outer `drainTask = Task.WhenAll(sealedSnapshots)`, и он awaits независимо от `IsCompleted`/`IsFaulted`.
+- После seal новые delayed property/repeater callbacks не могут зарегистрировать save; quiescence loop больше не нужен.
+- Cleanup API не принимает cancellation token. Внешний test timeout применяется только к regression await и не отменяет owned save.
+- Если captured save task faulted, cleanup всё равно пытается освободить resources/delete artifacts, затем возвращает fault. После await outer `drainTask` ошибки берутся из `drainTask.Exception!.Flatten().InnerExceptions`, а не только из exception, выброшенного `await`; outer task инспектируется ровно один раз, поэтому faults из вложенных `Task.WhenAll` не теряются и не дублируются.
+
+#### Dispose/delete contract
+- Полный порядок остаётся единым:
+  1. capture repository reference;
+  2. `MainWindowViewModelTest.Dispose()`;
+  3. snapshot task view models;
+  4. synchronously seal every task and capture returned pending tasks;
+  5. await every captured task, including already completed/faulted;
+  6. storage `IDisposable.Dispose()`;
+  7. configuration dispose;
+  8. config file delete;
+  9. expansion-state file delete;
+  10. tasks directory delete;
+  11. fixture directory delete.
+- Два ручных предварительных ViewModel dispose в `LocalizationDisplayDefinitionTests` удаляются: fixture — единственный владелец порядка.
+- Delete helper выполняет не более трёх попыток с async backoff; отсутствие path считается success.
+- После последней неудачи helper выбрасывает exception с operation/path и сохраняет inner exception.
+- Если drain/dispose/delete дали несколько ошибок, cleanup возвращает `AggregateException`, чтобы исходная lifecycle ошибка не была заменена последней delete error.
+
+#### Consumer migration
+- Все 147 `fixture.CleanTasks()`/`projectionFixture.CleanTasks()` call sites заменяются на awaited `CleanTasksAsync()`.
+- Существующие async test methods/lambdas сохраняются async; synchronous consumer при необходимости становится `async Task`.
+- `BaseModelTests.Dispose()` заменяется на `ValueTask DisposeAsync()`.
+- `RunWithTreeProjectionAsync` awaits `projectionFixture.CleanTasksAsync()` внутри `session.DispatchAsync`, затем outer finally awaits headless session dispose.
+- Nullable fixture cleanup использует явный null-check; null-conditional await не вводится.
+- Для fixture без `Connect()` `taskRepository == null`: cleanup пропускает snapshot/seal/drain/storage-dispose, но ровно один раз dispose MainWindow/config и удаляет temp paths.
+- В четырёх callers, где после cleanup обязательно восстанавливается global state (две localization, application font resources, requested theme), restore помещается во вложенный `finally`, чтобы cleanup fault его не пропустил.
+
+#### Deterministic regression
+Новый тест `MainWindowViewModelFixtureLifecycleTests.CleanTasksAsync_ConcurrentCallersWaitForInFlightSaveBeforeDirectoryDeletion`:
+1. Создаёт fixture и awaits `MainWindowViewModelTest.Connect()`.
+2. Выбирает существующий task и заменяет public `SaveItemCommand` контролируемой command с `started`/`release` `TaskCompletionSource`, созданными с `RunContinuationsAsynchronously`; сразу подписывает `ThrownExceptions` наблюдающим test observer, чтобы expected fault не ушёл в ReactiveUI default exception handler.
+3. Меняет `Status` на другое значение, чтобы existing `ExecuteSaveCommand()` зарегистрировал task в `_pendingSaves`.
+4. Awaits `started`.
+5. Вызывает `CleanTasksAsync()` дважды и `DisposeAsync().AsTask()` один раз; fixture disposes MainWindow, seals task saves и все три caller ждут одну core operation.
+6. Пока первая command заблокирована, повторно меняет status и проверяет, что invocation count остаётся `1`: producer barrier не допускает save после seal.
+7. До `release` не бросает assertion: записывает `sameCleanTask`, `disposeJoinedSameOperation`, `completedBeforeRelease`, existence files/directories и invocation count. Это нужно, чтобы old-order command fault после release не заменил ожидаемый RED marker.
+8. Освобождает `release`; каждый реально начат controlled invocation затем вызывает `repository.Update(task)`, то есть проходит production `TaskTreeManager`/`Storage.GetAll` path.
+9. Bounded-observes все cleanup references и все command execution tasks, сохраняя exception как данные; затем первой проверкой делает `completedBeforeRelease == false` с точным message `cleanup completed before controlled save release`. После неё проверяет same-operation, invocation count, отсутствие command fault и удаление directories.
+10. `finally` всегда выполняет `release.TrySetResult()`, bounded-observe без throw всех уже созданных cleanup/command tasks, затем dispose `ThrownExceptions` subscription и controlled command. Сам regression не оставляет teardown/background work и не маскирует primary test failure даже при раннем setup/timeout failure.
+
+Для RED gate сначала добавляется тест и минимальный compile seam, который делегирует текущему synchronous cleanup. Ожидаемый RED: cleanup завершается/удаляет directory до `release`. После этого реализуется async owner contract.
+
+#### Visual planning и UI evidence
+- Visual planning artifact: Не применимо — production layout, copy и interaction не меняются.
+- UI test video evidence: Не применимо — это test-infrastructure teardown fix; evidence дают deterministic lifecycle test, Headless suite и CI logs.
+- Headless suite всё равно обязателен, потому что consumer inventory включает Avalonia Headless flows и меняется их teardown ordering.
+
+#### Performance
+- Normal cleanup добавляет lock-only seal и ожидание только реально зарегистрированных saves; delayed callbacks после seal становятся no-op.
+- Нельзя добавлять unconditional multi-second sleeps.
+- Таргетированный test stress должен завершаться в bounded time; full suite должен укладываться в существующий 30-minute CI timeout без его изменения.
+
+### 6.3 User-Observable Scenarios
+
+| Scenario | User action / trigger | Expected visible result / output | Evidence required | Covered by AC |
+| --- | --- | --- | --- | --- |
+| Maintainer запускает один lifecycle regression | Targeted TUnit command | Test reliably GREEN after fix and RED on old ordering | RED/GREEN logs | TF-AC-01,02 |
+| Maintainer запускает full test workflow | Local/PR serial suites | Suite completes; no fixture `FileNotFoundException`, unobserved task or timeout | full logs + GitHub check | TF-AC-08,10 |
+| Два teardown path вызывают cleanup | Concurrent/repeated calls | Оба await same completion/failure; delete executes once | regression assertions | TF-AC-01,03 |
+| Unrelated emoji UI assertion снова flakes | Full suite | Failure остаётся видимой и классифицируется отдельно; lifecycle code не расширяется | targeted rerun + PR note | TF-AC-09,10 |
+
+### 6.4 State / Interaction Matrix
+
+| Current state | Trigger | Expected transition/result | Empty/error/disabled/concurrent case | Notes |
+| --- | --- | --- | --- | --- |
+| No cleanup started, no pending saves | First `CleanTasksAsync` | dispose producers -> atomic seal -> dispose storage/config -> delete -> completed | Empty repository allowed | No blocking adapter |
+| Fixture created, `Connect()` не вызван | First cleanup | skip task seal/drain, dispose config/VM, delete paths | `taskRepository == null` | Dedicated regression |
+| No cleanup started, pending save active | First cleanup | waits; files stay present | Save failure recorded, cleanup still releases resources | Core regression |
+| Cleanup running | Second cleanup | returns same task | No second dispose/delete | Reference equality asserted |
+| Cleanup completed | Later cleanup | returns same completed task | No-op observable as same result | Idempotent |
+| Cleanup faulted | Later cleanup | returns same faulted task | Failure not swallowed/retried | Diagnostic stability |
+| Delete transiently locked | Delete helper | bounded retry then success | Final failure includes path | No `Thread.Sleep` |
+| Headless dispatcher active | Inner finally | awaited cleanup inside dispatcher | Session dispose only afterwards | Preserves affinity/order |
+
+### 6.5 Decision Ledger
+
+| Decision | Owner | Default / chosen option | Confidence | Risk if assumed | Needs user before EXEC |
+| --- | --- | --- | ---: | --- | --- |
+| Scope | agent | test fixture/consumers + internal `TaskItemViewModel` producer barrier/friend declaration | 0.99 | Без same-lock seal delayed throttle сохраняет гонку; более широкий runtime scope неоправдан | Нет |
+| Cleanup API | agent | `Task CleanTasksAsync` + `IAsyncDisposable` | 0.99 | Blocking cleanup can deadlock and preserve race | Нет |
+| Idempotency | agent | one shared cleanup task, including shared fault | 0.99 | Duplicate dispose/delete introduces new races | Нет |
+| Pending saves | agent | same-lock atomic seal + one full snapshot, no cancellation | 0.99 | Yield/quiet-window не закрывают delayed producer; cancellation может потерять write | Нет |
+| Delete failures | agent | bounded async retry, then propagate/aggregate | 0.98 | Silent leak recreates false success | Нет |
+| UI flake | agent | explicitly separate package | 0.99 | Scope creep and unverifiable root-cause claim | Нет |
+| Production source switching | agent | MEDIUM follow-up, not this EXEC | 0.90 | Similar risk is possible but not proven | Нет |
+| Approval | user | exact new child-spec approval required | 1.00 | Roadmap governance would be bypassed | Да, самой фразой approval |
+
+### 6.6 Runtime / Config / Data Contract Matrix
+
+| Contract area | Current source of truth | Expected change | Compatibility / migration | Verification |
+| --- | --- | --- | --- | --- |
+| Test lifecycle | `MainWindowViewModelFixture.CleanTasks()` | async shared cleanup task | all test callers migrated atomically | build + zero old calls |
+| TUnit instance cleanup | `BaseModelTests : IDisposable` | `IAsyncDisposable` | TUnit 1.44 supported | base-class tests + full suite |
+| Save admission | `TaskItemViewModel.ExecuteSaveCommand()` + `_pendingSavesLock` | internal same-lock `_acceptingSaves`/`SealPendingSaves()` | normal runtime flag stays true; seam доступен только friend test assembly | producer-barrier regression |
+| Pending saves | `TaskItemViewModel.WaitForPendingSavesAsync()` | existing API unchanged; fixture uses sealed one-time snapshot | no data/schema change | controlled real-storage regression |
+| File cleanup | silent `Try(Action)` | bounded async retry + surfaced path | test temp paths only | mandatory injected delete-failure tests + full suite |
+| CI | `.github/workflows/tests.yml` | unchanged | existing 30m/serial contract retained | PR checks |
+| Persisted data | fixture temp files | no schema/content change | none | diff inspection |
+
+## 7. Бизнес-правила / Алгоритмы
+Lifecycle invariants:
+1. `sealLinearized => no later ExecuteSaveCommand can register a save`.
+2. `deleteStarted => every save registered before seal completed`.
+3. Пока controlled save pending, `tasksDirectoryExists == true`.
+4. `CleanTasksAsync()` создаёт не более одной core operation.
+5. Повторные caller наблюдают одинаковый completion или одинаковый failure.
+6. Cleanup failure никогда не становится success из-за retry exhaustion/swallow.
+7. Save cancellation не используется как способ ускорить teardown.
+8. Normal production autosave и workflow settings не меняются; internal seal вызывается только test fixture.
+
+Atomic seal algorithm:
+1. Capture repository reference and dispose MainWindow-side subscriptions.
+2. If repository is null, skip task/storage branch and continue resource deletion.
+3. Snapshot task view models.
+4. Under each task's `_pendingSavesLock`, set `_acceptingSaves = false` and capture `Task.WhenAll` over all current saves, including completed/faulted.
+5. Create one outer `drainTask = Task.WhenAll(sealedSnapshots)`, await it once, and on fault retain every `drainTask.Exception!.Flatten().InnerExceptions` entry once.
+6. Dispose storage/config and delete paths; retain cleanup failures.
+7. Throw the single retained error or one `AggregateException` without duplicate entries.
+
+## 8. Точки интеграции и триггеры
+- TUnit test-class teardown вызывает `BaseModelTests.DisposeAsync()`.
+- Direct test `finally` blocks вызывают `await fixture.CleanTasksAsync()`.
+- Headless dispatcher lambdas выполняют awaited cleanup до `SafeHeadlessUnitTestSession.DisposeAsync()`.
+- `TaskItemViewModel.ExecuteSaveCommand()` и internal `SealPendingSaves()` используют один `_pendingSavesLock` как admission/join barrier.
+- Controlled status mutation вызывает existing `TaskItemViewModel.ExecuteSaveCommand()`; test не обращается к `_pendingSaves` напрямую.
+- GitHub pull request запускает unchanged `.github/workflows/tests.yml`.
+- После merge fix PR ветка PR #274 обновляется от `main`, что повторно запускает required checks.
+
+## 9. Изменения модели данных / состояния
+- Production model/data/schema и normal runtime output: не меняются.
+- Internal ViewModel lifecycle state:
+  - добавляется `_acceptingSaves`, изначально `true`;
+  - `SealPendingSaves()` необратимо переводит конкретный task VM в test-teardown state;
+  - seam не сериализуется и не вызывается normal runtime path.
+- Test fixture state:
+  - удаляется `bool isCleaned`;
+  - добавляются cleanup lock и `Task? cleanupTask`;
+  - при необходимости добавляется test-visible read-only fixture directory path для assertions.
+- Persisted fixture files остаются прежними и удаляются только после drain.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция выполняется атомарно в одном lifecycle PR: internal seal, async fixture API и все 147 callers меняются вместе.
+- Нет runtime/user data migration.
+- Rollout:
+  1. deterministic RED/GREEN locally;
+  2. 20x targeted stress;
+  3. full local unit + Headless suites;
+  4. draft PR, green required checks, ready/merge;
+  5. rebase/update PR #274, green checks, ready/merge.
+- Rollback: revert lifecycle PR. Это вернёт прежнюю CI race, но не затронет production data/schema; normal runtime не требует migration.
+- Нельзя откатывать частично только consumer awaits или только fixture API.
+
+## 11. Тестирование и критерии приёмки
+
+### Acceptance Criteria
+- **TF-AC-01:** `CleanTasksAsync()`/`DisposeAsync()` используют одну shared core task; concurrent mixed `CleanTasksAsync()` + `DisposeAsync().AsTask()`, repeated-after-success и repeated-after-failure caller не запускают второй dispose/delete и получают тот же completion/fault; две прямые `CleanTasksAsync()` references и `DisposeAsync().AsTask()` reference равны.
+- **TF-AC-02:** Same-lock seal линейризуется с `ExecuteSaveCommand`: controlled in-flight status save остаётся pending; post-seal status mutation не запускает вторую command; до release files существуют; после release controlled command выполняет реальный `repository.Update(task)`, cleanup завершается и directories отсутствуют.
+- **TF-AC-03:** Минимум два captured in-flight save failures из разных sealed snapshots и boundary-observable delete failure не скрываются; terminal delete failure содержит operation/path; combined failures дают один aggregate с каждой из трёх причин ровно один раз; existing inner `DisposableList.Dispose()` swallowing не расширяется этой spec и явно остаётся accepted limitation.
+- **TF-AC-04:** `BaseModelTests` использует TUnit async disposal; Headless cleanup остаётся внутри dispatcher до session disposal; четыре global-state restoration path выполнены во вложенном `finally` даже при cleanup fault.
+- **TF-AC-05:** Fixture без `Connect()`/repository очищается успешно, повторно идемпотентна и удаляет config/tasks/fixture paths.
+- **TF-AC-06:** Все 147 старых `.CleanTasks()` call sites в 21 файле мигрированы; `rg -n "\.CleanTasks\(\)" src/Unlimotion.Test` не находит совпадений; два manual pre-dispose удалены.
+- **TF-AC-07:** New lifecycle class содержит минимум три обязательных regression и проходит targeted run и 20 последовательных запусков с `--maximum-parallel-tests 1`.
+- **TF-AC-08:** Full `Unlimotion.Test` выполняет минимум 603 tests, а `Unlimotion.UiTests.Headless` — минимум 31 test; оба serial suites PASS в существующем 30-minute CI budget, bounded local runs не timeout и logs не содержат fixture `FileNotFoundException`/`Unobserved task exception`.
+- **TF-AC-09:** Diff ограничен этой spec, `src/Unlimotion.Test/**`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs` и новым `src/Unlimotion.ViewModel/AssemblyInfo.cs`; workflow, UI behavior и unrelated emoji assertion не меняются.
+- **TF-AC-10:** Fix PR green/ready/merged; PR #274 body обновлён точной root cause/validation/link на fix PR, branch обновлена от merge, required checks green, PR ready/merged до Stage 2 production EXEC.
+
+### Tests to add/update
+- New `MainWindowViewModelFixtureLifecycleTests`:
+  - `CleanTasksAsync_ConcurrentCallersWaitForInFlightSaveBeforeDirectoryDeletion`;
+  - `CleanTasksAsync_RepeatedCallAfterSaveAndDeleteFailuresReturnsSameAggregate`: два controlled saves на разных task VM сигнализируют `started` и остаются pending до seal, затем после общего `release` faulted двумя различимыми exceptions; injected test-only delete operation исчерпывает все три попытки; test проверяет ровно три причины без потерь/дублей, operation/path, один cleanup task и отсутствие повторного delete при повторном caller;
+  - `CleanTasksAsync_UnconnectedFixtureDeletesOwnedPathsOnce`.
+- Failure injection обязателен и остаётся внутри fixture/test assembly: cleanup operations/deletion delegate можно заменить в regression, normal constructor использует real filesystem.
+- Каждая controlled replacement `ReactiveCommand` имеет test-owned `ThrownExceptions` subscription; subscription и command dispose только после bounded observation всех её invocations.
+- Update all direct cleanup consumers and `BaseModelTests` lifecycle signatures.
+- No new FlaUI/video test: no production UI behavior change.
+
+### Characterization baseline
+- `rg` inventory: 147 old calls / 21 files.
+- PR #274 run attempt 1: 600 total, 599 pass, 1 unrelated UI failure, three fixture `FileNotFoundException` unobserved exceptions.
+- PR #274 run attempt 2: no assertion result, 30m timeout after assembly start.
+- В текущей сессии baseline Headless run прошёл 31 test; durable log не сохранён, поэтому `--minimum-expected-tests 31` заново подтверждает count в EXEC evidence.
+- Unchanged workflow already serializes tests.
+
+### Commands
+Evidence directory, bounded process helper и restore:
+
+```powershell
+$evidenceDir = Join-Path (Get-Location) 'artifacts/test-fixture-lifecycle'
+New-Item -ItemType Directory -Force $evidenceDir | Out-Null
+
+function Stop-ProcessTree([int]$ProcessId) {
+    Get-CimInstance Win32_Process -Filter "ParentProcessId = $ProcessId" |
+        ForEach-Object { Stop-ProcessTree -ProcessId $_.ProcessId }
+    Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
+}
+
+function Invoke-BoundedDotnetTest {
+    param(
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [int] $TimeoutSeconds,
+        [Parameter(Mandatory)] [string[]] $Arguments,
+        [switch] $ExpectFailure
+    )
+
+    $stdout = Join-Path $evidenceDir "$Name.stdout.log"
+    $stderr = Join-Path $evidenceDir "$Name.stderr.log"
+    $process = Start-Process dotnet `
+        -ArgumentList $Arguments `
+        -NoNewWindow `
+        -PassThru `
+        -RedirectStandardOutput $stdout `
+        -RedirectStandardError $stderr
+
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+        Stop-ProcessTree -ProcessId $process.Id
+        throw "Timed out after $TimeoutSeconds seconds: $Name"
+    }
+
+    $process.WaitForExit()
+    Get-Content $stdout
+    if (Test-Path $stderr) { Get-Content $stderr }
+    if ($ExpectFailure -and $process.ExitCode -eq 0) {
+        throw "Expected failing test run succeeded unexpectedly: $Name"
+    }
+    if (-not $ExpectFailure -and $process.ExitCode -ne 0) {
+        throw "dotnet test failed with exit code $($process.ExitCode): $Name"
+    }
+}
+
+dotnet restore src/Unlimotion.Test/Unlimotion.Test.csproj
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+dotnet restore tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+```
+
+Build после добавления tests и минимального compile seam:
+
+```powershell
+dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj `
+  -c Debug `
+  --no-restore `
+  -p:UseSharedCompilation=false
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+```
+
+Deterministic RED до implementation. Test использует assertion message `cleanup completed before controlled save release`; timeout, crash или другой failure не принимаются как RED:
+
+```powershell
+Invoke-BoundedDotnetTest `
+  -Name 'targeted-red' `
+  -TimeoutSeconds 180 `
+  -ExpectFailure `
+  -Arguments @(
+      'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
+      '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
+      '--treenode-filter', '/*/*/MainWindowViewModelFixtureLifecycleTests/CleanTasksAsync_ConcurrentCallersWaitForInFlightSaveBeforeDirectoryDeletion',
+      '--minimum-expected-tests', '1',
+      '--maximum-parallel-tests', '1', '--output', 'Detailed')
+
+$redLog = Join-Path $evidenceDir 'targeted-red.stdout.log'
+if (-not (Select-String -LiteralPath $redLog -SimpleMatch 'cleanup completed before controlled save release' -Quiet)) {
+    throw 'Targeted RED did not fail at the expected lifecycle assertion.'
+}
+```
+
+Targeted lifecycle GREEN после implementation:
+
+```powershell
+Invoke-BoundedDotnetTest `
+  -Name 'targeted-green' `
+  -TimeoutSeconds 180 `
+  -Arguments @(
+      'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
+      '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
+      '--treenode-filter', '/*/*/MainWindowViewModelFixtureLifecycleTests/*',
+      '--minimum-expected-tests', '3',
+      '--maximum-parallel-tests', '1', '--output', 'Detailed')
+```
+
+Stress:
+
+```powershell
+1..20 | ForEach-Object {
+    Invoke-BoundedDotnetTest `
+      -Name ('stress-{0:D2}' -f $_) `
+      -TimeoutSeconds 180 `
+      -Arguments @(
+          'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
+          '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
+          '--treenode-filter', '/*/*/MainWindowViewModelFixtureLifecycleTests/*',
+          '--minimum-expected-tests', '3',
+          '--maximum-parallel-tests', '1', '--output', 'Detailed')
+}
+```
+
+Full workflow equivalent:
+
+```powershell
+Invoke-BoundedDotnetTest `
+  -Name 'full-unlimotion' `
+  -TimeoutSeconds 1200 `
+  -Arguments @(
+      'test', 'src/Unlimotion.Test/Unlimotion.Test.csproj',
+      '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
+      '--minimum-expected-tests', '603',
+      '--maximum-parallel-tests', '1', '--output', 'Detailed')
+
+Invoke-BoundedDotnetTest `
+  -Name 'full-headless' `
+  -TimeoutSeconds 300 `
+  -Arguments @(
+      'test', 'tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj',
+      '-c', 'Debug', '--no-restore', '-p:UseSharedCompilation=false', '--',
+      '--minimum-expected-tests', '31',
+      '--maximum-parallel-tests', '1', '--output', 'Detailed')
+
+$greenLogs = Get-ChildItem $evidenceDir -Filter '*.log' |
+    Where-Object Name -Match '^(targeted-green|stress-\d+|full-(unlimotion|headless))\.(stdout|stderr)\.log$'
+$greenLogText = ($greenLogs | ForEach-Object {
+    Get-Content -LiteralPath $_.FullName -Raw
+}) -join "`n"
+$lifecycleMarkers = 'Unobserved task exception|FileNotFoundException[\s\S]{0,2000}MainWindowViewModelFixture_|MainWindowViewModelFixture_[\s\S]{0,2000}FileNotFoundException'
+if ($greenLogText -match $lifecycleMarkers) {
+    throw 'Lifecycle exception marker found in validation logs.'
+}
+```
+
+Static scope gates:
+
+```powershell
+$oldCleanupCalls = @(rg -n "\.CleanTasks\(\)" src/Unlimotion.Test)
+$oldCleanupExit = $LASTEXITCODE
+if ($oldCleanupExit -eq 0) {
+    $oldCleanupCalls
+    throw 'Synchronous CleanTasks call sites remain.'
+}
+if ($oldCleanupExit -ne 1) {
+    throw "rg inventory failed with exit code $oldCleanupExit"
+}
+
+$allowedPatterns = @(
+    '^specs/2026-07-17-test-fixture-lifecycle\.md$',
+    '^src/Unlimotion\.Test/',
+    '^src/Unlimotion\.ViewModel/TaskItemViewModel\.cs$',
+    '^src/Unlimotion\.ViewModel/AssemblyInfo\.cs$'
+)
+
+function Assert-Allowlisted([string[]] $Paths) {
+    $unexpected = @($Paths | Where-Object {
+        $path = $_
+        -not ($allowedPatterns | Where-Object { $path -match $_ })
+    })
+    if ($unexpected.Count -gt 0) {
+        $unexpected
+        throw 'Diff contains paths outside the approved allowlist.'
+    }
+}
+
+$status = @(git status --short)
+if ($LASTEXITCODE -ne 0) { throw 'git status failed.' }
+$status
+
+$worktreePaths = @(git diff --name-only origin/main)
+if ($LASTEXITCODE -ne 0) { throw 'git diff origin/main failed.' }
+$untrackedPaths = @(git ls-files --others --exclude-standard)
+if ($LASTEXITCODE -ne 0) { throw 'git ls-files failed.' }
+Assert-Allowlisted -Paths @(($worktreePaths + $untrackedPaths) | Select-Object -Unique)
+
+git diff --check
+if ($LASTEXITCODE -ne 0) { throw 'Worktree diff check failed.' }
+
+# После intentional staging implementation paths:
+git diff --cached --check
+if ($LASTEXITCODE -ne 0) { throw 'Staged diff check failed.' }
+$stagedPaths = @(git diff --cached --name-only origin/main)
+if ($LASTEXITCODE -ne 0) { throw 'Staged path inventory failed.' }
+Assert-Allowlisted -Paths $stagedPaths
+
+# После commit implementation:
+$committedPaths = @(git diff --name-only origin/main...HEAD)
+if ($LASTEXITCODE -ne 0) { throw 'Committed path inventory failed.' }
+Assert-Allowlisted -Paths $committedPaths
+git diff --check origin/main...HEAD
+if ($LASTEXITCODE -ne 0) { throw 'Committed diff check failed.' }
+```
+
+Expected `rg` result: exit code 1/no matches; exit 0 и infrastructure error fail closed. Allowlist проверяет tracked, untracked, staged и committed paths: this spec, `src/Unlimotion.Test/**`, `src/Unlimotion.ViewModel/TaskItemViewModel.cs`, `src/Unlimotion.ViewModel/AssemblyInfo.cs`.
+
+Test loop stop rules:
+- Targeted test timeout uses `WaitAsync` and fails; it does not cancel/release cleanup invisibly.
+- One RED observation is enough before implementation; do not use probabilistic repetition as root-cause proof.
+- Any post-fix lifecycle regression failure stops full-suite runs.
+- Full suite timeout or lifecycle exception after GREEN target stops delivery and reopens diagnosis.
+- Unrelated UI assertion gets isolated rerun/evidence and separate scope; required check still must become green before merge.
+
+### Acceptance-to-Test Matrix
+
+| Acceptance criterion | Automated test | Manual / visual / log check | Evidence artifact | If not tested, why |
+| --- | --- | --- | --- | --- |
+| TF-AC-01 | concurrent/success/failure idempotency tests | inspect shared-task implementation | targeted log | — |
+| TF-AC-02 | controlled real-storage in-flight save + post-seal mutation | RED/GREEN comparison | `targeted-red/green` logs | — |
+| TF-AC-03 | mandatory combined save/delete failure regression | inspect aggregate entries/path | targeted log + diff | Existing inner `DisposableList` swallowing is documented limitation |
+| TF-AC-04 | affected base/Headless tests + nested-finally source assertions | inspect dispatcher/global-state ordering | full logs | — |
+| TF-AC-05 | unconnected fixture regression | inspect null-repository branch | targeted log | — |
+| TF-AC-06 | build + zero-match `rg` | compare expected 147/21 inventory | static-check output | — |
+| TF-AC-07 | targeted + 20x stress with minimum count | bounded elapsed time | `stress-*.log` | — |
+| TF-AC-08 | two bounded full serial runs with minimum counts | search logs for lifecycle markers | full logs + Actions URL | — |
+| TF-AC-09 | pre/post-commit scope gates | allowlist review | Post-EXEC review | — |
+| TF-AC-10 | GitHub required checks + PR #274 body/ancestry | inspect root-cause/link/check states | two PR URLs/check summaries | — |
+
+## 12. Риски и edge cases
+- Delayed producer может попытаться сохранить после cleanup start. Mitigation: same-lock atomic seal; post-seal mutation regression.
+- 147 mechanical conversions могут оставить один unawaited finally. Mitigation: zero-match `rg`, compile, full suite.
+- `async void` может появиться при неверной конверсии lambda/method. Mitigation: signatures review; разрешены только `async Task`/`ValueTask` lifecycle paths.
+- Cleanup exception в прямом C# `finally` может заменить body exception. Mitigation: accepted limitation явно указан; cleanup errors сохраняются внутри своего aggregate, а global state восстанавливается nested `finally`. TUnit `IAsyncDisposable` path отдельно проверяется.
+- Delete retry может удлинить teardown. Mitigation: bounded three attempts, async backoff, path-specific failure.
+- Headless session может быть disposed раньше fixture. Mitigation: cleanup остаётся внутри dispatcher; explicit regression/review.
+- Attempt-2 timeout может иметь другую причину. Mitigation: не заявлять доказанную идентичность; требовать deterministic regression и полный post-fix green suite.
+- Unrelated emoji UI flake может снова сделать required check red. Mitigation: isolate and address only через отдельную approved package; не ослаблять assertion в этом diff.
+- Production source switch имеет похожий потенциальный risk. Mitigation: отдельный follow-up spec/evidence, без scope expansion здесь.
+
+### Expected User Review Objections
+
+| Likely objection | Why likely | Mitigation in spec/code plan | Status |
+| --- | --- | --- | --- |
+| Почему всё же меняется `TaskItemViewModel`? | Root проявился в fixture | Без same-lock producer seal queued 2-second repeater callback может появиться после snapshot; internal friend-only seam не меняет normal runtime | mitigated |
+| Почему нельзя просто увеличить timeout? | Видимый симптом — 30m timeout | Attempt 1 уже показывает delete/read race; timeout не добавляет await и не устраняет unobserved exceptions | mitigated |
+| Почему менять 147 мест? | Большой mechanical diff | Blocking adapter сохраняет неправильный lifecycle; compile + zero-match + full suite контролируют migration | mitigated |
+| Как доказать, что это не вероятностная попытка? | Полный suite нестабилен | Controlled `started/release` interleaving задаёт детерминированный RED/GREEN | mitigated |
+| Не скрываем ли отдельную UI-флейку? | Attempt 1 содержит UI failure | Она явно non-goal и остаётся required-check blocker, если повторится | mitigated |
+
+### Rework Prevention Checklist
+- User-visible output назван: green deterministic/full CI evidence и merge sequencing.
+- Каждый observable scenario связан с AC/evidence.
+- Все agent decisions зафиксированы; product/runtime choice не скрыт.
+- Вероятные objections перечислены и закрыты.
+- Tester/architect/delivery roles обязательны; UX marked not applicable с причиной.
+- AC проверяют выполненный результат, а не только подготовительные шаги.
+- EXEC содержит RED/GREEN, stress, full-suite, static scope и GitHub proof path.
+
+## 13. План выполнения
+1. Получить отдельную точную approval-фразу для этой child spec — выполнено 2026-07-18.
+2. Freshness gate: fetch, проверить `origin/main` base/branch, clean tree, PR #274 state.
+3. Добавить deterministic regression и минимальный compile seam; зафиксировать ожидаемый RED.
+4. Реализовать same-lock atomic producer seal в `TaskItemViewModel`, friend-only internal seam, shared async cleanup owner и dispose/delete error contract.
+5. Перевести `BaseModelTests` и все 147 call sites; удалить manual pre-dispose, сохранить unconnected-fixture path и вложенное восстановление четырёх global-state owners.
+6. Запустить build, bounded targeted GREEN, 20x stress, minimum-count/static/log-marker gates.
+7. Запустить full `Unlimotion.Test` и Headless serially; разобрать любой failure без scope masking.
+8. Выполнить Post-EXEC review и independent re-review после fixes.
+9. Commit/push; открыть draft PR с Summary/Changes/Validation/Risks-Rollback/Links; дождаться green checks, перевести ready и merge.
+10. Обновить body PR #274 точной root cause, validation evidence и ссылкой на merged fix PR; обновить branch от merged `main`, проверить ancestry и rerun required checks; только green PR перевести ready и merge.
+11. Вернуться на `fix/status-availability-contract`, rebase на новый `origin/main`, повторить Stage 2 baseline и начать уже утверждённый Stage 2 EXEC.
+
+## 14. Открытые вопросы
+Нет открытых design/product вопросов. Обязательная отдельная approval-фраза `Спеку подтверждаю` получена 2026-07-18.
+
+Утверждённый дизайн уже включает ровно один узкий production-assembly seam: internal same-lock seal в `TaskItemViewModel` плюс friend declaration. Если deterministic RED или корректный fix потребуют любого более широкого production seam, работа останавливается для новой review/approval.
+
+## 15. Соответствие профилю
+- Профиль: testing-baseline + testing-dotnet + dotnet-desktop-client + CI delivery + review loops.
+- Выполненные требования профиля:
+  - TUnit filters используют `--treenode-filter`;
+  - test-first deterministic regression;
+  - local override учтён: Headless suite обязателен, хотя UI behavior не меняется;
+  - UI video явно N/A с причиной;
+  - exact commands, stop rules, evidence paths и existing CI topology зафиксированы;
+  - production/test boundary и rollback заданы;
+  - Post-SPEC/Post-EXEC review предусмотрены.
+
+## 16. Таблица изменений файлов
+
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `specs/2026-07-17-test-fixture-lifecycle.md` | Этот contract и evidence | QUEST child-spec |
+| `src/Unlimotion.ViewModel/TaskItemViewModel.cs` | Same-lock save-admission gate и cached internal sealed snapshot | Закрыть delayed-producer race без изменения normal runtime path |
+| `src/Unlimotion.ViewModel/AssemblyInfo.cs` (new) | `InternalsVisibleTo("Unlimotion.Test")` | Ограничить lifecycle seam тестовой assembly |
+| `src/Unlimotion.Test/MainWindowViewModelFixture.cs` | async shared cleanup, seal/drain, null-repository branch, injected delete boundary, surfaced failures, `IAsyncDisposable` | Root fix и детерминированные regressions |
+| `src/Unlimotion.Test/MainWindowViewModelFixtureLifecycleTests.cs` (new) | Controlled RED/GREEN lifecycle tests | Deterministic proof |
+| `src/Unlimotion.Test/MainWindowViewModelTests.cs` | `BaseModelTests : IAsyncDisposable`; awaited projection cleanup; remaining direct calls | TUnit lifecycle owner |
+| `src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs` | awaited cleanup; remove manual pre-dispose; nested culture restore | Single owner и guaranteed global-state restore |
+| `src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs` | awaited cleanup и nested application-font restore | Global-state restore even on cleanup fault |
+| `src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs` | awaited cleanup и nested requested-theme restore | Global-state restore even on cleanup fault |
+| 19 consumer files below, кроме `MainWindowViewModelTests.cs` и `LocalizationDisplayDefinitionTests.cs`; два из 19 раскрыты отдельными строками выше | mechanical awaited cleanup migration | Remove all synchronous callers |
+
+Exact remaining consumer inventory:
+- `BreadcrumbEmojiUiTests.cs`
+- `MainControlAvailabilityUiTests.cs`
+- `MainControlDateQuickSelectionUiTests.cs`
+- `MainControlFilterToolbarResponsiveUiTests.cs`
+- `MainControlNewTaskDeadlineUiTests.cs`
+- `MainControlResetFiltersUiTests.cs`
+- `MainControlRelationPickerUiTests.cs`
+- `MainControlTaskCardLayoutUiTests.cs`
+- `MainControlTabsOverflowUiTests.cs`
+- `MainControlTaskStatusIconUiTests.cs`
+- `MainControlTreeCommandsUiTests.cs`
+- `MainScreenLoadingUiTests.cs`
+- `PackageUpdateCompatibilityUiTests.cs`
+- `MainControlWantedUiTests.cs`
+- `RoadmapGraphUiTests.cs`
+- `SettingsControlResponsiveUiTests.cs`
+- `TaskImportanceUiTests.cs`
+- `TaskListRepeaterMarkerUiTests.cs`
+- `ToastNotificationUiTests.cs`
+
+Explicitly unchanged:
+- `.github/workflows/tests.yml`;
+- все production files, кроме точных `src/Unlimotion.ViewModel/TaskItemViewModel.cs` и нового `src/Unlimotion.ViewModel/AssemblyInfo.cs`;
+- README/specs other than this child spec during its delivery.
+
+## 17. Таблица соответствий (было -> стало)
+
+| Область | Было | Стало |
+| --- | --- | --- |
+| Fixture cleanup | synchronous fire-and-forget boundary | awaitable single-owner lifecycle |
+| Save admission | delayed callbacks могут начать save после snapshot | same-lock irreversible seal; post-seal callbacks are no-op |
+| Pending saves | API exists but teardown ignores it | one cached sealed snapshot полностью awaited before delete |
+| Repeated cleanup | bool early return, second caller cannot await first | same shared task/result/fault |
+| Delete failure | swallowed after three sleeps | bounded async retry then explicit path error |
+| TUnit teardown | `IDisposable` | `IAsyncDisposable` |
+| Headless order | sync cleanup in finally | awaited cleanup in dispatcher before session dispose |
+| CI response | retry/timeout ambiguity | deterministic regression + unchanged full workflow proof |
+| Production behavior | autosave has no teardown admission state | normal autosave remains unchanged; only friend test fixture invokes internal seal |
+
+## 18. Альтернативы и компромиссы
+- Вариант: повысить workflow timeout.
+  - Плюсы: минимальный diff.
+  - Минусы: не устраняет delete/read race и unobserved exceptions.
+  - Решение: отклонён.
+- Вариант: ловить `FileNotFoundException` в `FileTaskStorage.GetAll()`.
+  - Плюсы: скрывает конкретный stack.
+  - Минусы: маскирует нарушение ownership, меняет production semantics, не гарантирует отсутствие hang.
+  - Решение: отклонён.
+- Вариант: оставить sync `CleanTasks()` и блокировать async через `.GetAwaiter().GetResult()`.
+  - Плюсы: меньше caller edits.
+  - Минусы: deadlock risk на dispatcher, не выражает TUnit lifecycle, сохраняет двусмысленное ownership.
+  - Решение: отклонён.
+- Вариант: изменить production disposal/source switching одновременно.
+  - Плюсы: потенциально закрывает более широкий класс риска.
+  - Минусы: нет доказанной production потери, другой контракт/риск/тесты, блокирует точечный CI fix.
+  - Решение: отдельный MEDIUM follow-up.
+- Выбранное решение: async fixture owner + минимальный internal same-lock producer barrier в `TaskItemViewModel` + deterministic interleaving test. Барьер закрывает очередь delayed callbacks, остаётся недоступным public/runtime callers и даёт проверяемый rollback.
+
+## 19. Результат quality gate и review
+
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Root problem, scope, evidence, goals/non-goals заданы |
+| B. Качество дизайна | 6-10 | PASS | Async owner, same-lock cached seal, drain и error contract конкретны |
+| C. Безопасность изменений | 11-13 | PASS | Узкий internal production seam, exact allowlist, rollback и stop rules явные |
+| D. Проверяемость | 14-16 | PASS | Deterministic RED/GREEN, stress, full CI и static gates связаны с AC |
+| E. Готовность к автономной реализации | 17-19 | PASS | Independent reviews закрыты; commands, sequencing и stop conditions однозначны; approval — отдельный governance gate |
+| F. Соответствие профилю | 20 | PASS | TUnit/.NET/Headless/CI governance отражены |
+
+Итог: `ГОТОВО`. Production EXEC остаётся запрещён только до отдельной точной approval-фразы.
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | One-root lifecycle package; narrow internal seam и non-goals явные |
+| 2. Понимание текущего состояния | 5 | Source, callsite и two-attempt CI evidence |
+| 3. Конкретность целевого дизайна | 5 | Same-lock seal, outer drain, ordering/errors и consumer migration |
+| 4. Безопасность (миграция, откат) | 5 | Atomic migration, exact production boundary, revert path и stop rules |
+| 5. Тестируемость | 5 | Controlled interleaving, stress, full suites |
+| 6. Готовность к автономной реализации | 5 | Independent fix/re-review PASS; exact commands/evidence/delivery handoff заданы |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению после обязательного approval gate.
+
+### Role-Based Review Result
+
+| Role | Applicability | Review question | Verdict | Required spec changes |
+| --- | --- | --- | --- | --- |
+| Business analyst / domain workflow | not applicable | Production workflow/data не меняются | PASS | Scope boundary review only |
+| UX / designer | not applicable | User UI/layout/copy не меняются | PASS | Video/visual N/A зафиксировано |
+| Tester / validation | applicable | Deterministic RED/GREEN и full evidence достаточны? | PASS | Final adversarial audit подтвердил non-masking RED, ReactiveCommand observer, mixed disposal, fail-closed scope и все 10 AC |
+| Developer / architect | applicable | Ownership, async ordering и failure semantics coherent? | PASS | Same-lock cached seal и outer flattened drain прошли повторное independent review |
+| Delivery / operations / security | applicable | CI/PR sequencing и scope safe? | PASS | Restore/timeouts/logs/allowlist и fix PR → PR #274 → Stage 2 прошли повторное review |
+
+### Post-SPEC Review
+- Статус: PASS
+- Scope reviewed: final spec, source/callsite inventory, delayed producer paths, TUnit package contract, PR #274 CI attempts, validation commands и delivery sequencing
+- Decision: запросить отдельную user approval; EXEC до неё не начинать
+- Review passes:
+  - Scope/Evidence pass: self-review PASS
+  - Contract pass: independent architect review PASS
+  - Adversarial risk pass: same-lock producer barrier и multi-fault drain re-review PASS
+  - Role-Based pass: tester/validation + architect + delivery PASS
+  - Re-review after fixes / Fix and re-review: architect, delivery и final adversarial consistency verdicts PASS
+  - Stop decision: approval получен; EXEC разрешён в exact allowlist, остальные stop rules остаются активны
+- Evidence inspected: source lines, 147/21 inventory, delayed throttle producers, workflow, TUnit 1.44 package XML, local resolved SDK, GitHub run attempts/logs
+- Depth checklist:
+  - Scope drift / unrelated changes: spec-only
+  - Acceptance criteria: 10 AC mapped
+  - User-observable scenarios / Decision ledger / Expected objections: заполнены
+  - Validation evidence: before evidence + exact after plan
+  - Unsupported claims: attempt-2 causation explicitly limited
+  - Regression / edge case: concurrent/repeated/faulted caller, two nested save faults, delete failure, unconnected fixture, dispatcher/global-state ordering
+  - Comments/docs/changelog: PR handoff only; README/release notes N/A
+  - Hidden contract change: только явно описанный internal `TaskItemViewModel` seal, доступный friend test assembly
+  - Manual-review challenge: проверить lock linearization, flattened outer drain, failure aggregation и every async caller signature
+- No-findings justification: финальные independent architect и delivery/validation re-reviews повторно проверили исправленные HIGH/MEDIUM findings; открытых findings не осталось.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | architecture | Initial snapshot/quiescence design не закрывал delayed producers | Добавить same-lock cached seal и narrow friend-only seam | fixed; re-review PASS |
+| HIGH | delivery/validation | Initial scope/table/commands не покрывали production seam, unconnected fixture, global restores и false-green gates | Расширить exact contract, обязательные regressions и bounded evidence commands | fixed; re-review PASS |
+| HIGH | deterministic RED | Early assertion мог быть замаскирован post-release storage fault; replacement command не наблюдал `ThrownExceptions` | Record-first RED, bounded non-throwing observation, exact final assertion и test observer | fixed; adversarial re-review PASS |
+| MEDIUM | failure semantics | Nested `Task.WhenAll` мог потерять несколько save faults | Один outer drain + `Exception.Flatten()` + two-save/delete regression | fixed; re-review PASS |
+| MEDIUM | traceability/gates | Scenario-to-AC links, mixed `DisposeAsync` coverage и static checks были неполными/fail-open | Исправить mapping, mixed caller regression и fail-closed path/rg gates | fixed; adversarial re-review PASS |
+| LOW | audit metadata | Linter/rubric/journal описывали старый test-only design | Согласовать §19/журнал с final contract | fixed |
+
+- Fixed before continuing: все initial independent findings исправлены; каждая substantive правка прошла повторное review
+- Checks rerun: 22 обязательных H2 section, 14 fences, 10 AC, 7 PowerShell blocks без parse errors, zero trailing whitespace/tabs, stale-term scan и untracked-file whitespace check
+- Needs human: только точная approval-фраза для child EXEC
+- Residual risks / follow-ups: production source-switch drain; unrelated emoji flake
+
+### Post-EXEC Review
+- Статус: Не выполнен до EXEC
+- Scope reviewed: Не применимо
+- Decision: Не применимо до approval/EXEC
+- Review passes: Не применимо
+- Evidence inspected: Не применимо
+- Depth checklist: Не применимо
+- No-findings justification: Не применимо
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | phase | EXEC не начат | Выполнить полный Post-EXEC review после implementation/validation | follow-up |
+
+- Fixed before final report: Не применимо
+- Checks rerun: Не применимо
+- Validation evidence: Не применимо
+- Unrelated changes: Не применимо
+- Needs human: approval child spec
+- Residual risks / follow-ups: перечислены выше
+
+## Approval
+Получена отдельная точная фраза `Спеку подтверждаю` 2026-07-18. Статус: APPROVED FOR EXEC.
+
+Approval master roadmap, Stage 1 или Stage 2 не распространяется автоматически на этот CI-lifecycle child EXEC.
+
+## 20. Журнал действий агента
+
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | ---: | --- | --- | --- | --- | --- | --- |
+| SPEC | Freshness/CI evidence gate | 1.00 | Нет для root package | Audit source, call sites и run attempts | Нет | Не применимо | PR #274 блокирует roadmap sequencing | CI logs, source, workflow |
+| SPEC | Локализовать lifecycle owner | 0.99 | Attempt-2 не имеет stack | Ограничить fix lifecycle boundary и задать deterministic proof | Нет | Independent audit completed | Attempt 1 прямо показывает read-after-delete; initial load awaited | Source inventory |
+| SPEC | Initial independent reviews | 1.00 | Нет | Исправить HIGH producer-barrier и delivery/validation gaps | Нет | Architect и delivery verdict `NEEDS-FIX` | Delayed 2-second producer требует same-lock seal; validation не должна давать false green | Эта spec, source, commands |
+| SPEC | Перепроектировать child contract | 0.99 | Нет | Добавить narrow internal seal, outer flattened drain, unconnected/global-state и bounded evidence contracts | Нет | Findings приняты | Чисто test-only snapshot не может атомарно закрыть delayed callbacks | Эта spec |
+| SPEC | Fix and re-review | 1.00 | Нет | Провести повторные architect и delivery/validation reviews | Нет | Оба independent verdict `PASS` | Same-lock/cached seal, multi-fault aggregation и delivery gates подтверждены | Эта spec |
+| SPEC | Final adversarial consistency audit | 1.00 | Нет | Исправить RED masking, ReactiveCommand observer, AC mapping и fail-closed scope gates; повторить audit | Нет | Final verdict `PASS` | Исполняемый test/delivery contract проверен после последних правок | Эта spec, source, commands |
+| SPEC | Approval gate | 1.00 | Нет | Перейти к EXEC в exact allowlist | Да | Пользователь: `Спеку подтверждаю` | Roadmap-required child approval получен 2026-07-18 | Эта spec |

--- a/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
+++ b/src/Unlimotion.Test/BreadcrumbEmojiUiTests.cs
@@ -61,7 +61,7 @@ public class BreadcrumbEmojiUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/HeadlessSessionExtensions.cs
+++ b/src/Unlimotion.Test/HeadlessSessionExtensions.cs
@@ -22,7 +22,7 @@ public static class HeadlessSessionExtensions
 
         async Task DispatchAndThrowAsync()
         {
-            await session.Dispatch(async () =>
+            await session.Dispatch<bool>(async () =>
             {
                 try
                 {
@@ -88,7 +88,7 @@ public sealed class SafeHeadlessUnitTestSession : IAsyncDisposable
 
     public Task Dispatch(Func<Task> action, CancellationToken cancellationToken)
     {
-        return _session.Dispatch(action, cancellationToken);
+        return _session.DispatchAsync(action, cancellationToken);
     }
 
     public Task DispatchAsync(Func<Task> action, CancellationToken cancellationToken)

--- a/src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs
+++ b/src/Unlimotion.Test/LocalizationDisplayDefinitionTests.cs
@@ -93,9 +93,17 @@ public class LocalizationDisplayDefinitionTests
         }
         finally
         {
-            fixture?.MainWindowViewModelTest.Dispose();
-            fixture?.CleanTasks();
-            LocalizationService.Current = previousLocalization;
+            try
+            {
+                if (fixture is not null)
+                {
+                    await fixture.CleanTasksAsync();
+                }
+            }
+            finally
+            {
+                LocalizationService.Current = previousLocalization;
+            }
         }
     }
 
@@ -131,9 +139,17 @@ public class LocalizationDisplayDefinitionTests
         }
         finally
         {
-            fixture?.MainWindowViewModelTest.Dispose();
-            fixture?.CleanTasks();
-            LocalizationService.Current = previousLocalization;
+            try
+            {
+                if (fixture is not null)
+                {
+                    await fixture.CleanTasksAsync();
+                }
+            }
+            finally
+            {
+                LocalizationService.Current = previousLocalization;
+            }
         }
     }
 

--- a/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
+++ b/src/Unlimotion.Test/MainControlAvailabilityUiTests.cs
@@ -65,7 +65,7 @@ public class MainControlAvailabilityUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -122,7 +122,7 @@ public class MainControlAvailabilityUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
+++ b/src/Unlimotion.Test/MainControlDateQuickSelectionUiTests.cs
@@ -59,7 +59,10 @@ public class MainControlDateQuickSelectionUiTests
                 finally
                 {
                     CloseWindow(window);
-                    fixture?.CleanTasks();
+                    if (fixture is not null)
+                    {
+                        await fixture.CleanTasksAsync();
+                    }
                 }
             }, CancellationToken.None);
         }

--- a/src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/MainControlFilterToolbarResponsiveUiTests.cs
@@ -83,7 +83,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -148,7 +148,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -195,7 +195,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -286,7 +286,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -391,7 +391,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -451,7 +451,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -504,7 +504,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -558,7 +558,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -602,9 +602,15 @@ public class MainControlFilterToolbarResponsiveUiTests
             }
             finally
             {
-                window?.Close();
-                fixture.CleanTasks();
-                ApplyApplicationFontResources(AppearanceSettings.DefaultFontSize);
+                try
+                {
+                    window?.Close();
+                    await fixture.CleanTasksAsync();
+                }
+                finally
+                {
+                    ApplyApplicationFontResources(AppearanceSettings.DefaultFontSize);
+                }
             }
         }, CancellationToken.None);
     }
@@ -674,7 +680,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -725,7 +731,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -764,7 +770,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -802,7 +808,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -854,7 +860,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -907,7 +913,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -949,7 +955,7 @@ public class MainControlFilterToolbarResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlNewTaskDeadlineUiTests.cs
+++ b/src/Unlimotion.Test/MainControlNewTaskDeadlineUiTests.cs
@@ -135,7 +135,7 @@ public class MainControlNewTaskDeadlineUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -191,7 +191,7 @@ public class MainControlNewTaskDeadlineUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -328,7 +328,7 @@ public class MainControlNewTaskDeadlineUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
+++ b/src/Unlimotion.Test/MainControlRelationPickerUiTests.cs
@@ -71,7 +71,7 @@ public class MainControlRelationPickerUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -150,7 +150,7 @@ public class MainControlRelationPickerUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
+++ b/src/Unlimotion.Test/MainControlResetFiltersUiTests.cs
@@ -84,7 +84,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -139,7 +139,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -203,7 +203,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -266,7 +266,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -324,7 +324,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -370,7 +370,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -435,7 +435,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -499,7 +499,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -564,7 +564,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -620,7 +620,7 @@ public class MainControlResetFiltersUiTests
             {
                 await DrainUiThrottlesAsync();
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlTabsOverflowUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTabsOverflowUiTests.cs
@@ -61,7 +61,7 @@ public class MainControlTabsOverflowUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -103,7 +103,7 @@ public class MainControlTabsOverflowUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -143,7 +143,7 @@ public class MainControlTabsOverflowUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -179,7 +179,7 @@ public class MainControlTabsOverflowUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -215,7 +215,7 @@ public class MainControlTabsOverflowUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -247,7 +247,7 @@ public class MainControlTabsOverflowUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -301,7 +301,7 @@ public class MainControlTabsOverflowUiTests
                     localization.SetLanguage(LocalizationService.EnglishLanguage);
                     RunLayoutJobs();
                     CloseWindow(window);
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -342,7 +342,7 @@ public class MainControlTabsOverflowUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs
@@ -139,7 +139,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -177,7 +177,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -227,9 +227,15 @@ public class MainControlTaskCardLayoutUiTests
             }
             finally
             {
-                CloseWindow(window);
-                fixture.CleanTasks();
-                app.RequestedThemeVariant = previousTheme;
+                try
+                {
+                    CloseWindow(window);
+                    await fixture.CleanTasksAsync();
+                }
+                finally
+                {
+                    app.RequestedThemeVariant = previousTheme;
+                }
             }
         }, CancellationToken.None);
     }
@@ -265,7 +271,7 @@ public class MainControlTaskCardLayoutUiTests
                 finally
                 {
                     CloseWindow(window);
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -305,7 +311,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -344,7 +350,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -389,7 +395,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -437,7 +443,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -489,7 +495,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -547,7 +553,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -598,7 +604,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -646,7 +652,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -738,7 +744,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -769,7 +775,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -843,7 +849,7 @@ public class MainControlTaskCardLayoutUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
@@ -86,7 +86,7 @@ public class MainControlTaskStatusIconUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -132,7 +132,7 @@ public class MainControlTaskStatusIconUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -198,7 +198,7 @@ public class MainControlTaskStatusIconUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -267,7 +267,7 @@ public class MainControlTaskStatusIconUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -772,7 +772,7 @@ public class MainControlTaskStatusIconUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTreeCommandsUiTests.cs
@@ -120,7 +120,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -164,7 +164,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -285,7 +285,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -391,7 +391,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -469,7 +469,7 @@ public class MainControlTreeCommandsUiTests
             }
             finally
             {
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -555,7 +555,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -686,7 +686,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -819,7 +819,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -903,7 +903,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -969,7 +969,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1014,7 +1014,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1053,7 +1053,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1101,7 +1101,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1153,7 +1153,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1203,7 +1203,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1282,7 +1282,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1335,7 +1335,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1402,7 +1402,7 @@ public class MainControlTreeCommandsUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -1452,7 +1452,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1559,7 +1559,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1620,7 +1620,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1692,7 +1692,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1743,7 +1743,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1804,7 +1804,7 @@ public class MainControlTreeCommandsUiTests
                 }
 
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1846,7 +1846,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1908,7 +1908,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1962,7 +1962,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2015,7 +2015,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2092,7 +2092,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2132,7 +2132,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2183,7 +2183,7 @@ public class MainControlTreeCommandsUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -2234,7 +2234,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2279,7 +2279,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2331,7 +2331,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2384,7 +2384,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2476,7 +2476,7 @@ public class MainControlTreeCommandsUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainControlWantedUiTests.cs
+++ b/src/Unlimotion.Test/MainControlWantedUiTests.cs
@@ -65,7 +65,7 @@ public class MainControlWantedUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
+++ b/src/Unlimotion.Test/MainScreenLoadingUiTests.cs
@@ -58,7 +58,7 @@ public class MainScreenLoadingUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/MainWindowViewModelFixture.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelFixture.cs
@@ -1,6 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using ServiceStack;
 using Unlimotion.Services;
@@ -9,18 +13,24 @@ using WritableJsonConfiguration;
 
 namespace Unlimotion.Test
 {
-    public class MainWindowViewModelFixture
+    public class MainWindowViewModelFixture : IAsyncDisposable
     {
         private const string DefaultConfigName = "TestSettings.json";
         private string UniquiId => guid.ToString()!;
         private readonly ThreadLocal<Guid> guid;
         private readonly IDisposable? configurationDisposable;
+        private readonly ITaskStorage ownedTaskStorage;
 
         private readonly string fixtureDirectory;
         private readonly string uniqueConfigName;
-        private bool isCleaned;
+        private readonly object cleanupLock = new();
+        private Task? cleanupTask;
+        internal Func<string, string, Exception?>? DeleteFailureInjector { get; set; }
+        internal Func<ITaskStorage, TaskItemViewModel[]> TaskItemsSnapshotProvider { get; set; } =
+            static repository => repository.Tasks.Items.ToArray();
         public MainWindowViewModel MainWindowViewModelTest { get; private set; }
         public string ConfigPath => Path.GetFullPath(uniqueConfigName);
+        internal string FixtureDirectoryPath => fixtureDirectory;
         public string? TaskTreeExpansionStatePath => TaskTreeExpansionStateStore.GetDefaultPath(ConfigPath);
         public readonly string DefaultTasksFolderPath;
         private readonly string defaultSnapshotsFolderPath;
@@ -91,7 +101,7 @@ namespace Unlimotion.Test
             // Create storage factory
             var storageFactory = new TaskStorageFactory(configuration, mapper, notificationManagerMock);
             // Create file storage
-            storageFactory.CreateFileStorage(DefaultTasksFolderPath);
+            ownedTaskStorage = storageFactory.CreateFileStorage(DefaultTasksFolderPath);
 
             // Create SettingsViewModel
             var settingsViewModel = new SettingsViewModel(configuration);
@@ -101,7 +111,7 @@ namespace Unlimotion.Test
                 new AppNameDefinitionService(),
                 notificationManagerMock,
                 configuration,
-                () => storageFactory.SourceManager.ActiveStorage,
+                () => ownedTaskStorage,
                 settingsViewModel,
                 taskTreeExpansionStatePath: TaskTreeExpansionStatePath
             );
@@ -140,31 +150,194 @@ namespace Unlimotion.Test
             }
         }
 
-        public void CleanTasks()
+        public Task CleanTasksAsync()
         {
-            if (isCleaned)
+            lock (cleanupLock)
             {
+                return cleanupTask ??= CleanTasksCoreAsync();
+            }
+        }
+
+        public ValueTask DisposeAsync() => new(CleanTasksAsync());
+
+        private async Task CleanTasksCoreAsync()
+        {
+            var failures = new List<Exception>();
+            var taskRepository = MainWindowViewModelTest.taskRepository;
+            var filesystemDeletionSafe = true;
+
+            CaptureFailure(failures, MainWindowViewModelTest.Dispose);
+
+            if (taskRepository != null)
+            {
+                TaskItemViewModel[] taskItems = [];
+                try
+                {
+                    taskItems = TaskItemsSnapshotProvider(taskRepository);
+                }
+                catch (Exception exception)
+                {
+                    filesystemDeletionSafe = false;
+                    AddFailure(failures, exception);
+                }
+
+                var sealedSnapshots = new List<Task>(taskItems.Length);
+                foreach (var taskItem in taskItems)
+                {
+                    try
+                    {
+                        sealedSnapshots.Add(taskItem.SealPendingSaves());
+                    }
+                    catch (Exception exception)
+                    {
+                        filesystemDeletionSafe = false;
+                        AddFailure(failures, exception);
+                    }
+                }
+
+                var drainTask = Task.WhenAll(sealedSnapshots);
+                try
+                {
+                    await drainTask;
+                }
+                catch (Exception exception)
+                {
+                    if (drainTask.Exception != null)
+                    {
+                        foreach (var innerException in drainTask.Exception.Flatten().InnerExceptions)
+                        {
+                            failures.Add(innerException);
+                        }
+                    }
+                    else
+                    {
+                        AddFailure(failures, exception);
+                    }
+                }
+            }
+
+            if (ownedTaskStorage is IDisposable taskStorageDisposable)
+            {
+                CaptureFailure(failures, taskStorageDisposable.Dispose);
+            }
+
+            if (configurationDisposable != null)
+            {
+                CaptureFailure(failures, configurationDisposable.Dispose);
+            }
+
+            if (filesystemDeletionSafe)
+            {
+                await DeleteWithRetryAsync(
+                    "delete config file",
+                    uniqueConfigName,
+                    () => File.Exists(uniqueConfigName),
+                    () => File.Delete(uniqueConfigName),
+                    failures);
+
+                if (!string.IsNullOrWhiteSpace(TaskTreeExpansionStatePath))
+                {
+                    var expansionStatePath = TaskTreeExpansionStatePath;
+                    await DeleteWithRetryAsync(
+                        "delete expansion-state file",
+                        expansionStatePath,
+                        () => File.Exists(expansionStatePath),
+                        () => File.Delete(expansionStatePath),
+                        failures);
+                }
+
+                await DeleteWithRetryAsync(
+                    "delete tasks directory",
+                    DefaultTasksFolderPath,
+                    () => Directory.Exists(DefaultTasksFolderPath),
+                    () => Directory.Delete(DefaultTasksFolderPath, true),
+                    failures);
+                await DeleteWithRetryAsync(
+                    "delete fixture directory",
+                    fixtureDirectory,
+                    () => Directory.Exists(fixtureDirectory),
+                    () => Directory.Delete(fixtureDirectory, true),
+                    failures);
+            }
+
+            if (failures.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(failures[0]).Throw();
+            }
+
+            if (failures.Count > 1)
+            {
+                throw new AggregateException("Fixture cleanup failed.", failures);
+            }
+        }
+
+        private async Task DeleteWithRetryAsync(
+            string operation,
+            string path,
+            Func<bool> exists,
+            Action delete,
+            ICollection<Exception> failures,
+            int attempts = 3)
+        {
+            Exception? lastException = null;
+            for (var attempt = 1; attempt <= attempts; attempt++)
+            {
+                try
+                {
+                    if (!exists())
+                    {
+                        return;
+                    }
+
+                    var injectedFailure = DeleteFailureInjector?.Invoke(operation, path);
+                    if (injectedFailure != null)
+                    {
+                        throw injectedFailure;
+                    }
+
+                    delete();
+                    return;
+                }
+                catch (Exception exception)
+                {
+                    lastException = exception;
+                    if (attempt < attempts)
+                    {
+                        await Task.Delay(100);
+                    }
+                }
+            }
+
+            failures.Add(new IOException(
+                $"Failed to {operation} '{path}' after {attempts} attempts.",
+                lastException));
+        }
+
+        private static void CaptureFailure(ICollection<Exception> failures, Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception exception)
+            {
+                AddFailure(failures, exception);
+            }
+        }
+
+        private static void AddFailure(ICollection<Exception> failures, Exception exception)
+        {
+            if (exception is AggregateException aggregateException)
+            {
+                foreach (var innerException in aggregateException.Flatten().InnerExceptions)
+                {
+                    failures.Add(innerException);
+                }
+
                 return;
             }
 
-            isCleaned = true;
-            var taskStorageDisposable = MainWindowViewModelTest.taskRepository as IDisposable;
-            MainWindowViewModelTest.Dispose();
-            taskStorageDisposable?.Dispose();
-            configurationDisposable?.Dispose();
-
-            if (File.Exists(uniqueConfigName))
-            {
-                Try(() => File.Delete(uniqueConfigName));
-            }
-
-            if (!string.IsNullOrWhiteSpace(TaskTreeExpansionStatePath) && File.Exists(TaskTreeExpansionStatePath))
-            {
-                Try(() => File.Delete(TaskTreeExpansionStatePath));
-            }
-
-            Try(() => Directory.Delete(DefaultTasksFolderPath, true));
-            Try(() => Directory.Delete(fixtureDirectory, true));
+            failures.Add(exception);
         }
     }
 }

--- a/src/Unlimotion.Test/MainWindowViewModelFixtureLifecycleTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelFixtureLifecycleTests.cs
@@ -1,0 +1,480 @@
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ReactiveUI;
+using Unlimotion.ViewModel;
+using DomainTaskStatus = Unlimotion.Domain.TaskStatus;
+
+namespace Unlimotion.Test;
+
+public sealed class MainWindowViewModelFixtureLifecycleTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(15);
+
+    [Test]
+    public async Task CleanTasksAsync_ConcurrentCallersWaitForInFlightSaveBeforeDirectoryDeletion()
+    {
+        var fixture = new MainWindowViewModelFixture();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var commandExceptions = new ConcurrentQueue<Exception>();
+        ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit>? controlledCommand = null;
+        IDisposable? commandExceptionSubscription = null;
+        Task? firstCleanup = null;
+        Task? secondCleanup = null;
+        Task? disposeCleanup = null;
+        Task? pendingSave = null;
+        Exception? pendingSaveFailure = null;
+        Exception? cleanupFailure = null;
+        bool cleanupCompletedBeforeRelease = true;
+        bool sameCleanTask = false;
+        bool disposeJoinedSameOperation = false;
+        bool tasksDirectoryExistedBeforeRelease = false;
+        bool taskFileExistedBeforeRelease = false;
+        bool pendingSaveWasIncomplete = false;
+        bool tasksDirectoryExistsAfterCleanup = true;
+        bool fixtureDirectoryExistsAfterCleanup = true;
+        int invocationCountAfterSeal = 0;
+
+        try
+        {
+            var mainWindow = fixture.MainWindowViewModelTest;
+            await mainWindow.Connect();
+            var repository = mainWindow.taskRepository
+                ?? throw new InvalidOperationException("Task repository was not initialized.");
+            var task = repository.Tasks.Items.Single(item => item.Id == MainWindowViewModelFixture.RootTask1Id);
+            var invocationCount = 0;
+
+            controlledCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+                Interlocked.Increment(ref invocationCount);
+                started.TrySetResult();
+                await release.Task;
+                await repository.Update(task);
+            });
+            commandExceptionSubscription = controlledCommand.ThrownExceptions.Subscribe(commandExceptions.Enqueue);
+            task.SaveItemCommand = controlledCommand;
+
+            task.Status = NextStatus(task.Status);
+            await started.Task.WaitAsync(TestTimeout);
+            pendingSave = await WaitForPendingSaveRegistrationAsync(task);
+            pendingSaveWasIncomplete = !pendingSave.IsCompleted;
+
+            firstCleanup = fixture.CleanTasksAsync();
+            secondCleanup = fixture.CleanTasksAsync();
+            disposeCleanup = fixture.DisposeAsync().AsTask();
+
+            sameCleanTask = ReferenceEquals(firstCleanup, secondCleanup);
+            disposeJoinedSameOperation = ReferenceEquals(firstCleanup, disposeCleanup);
+            cleanupCompletedBeforeRelease = firstCleanup.IsCompleted;
+            tasksDirectoryExistedBeforeRelease = Directory.Exists(fixture.DefaultTasksFolderPath);
+            taskFileExistedBeforeRelease = File.Exists(Path.Combine(fixture.DefaultTasksFolderPath, task.Id));
+
+            if (!cleanupCompletedBeforeRelease)
+            {
+                task.Status = NextStatus(task.Status);
+            }
+
+            invocationCountAfterSeal = Volatile.Read(ref invocationCount);
+            release.TrySetResult();
+
+            pendingSaveFailure = await ObserveFailureAsync(pendingSave);
+            cleanupFailure = await ObserveFailureAsync(firstCleanup);
+            await ObserveFailureAsync(secondCleanup);
+            await ObserveFailureAsync(disposeCleanup);
+            tasksDirectoryExistsAfterCleanup = Directory.Exists(fixture.DefaultTasksFolderPath);
+            fixtureDirectoryExistsAfterCleanup = Directory.Exists(fixture.FixtureDirectoryPath);
+        }
+        finally
+        {
+            release.TrySetResult();
+            if (pendingSave != null)
+            {
+                await ObserveFailureAsync(pendingSave);
+            }
+
+            var finalCleanup = firstCleanup ?? fixture.CleanTasksAsync();
+            await ObserveFailureAsync(finalCleanup);
+            if (secondCleanup != null)
+            {
+                await ObserveFailureAsync(secondCleanup);
+            }
+
+            if (disposeCleanup != null)
+            {
+                await ObserveFailureAsync(disposeCleanup);
+            }
+
+            commandExceptionSubscription?.Dispose();
+            controlledCommand?.Dispose();
+        }
+
+        await Assert.That(cleanupCompletedBeforeRelease)
+            .IsFalse()
+            .Because("cleanup completed before controlled save release");
+        await Assert.That(sameCleanTask).IsTrue();
+        await Assert.That(disposeJoinedSameOperation).IsTrue();
+        await Assert.That(tasksDirectoryExistedBeforeRelease).IsTrue();
+        await Assert.That(taskFileExistedBeforeRelease).IsTrue();
+        await Assert.That(pendingSaveWasIncomplete).IsTrue();
+        await Assert.That(invocationCountAfterSeal).IsEqualTo(1);
+        await Assert.That(pendingSaveFailure).IsNull();
+        await Assert.That(cleanupFailure).IsNull();
+        await Assert.That(commandExceptions).IsEmpty();
+        await Assert.That(tasksDirectoryExistsAfterCleanup).IsFalse();
+        await Assert.That(fixtureDirectoryExistsAfterCleanup).IsFalse();
+    }
+
+    [Test]
+    public async Task CleanTasksAsync_RepeatedCallAfterSaveAndDeleteFailuresReturnsSameAggregate()
+    {
+        var fixture = new MainWindowViewModelFixture();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstSaveFailure = new InvalidOperationException("controlled save one failed");
+        var secondSaveFailure = new InvalidOperationException("controlled save two failed");
+        var injectedDeleteFailure = new IOException("controlled delete failed");
+        var commandExceptions = new ConcurrentQueue<Exception>();
+        ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit>? firstCommand = null;
+        ReactiveCommand<System.Reactive.Unit, System.Reactive.Unit>? secondCommand = null;
+        IDisposable? firstExceptionSubscription = null;
+        IDisposable? secondExceptionSubscription = null;
+        Task? firstPendingSave = null;
+        Task? secondPendingSave = null;
+        Task? firstCleanup = null;
+        Task? concurrentCleanup = null;
+        Task? repeatedCleanup = null;
+        Task? disposeCleanup = null;
+        Exception? cleanupFailure = null;
+        Exception? repeatedCleanupFailure = null;
+        AggregateException? flattenedCleanupTaskException = null;
+        Exception? residualDirectoryCleanupFailure = null;
+        var fixtureDirectoryExistedAfterCleanupFailure = false;
+        var deleteAttempts = 0;
+
+        try
+        {
+            var mainWindow = fixture.MainWindowViewModelTest;
+            await mainWindow.Connect();
+            var repository = mainWindow.taskRepository
+                ?? throw new InvalidOperationException("Task repository was not initialized.");
+            var firstTask = repository.Tasks.Items.Single(item => item.Id == MainWindowViewModelFixture.RootTask1Id);
+            var secondTask = repository.Tasks.Items.Single(item => item.Id == MainWindowViewModelFixture.RootTask2Id);
+
+            firstCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+                firstStarted.TrySetResult();
+                await release.Task;
+                throw firstSaveFailure;
+            });
+            secondCommand = ReactiveCommand.CreateFromTask(async () =>
+            {
+                secondStarted.TrySetResult();
+                await release.Task;
+                throw secondSaveFailure;
+            });
+            firstExceptionSubscription = firstCommand.ThrownExceptions.Subscribe(commandExceptions.Enqueue);
+            secondExceptionSubscription = secondCommand.ThrownExceptions.Subscribe(commandExceptions.Enqueue);
+            firstTask.SaveItemCommand = firstCommand;
+            secondTask.SaveItemCommand = secondCommand;
+
+            firstTask.Status = NextStatus(firstTask.Status);
+            secondTask.Status = NextStatus(secondTask.Status);
+            await Task.WhenAll(firstStarted.Task, secondStarted.Task).WaitAsync(TestTimeout);
+            firstPendingSave = await WaitForPendingSaveRegistrationAsync(firstTask);
+            secondPendingSave = await WaitForPendingSaveRegistrationAsync(secondTask);
+
+            fixture.DeleteFailureInjector = (operation, path) =>
+            {
+                if (operation != "delete fixture directory" ||
+                    !string.Equals(path, fixture.FixtureDirectoryPath, StringComparison.Ordinal))
+                {
+                    return null;
+                }
+
+                Interlocked.Increment(ref deleteAttempts);
+                return injectedDeleteFailure;
+            };
+
+            firstCleanup = fixture.CleanTasksAsync();
+            concurrentCleanup = fixture.CleanTasksAsync();
+            release.TrySetResult();
+
+            await ObserveFailureAsync(firstPendingSave);
+            await ObserveFailureAsync(secondPendingSave);
+            cleanupFailure = await ObserveFailureAsync(firstCleanup);
+            await ObserveFailureAsync(concurrentCleanup);
+            flattenedCleanupTaskException = firstCleanup.Exception?.Flatten();
+            fixtureDirectoryExistedAfterCleanupFailure = Directory.Exists(fixture.FixtureDirectoryPath);
+
+            repeatedCleanup = fixture.CleanTasksAsync();
+            disposeCleanup = fixture.DisposeAsync().AsTask();
+            repeatedCleanupFailure = await ObserveFailureAsync(repeatedCleanup);
+            await ObserveFailureAsync(disposeCleanup);
+        }
+        finally
+        {
+            release.TrySetResult();
+            if (firstPendingSave != null)
+            {
+                await ObserveFailureAsync(firstPendingSave);
+            }
+
+            if (secondPendingSave != null)
+            {
+                await ObserveFailureAsync(secondPendingSave);
+            }
+
+            var finalCleanup = firstCleanup ?? fixture.CleanTasksAsync();
+            await ObserveFailureAsync(finalCleanup);
+            if (concurrentCleanup != null)
+            {
+                await ObserveFailureAsync(concurrentCleanup);
+            }
+
+            if (repeatedCleanup != null)
+            {
+                await ObserveFailureAsync(repeatedCleanup);
+            }
+
+            if (disposeCleanup != null)
+            {
+                await ObserveFailureAsync(disposeCleanup);
+            }
+
+            firstExceptionSubscription?.Dispose();
+            secondExceptionSubscription?.Dispose();
+            firstCommand?.Dispose();
+            secondCommand?.Dispose();
+
+            fixture.DeleteFailureInjector = null;
+            if (Directory.Exists(fixture.FixtureDirectoryPath))
+            {
+                try
+                {
+                    Directory.Delete(fixture.FixtureDirectoryPath, true);
+                }
+                catch (Exception exception)
+                {
+                    residualDirectoryCleanupFailure = exception;
+                }
+            }
+        }
+
+        await Assert.That(firstCleanup).IsSameReferenceAs(concurrentCleanup);
+        await Assert.That(firstCleanup).IsSameReferenceAs(repeatedCleanup);
+        await Assert.That(firstCleanup).IsSameReferenceAs(disposeCleanup);
+        await Assert.That(repeatedCleanupFailure).IsSameReferenceAs(cleanupFailure);
+        await Assert.That(deleteAttempts).IsEqualTo(3);
+        await Assert.That(cleanupFailure).IsAssignableTo<AggregateException>();
+        await Assert.That(flattenedCleanupTaskException).IsNotNull();
+        await Assert.That(fixtureDirectoryExistedAfterCleanupFailure).IsTrue();
+
+        var failures = flattenedCleanupTaskException!.InnerExceptions;
+        await Assert.That(failures.Count).IsEqualTo(3);
+        await Assert.That(failures.Count(exception => exception.Message == firstSaveFailure.Message)).IsEqualTo(1);
+        await Assert.That(failures.Count(exception => exception.Message == secondSaveFailure.Message)).IsEqualTo(1);
+
+        var deleteFailure = failures.Single(exception =>
+            exception is IOException &&
+            exception.Message.Contains("delete fixture directory", StringComparison.Ordinal) &&
+            exception.Message.Contains(fixture.FixtureDirectoryPath, StringComparison.Ordinal));
+        await Assert.That(deleteFailure.InnerException).IsSameReferenceAs(injectedDeleteFailure);
+        await Assert.That(commandExceptions.All(exception =>
+                ReferenceEquals(exception, firstSaveFailure) || ReferenceEquals(exception, secondSaveFailure)))
+            .IsTrue();
+        await Assert.That(residualDirectoryCleanupFailure).IsNull();
+    }
+
+    [Test]
+    public async Task CleanTasksAsync_SnapshotBarrierFailurePreservesOwnedPaths()
+    {
+        var fixture = new MainWindowViewModelFixture();
+        var barrierFailure = new InvalidOperationException("controlled snapshot barrier failed");
+        Task? firstCleanup = null;
+        Task? repeatedCleanup = null;
+        Task? disposeCleanup = null;
+        Exception? cleanupFailure = null;
+        Exception? repeatedCleanupFailure = null;
+        Exception? residualDirectoryCleanupFailure = null;
+        var deleteAttempts = 0;
+        var configExistedAfterFailure = false;
+        var tasksDirectoryExistedAfterFailure = false;
+        var fixtureDirectoryExistedAfterFailure = false;
+
+        try
+        {
+            await fixture.MainWindowViewModelTest.Connect();
+            fixture.TaskItemsSnapshotProvider = _ => throw barrierFailure;
+            fixture.DeleteFailureInjector = (_, _) =>
+            {
+                Interlocked.Increment(ref deleteAttempts);
+                return null;
+            };
+
+            firstCleanup = fixture.CleanTasksAsync();
+            cleanupFailure = await ObserveFailureAsync(firstCleanup);
+
+            repeatedCleanup = fixture.CleanTasksAsync();
+            disposeCleanup = fixture.DisposeAsync().AsTask();
+            repeatedCleanupFailure = await ObserveFailureAsync(repeatedCleanup);
+            await ObserveFailureAsync(disposeCleanup);
+
+            configExistedAfterFailure = File.Exists(fixture.ConfigPath);
+            tasksDirectoryExistedAfterFailure = Directory.Exists(fixture.DefaultTasksFolderPath);
+            fixtureDirectoryExistedAfterFailure = Directory.Exists(fixture.FixtureDirectoryPath);
+        }
+        finally
+        {
+            var finalCleanup = firstCleanup ?? fixture.CleanTasksAsync();
+            await ObserveFailureAsync(finalCleanup);
+            if (repeatedCleanup != null)
+            {
+                await ObserveFailureAsync(repeatedCleanup);
+            }
+
+            if (disposeCleanup != null)
+            {
+                await ObserveFailureAsync(disposeCleanup);
+            }
+
+            fixture.DeleteFailureInjector = null;
+            if (Directory.Exists(fixture.FixtureDirectoryPath))
+            {
+                try
+                {
+                    Directory.Delete(fixture.FixtureDirectoryPath, true);
+                }
+                catch (Exception exception)
+                {
+                    residualDirectoryCleanupFailure = exception;
+                }
+            }
+        }
+
+        await Assert.That(firstCleanup).IsSameReferenceAs(repeatedCleanup);
+        await Assert.That(firstCleanup).IsSameReferenceAs(disposeCleanup);
+        await Assert.That(cleanupFailure).IsSameReferenceAs(barrierFailure);
+        await Assert.That(repeatedCleanupFailure).IsSameReferenceAs(cleanupFailure);
+        await Assert.That(deleteAttempts).IsEqualTo(0);
+        await Assert.That(configExistedAfterFailure).IsTrue();
+        await Assert.That(tasksDirectoryExistedAfterFailure).IsTrue();
+        await Assert.That(fixtureDirectoryExistedAfterFailure).IsTrue();
+        await Assert.That(residualDirectoryCleanupFailure).IsNull();
+    }
+
+    [Test]
+    public async Task CleanTasksAsync_UnconnectedFixtureDeletesOwnedPathsOnce()
+    {
+        var fixture = new MainWindowViewModelFixture();
+        Task? firstCleanup = null;
+        Task? concurrentCleanup = null;
+        Task? repeatedCleanup = null;
+        Task? disposeCleanup = null;
+        Exception? cleanupFailure = null;
+        Exception? repeatedCleanupFailure = null;
+        var deleteAttempts = 0;
+        var repositoryWasNull = fixture.MainWindowViewModelTest.taskRepository == null;
+        var configExistedBeforeCleanup = File.Exists(fixture.ConfigPath);
+        var tasksDirectoryExistedBeforeCleanup = Directory.Exists(fixture.DefaultTasksFolderPath);
+        var fixtureDirectoryExistedBeforeCleanup = Directory.Exists(fixture.FixtureDirectoryPath);
+        var deleteAttemptsAfterFirstCleanup = 0;
+        var deleteAttemptsAfterRepeatedCleanup = 0;
+
+        fixture.DeleteFailureInjector = (_, _) =>
+        {
+            Interlocked.Increment(ref deleteAttempts);
+            return null;
+        };
+
+        try
+        {
+            firstCleanup = fixture.CleanTasksAsync();
+            concurrentCleanup = fixture.CleanTasksAsync();
+            disposeCleanup = fixture.DisposeAsync().AsTask();
+            cleanupFailure = await ObserveFailureAsync(firstCleanup);
+            await ObserveFailureAsync(concurrentCleanup);
+            await ObserveFailureAsync(disposeCleanup);
+            deleteAttemptsAfterFirstCleanup = Volatile.Read(ref deleteAttempts);
+
+            repeatedCleanup = fixture.CleanTasksAsync();
+            repeatedCleanupFailure = await ObserveFailureAsync(repeatedCleanup);
+            deleteAttemptsAfterRepeatedCleanup = Volatile.Read(ref deleteAttempts);
+        }
+        finally
+        {
+            var finalCleanup = firstCleanup ?? fixture.CleanTasksAsync();
+            await ObserveFailureAsync(finalCleanup);
+            if (concurrentCleanup != null)
+            {
+                await ObserveFailureAsync(concurrentCleanup);
+            }
+
+            if (repeatedCleanup != null)
+            {
+                await ObserveFailureAsync(repeatedCleanup);
+            }
+
+            if (disposeCleanup != null)
+            {
+                await ObserveFailureAsync(disposeCleanup);
+            }
+        }
+
+        await Assert.That(repositoryWasNull).IsTrue();
+        await Assert.That(configExistedBeforeCleanup).IsTrue();
+        await Assert.That(tasksDirectoryExistedBeforeCleanup).IsTrue();
+        await Assert.That(fixtureDirectoryExistedBeforeCleanup).IsTrue();
+        await Assert.That(firstCleanup).IsSameReferenceAs(concurrentCleanup);
+        await Assert.That(firstCleanup).IsSameReferenceAs(repeatedCleanup);
+        await Assert.That(firstCleanup).IsSameReferenceAs(disposeCleanup);
+        await Assert.That(cleanupFailure).IsNull();
+        await Assert.That(repeatedCleanupFailure).IsNull();
+        await Assert.That(deleteAttemptsAfterFirstCleanup).IsEqualTo(3);
+        await Assert.That(deleteAttemptsAfterRepeatedCleanup).IsEqualTo(deleteAttemptsAfterFirstCleanup);
+        await Assert.That(File.Exists(fixture.ConfigPath)).IsFalse();
+        await Assert.That(Directory.Exists(fixture.DefaultTasksFolderPath)).IsFalse();
+        await Assert.That(Directory.Exists(fixture.FixtureDirectoryPath)).IsFalse();
+    }
+
+    private static DomainTaskStatus NextStatus(DomainTaskStatus current) =>
+        current == DomainTaskStatus.InProgress
+            ? DomainTaskStatus.Prepared
+            : DomainTaskStatus.InProgress;
+
+    private static async Task<Task> WaitForPendingSaveRegistrationAsync(TaskItemViewModel task)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        while (stopwatch.Elapsed < TestTimeout)
+        {
+            var pendingSave = task.WaitForPendingSavesAsync();
+            if (!pendingSave.IsCompleted)
+            {
+                return pendingSave;
+            }
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException($"Pending save was not registered for task '{task.Id}'.");
+    }
+
+    private static async Task<Exception?> ObserveFailureAsync(Task task)
+    {
+        try
+        {
+            await task.WaitAsync(TestTimeout);
+            return null;
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+}

--- a/src/Unlimotion.Test/MainWindowViewModelTests.cs
+++ b/src/Unlimotion.Test/MainWindowViewModelTests.cs
@@ -20,7 +20,7 @@ using L10n = Unlimotion.ViewModel.Localization.Localization;
 
 namespace Unlimotion.Test
 {
-    public class BaseModelTests : IDisposable
+    public class BaseModelTests
     {
         private MainWindowViewModelFixture? _fixture;
         private MainWindowViewModel? _mainWindowVM;
@@ -40,7 +40,19 @@ namespace Unlimotion.Test
         /// <summary>
         /// Очистка после тестов
         /// </summary>
-        public void Dispose() => _fixture?.CleanTasks();
+        [TUnit.Core.After(TUnit.Core.HookType.Test)]
+        public async Task CleanupFixtureAsync()
+        {
+            var fixtureToClean = _fixture;
+            _fixture = null;
+            _mainWindowVM = null;
+            _taskRepository = null;
+
+            if (fixtureToClean is not null)
+            {
+                await fixtureToClean.CleanTasksAsync();
+            }
+        }
 
         private (MainWindowViewModelFixture Fixture, MainWindowViewModel MainWindowViewModel, ITaskStorage TaskRepository) EnsureInitialized()
         {
@@ -90,7 +102,7 @@ namespace Unlimotion.Test
                     }
                     finally
                     {
-                        projectionFixture.CleanTasks();
+                        await projectionFixture.CleanTasksAsync();
                     }
                 }, CancellationToken.None);
             }

--- a/src/Unlimotion.Test/PackageUpdateCompatibilityUiTests.cs
+++ b/src/Unlimotion.Test/PackageUpdateCompatibilityUiTests.cs
@@ -88,7 +88,7 @@ public class PackageUpdateCompatibilityUiTests
             {
                 Dialogs.PlatformOpenFolderDialogAsync = previousPlatformPicker;
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/RoadmapGraphUiTests.cs
+++ b/src/Unlimotion.Test/RoadmapGraphUiTests.cs
@@ -5,7 +5,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Input;
 using Avalonia;
 using Avalonia.Automation;
 using Avalonia.Controls;
@@ -78,7 +77,7 @@ public class RoadmapGraphUiTests
         }
         finally
         {
-            fixture.CleanTasks();
+            await fixture.CleanTasksAsync();
         }
     }
 
@@ -842,7 +841,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -962,7 +961,7 @@ public class RoadmapGraphUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         });
@@ -1091,7 +1090,7 @@ public class RoadmapGraphUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         });
@@ -1178,7 +1177,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1290,7 +1289,7 @@ public class RoadmapGraphUiTests
                 }
 
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1355,7 +1354,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1459,7 +1458,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1527,7 +1526,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1607,7 +1606,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1660,7 +1659,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1669,7 +1668,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_NodeClickSelection_AppliesModifierSemanticsAndVisualState()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1739,7 +1738,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1750,7 +1749,7 @@ public class RoadmapGraphUiTests
         var session = HeadlessUnitTestSession.StartNew(typeof(App));
         try
         {
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
                 Window? window = null;
@@ -1776,26 +1775,26 @@ public class RoadmapGraphUiTests
                     var blocked = WaitForTaskNode(graphControl, MainWindowViewModelFixture.BlockedTask2Id);
                     var root2Node = (RoadmapNode)root2.DataContext!;
 
-                    await ClickControlAsync(window, blocked);
-                    await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
-                    await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Shift);
+                    PressRoadmapNode(blocked, KeyModifiers.None, clickCount: 1);
+                    PressRoadmapNode(root2, KeyModifiers.Control, clickCount: 1);
+                    PressRoadmapNode(root3, KeyModifiers.Shift, clickCount: 1);
                     await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
 
-                    await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
-                    await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Control);
+                    PressRoadmapNode(root2, KeyModifiers.Control, clickCount: 1);
+                    PressRoadmapNode(root2, KeyModifiers.Control, clickCount: 2);
 
                     await Assert.That(root2Node.IsSelected).IsFalse();
                     await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
 
                     await Task.Delay(600);
-                    await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Shift);
-                    await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Shift);
+                    PressRoadmapNode(root2, KeyModifiers.Shift, clickCount: 1);
+                    PressRoadmapNode(root3, KeyModifiers.Shift, clickCount: 1);
                     await Assert.That(root2Node.IsSelected).IsTrue();
                     await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
 
                     await Task.Delay(600);
-                    await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Alt);
-                    await ClickControlAsync(window, root2, modifiers: RawInputModifiers.Alt);
+                    PressRoadmapNode(root2, KeyModifiers.Alt, clickCount: 1);
+                    PressRoadmapNode(root2, KeyModifiers.Alt, clickCount: 2);
 
                     await Assert.That(root2Node.IsSelected).IsFalse();
                     await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(MainWindowViewModelFixture.RootTask3Id);
@@ -1803,7 +1802,7 @@ public class RoadmapGraphUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -1817,7 +1816,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_ModifierDoubleClickSuppression_UsesClickCountWithoutLocalTimeWindow()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1861,7 +1860,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1870,7 +1869,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_SelectedNodeFrame_DoesNotResizeNodeOrShiftContent()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -1911,7 +1910,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -1922,7 +1921,7 @@ public class RoadmapGraphUiTests
         var session = HeadlessUnitTestSession.StartNew(typeof(App));
         try
         {
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
                 Window? window = null;
@@ -1986,7 +1985,7 @@ public class RoadmapGraphUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -2000,7 +1999,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_RectangleHitTesting_IgnoresMinimapItems()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2048,7 +2047,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2057,7 +2056,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_RectangleHitTesting_UsesZoomedNodeBounds()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2114,7 +2113,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2123,7 +2122,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_RectangleSelection_UsesViewportZoom()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2178,7 +2177,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2187,7 +2186,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_NodePointerDrag_StartsAfterMoveThresholdAndKeepsSelection()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2214,7 +2213,7 @@ public class RoadmapGraphUiTests
                     graphControl!,
                     MainWindowViewModelFixture.RootTask2Id);
 
-                var startPoint = GetControlCenterPoint(window, taskNode);
+                var startPoint = GetRoadmapNodePointerPoint(window, taskNode);
                 var movePoint = new Point(startPoint.X + 24, startPoint.Y + 16);
                 var dragStartCountBefore = graphControl!.RoadmapDragStartCount;
 
@@ -2242,14 +2241,14 @@ public class RoadmapGraphUiTests
                 if (mouseIsDown && window is { } topLevel && taskNode != null)
                 {
                     topLevel.MouseUp(
-                        GetControlCenterPoint(topLevel, taskNode),
+                        GetRoadmapNodePointerPoint(topLevel, taskNode),
                         MouseButton.Left,
                         RawInputModifiers.None);
                     Dispatcher.UIThread.RunJobs();
                 }
 
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2258,7 +2257,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_SelectedNodePlainClickWithoutDrag_CollapsesSelectionOnRelease()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2289,7 +2288,7 @@ public class RoadmapGraphUiTests
                     MainWindowViewModelFixture.RootTask3Id
                 });
 
-                var point = GetControlCenterPoint(window, root2);
+                var point = GetRoadmapNodePointerPoint(window, root2);
                 window.MouseDown(point, MouseButton.Left, RawInputModifiers.None);
                 mouseIsDown = true;
                 Dispatcher.UIThread.RunJobs();
@@ -2318,7 +2317,7 @@ public class RoadmapGraphUiTests
                 }
 
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2327,7 +2326,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_SelectedNodeDrag_PreservesMultiSelectionAfterThreshold()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2355,7 +2354,7 @@ public class RoadmapGraphUiTests
                 await ClickControlAsync(window, root3, modifiers: RawInputModifiers.Control);
                 var dragStartCountBefore = graphControl.RoadmapDragStartCount;
 
-                var startPoint = GetControlCenterPoint(window, taskNode);
+                var startPoint = GetRoadmapNodePointerPoint(window, taskNode);
                 var movePoint = new Point(startPoint.X + 24, startPoint.Y + 16);
                 window.MouseDown(startPoint, MouseButton.Left, RawInputModifiers.None);
                 mouseIsDown = true;
@@ -2387,14 +2386,14 @@ public class RoadmapGraphUiTests
                 if (mouseIsDown && window is { } topLevel && taskNode != null)
                 {
                     topLevel.MouseUp(
-                        GetControlCenterPoint(topLevel, taskNode),
+                        GetRoadmapNodePointerPoint(topLevel, taskNode),
                         MouseButton.Left,
                         RawInputModifiers.None);
                     Dispatcher.UIThread.RunJobs();
                 }
 
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2403,7 +2402,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_NodeRightDrag_PansViewportWithoutSelectingTask()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2470,7 +2469,7 @@ public class RoadmapGraphUiTests
                 }
 
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2481,7 +2480,7 @@ public class RoadmapGraphUiTests
         var session = HeadlessUnitTestSession.StartNew(typeof(App));
         try
         {
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
                 Window? window = null;
@@ -2551,7 +2550,7 @@ public class RoadmapGraphUiTests
                     }
 
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -2572,7 +2571,7 @@ public class RoadmapGraphUiTests
         var session = HeadlessUnitTestSession.StartNew(typeof(App));
         try
         {
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
                 Window? window = null;
@@ -2595,7 +2594,7 @@ public class RoadmapGraphUiTests
                     var selectedTask = TestHelpers.GetTask(vm, selectedTaskId);
                     await Assert.That(selectedTask).IsNotNull();
                     var selectedNode = WaitForTaskNode(graphControl!, selectedTaskId);
-                    selectedNode.RaiseEvent(new RoutedEventArgs(InputElement.DoubleTappedEvent));
+                    await ClickControlAsync(window, selectedNode);
                     await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTaskId);
 
                     var taskCountBefore = vm.taskRepository!.Tasks.Count;
@@ -2628,7 +2627,7 @@ public class RoadmapGraphUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -2639,13 +2638,15 @@ public class RoadmapGraphUiTests
     }
 
     [Test]
-    public async Task RoadmapGraph_TaskCardButtons_AfterRoadmapSelection_CreateExpectedTasks()
+    public async Task RoadmapGraph_CreateMenu_AfterRoadmapSelection_CreatesExpectedTasks()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
+            GraphControl? graphControl = null;
+            var roadmapDeactivated = false;
 
             try
             {
@@ -2653,14 +2654,13 @@ public class RoadmapGraphUiTests
                 await vm.Connect();
                 vm.AllTasksMode = false;
                 vm.GraphMode = true;
-                vm.DetailsAreOpen = true;
 
                 var view = new MainControl { DataContext = vm };
                 window = CreateWindow(view);
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
 
-                var graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
+                graphControl = OpenRoadmapTabAndWaitForGraphControl(view);
                 await Assert.That(graphControl).IsNotNull();
                 var selectedTask = TestHelpers.GetTask(vm, MainWindowViewModelFixture.RootTask2Id);
                 await Assert.That(selectedTask).IsNotNull();
@@ -2668,43 +2668,59 @@ public class RoadmapGraphUiTests
                 var selectedNode = WaitForTaskNode(graphControl!, selectedTask!.Id);
                 await ClickControlAsync(window, selectedNode);
                 await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTask.Id);
-                await Assert.That(vm.DetailsAreOpen).IsTrue();
 
                 var countBefore = vm.taskRepository!.Tasks.Count;
-                var createRootButton = FindButtonForCommand(view, vm.Create);
-                await ClickControlAsync(window, createRootButton);
+                ExecuteCreateCommandThroughMenu(view, "GlobalTaskCreateTaskMenuItem");
                 await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
                 var rootCreated = vm.CurrentTaskItem;
                 await Assert.That(rootCreated).IsNotNull();
                 await Assert.That(rootCreated!.Parents).IsEmpty();
 
                 await ClickControlAsync(window, selectedNode);
-                await Assert.That(vm.DetailsAreOpen).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTask.Id);
                 countBefore = vm.taskRepository.Tasks.Count;
-                var createSiblingButton = FindButtonForCommand(view, vm.CreateSibling);
-                await ClickControlAsync(window, createSiblingButton);
+                ExecuteCreateCommandThroughMenu(view, "GlobalTaskCreateSiblingMenuItem");
                 await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
 
                 await ClickControlAsync(window, selectedNode);
-                await Assert.That(vm.DetailsAreOpen).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTask.Id);
                 countBefore = vm.taskRepository.Tasks.Count;
-                var createBlockedSiblingButton = FindButtonForCommand(view, vm.CreateBlockedSibling);
-                await ClickControlAsync(window, createBlockedSiblingButton);
+                ExecuteCreateCommandThroughMenu(view, "GlobalTaskCreateBlockedSiblingMenuItem");
                 await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
                 await Assert.That(selectedTask.Blocks).Contains(vm.CurrentTaskItem!.Id);
 
                 await ClickControlAsync(window, selectedNode);
-                await Assert.That(vm.DetailsAreOpen).IsTrue();
+                await Assert.That(vm.CurrentTaskItem?.Id).IsEqualTo(selectedTask.Id);
                 countBefore = vm.taskRepository.Tasks.Count;
-                var createInnerButton = FindButtonForCommand(view, vm.CreateInner);
-                await ClickControlAsync(window, createInnerButton);
+                ExecuteCreateCommandThroughMenu(view, "GlobalTaskCreateInnerMenuItem");
                 await Assert.That(WaitFor(() => vm.taskRepository.Tasks.Count == countBefore + 1)).IsTrue();
                 await Assert.That(selectedTask.Contains).Contains(vm.CurrentTaskItem!.Id);
+
+                roadmapDeactivated = await DeactivateRoadmapGraphAsync(graphControl);
+                await Assert.That(roadmapDeactivated).IsTrue();
             }
             finally
             {
-                window?.Close();
-                fixture.CleanTasks();
+                try
+                {
+                    if (!roadmapDeactivated)
+                    {
+                        try
+                        {
+                            _ = await DeactivateRoadmapGraphAsync(graphControl);
+                        }
+                        catch (Exception teardownException)
+                        {
+                            Console.Error.WriteLine(
+                                $"Roadmap graph best-effort teardown failed: {teardownException}");
+                        }
+                    }
+                }
+                finally
+                {
+                    window?.Close();
+                    await fixture.CleanTasksAsync();
+                }
             }
         }, CancellationToken.None);
     }
@@ -2713,7 +2729,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_DropWithControl_CreatesBlockingRelationBetweenRoadmapNodes()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2751,6 +2767,7 @@ public class RoadmapGraphUiTests
                     targetNode,
                     new Avalonia.Point(targetNode.Bounds.Width / 2, targetNode.Bounds.Height / 2),
                     KeyModifiers.Control);
+                dropArgs.Source = targetNode;
 
                 await MainControl.Drop(view, dropArgs);
                 await TestHelpers.WaitThrottleTime();
@@ -2763,7 +2780,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2772,7 +2789,7 @@ public class RoadmapGraphUiTests
     public async Task RoadmapGraph_SelectedNodesDragDrop_AppliesBatchOperation()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
-        await session.Dispatch(async () =>
+        await session.DispatchAsync(async () =>
         {
             var fixture = new MainWindowViewModelFixture();
             Window? window = null;
@@ -2809,8 +2826,8 @@ public class RoadmapGraphUiTests
 
                 var firstNode = WaitForTaskNode(graphControl!, firstSource.Id);
                 var secondNode = WaitForTaskNode(graphControl, secondSource.Id);
-                await ClickControlAsync(window, firstNode);
-                await ClickControlAsync(window, secondNode, modifiers: RawInputModifiers.Control);
+                ApplyRoadmapClickSelectionForTest(graphControl, firstNode, firstSource, KeyModifiers.None);
+                ApplyRoadmapClickSelectionForTest(graphControl, secondNode, secondSource, KeyModifiers.Control);
                 await Assert.That(GetSelectedRoadmapTaskIds(graphControl)).IsEquivalentTo(new[]
                 {
                     firstSource.Id,
@@ -2825,6 +2842,7 @@ public class RoadmapGraphUiTests
                     targetNode,
                     new Avalonia.Point(targetNode.Bounds.Width / 2, targetNode.Bounds.Height / 2),
                     KeyModifiers.Control);
+                dropArgs.Source = targetNode;
 
                 await MainControl.Drop(view, dropArgs);
                 await TestHelpers.WaitThrottleTime();
@@ -2846,7 +2864,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -2958,7 +2976,7 @@ public class RoadmapGraphUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
 
@@ -3049,7 +3067,9 @@ public class RoadmapGraphUiTests
         MouseButton button = MouseButton.Left,
         RawInputModifiers modifiers = RawInputModifiers.None)
     {
-        var point = GetControlCenterPoint(window, control);
+        var point = control.DataContext is RoadmapNode
+            ? GetRoadmapNodePointerPoint(window, control)
+            : GetControlCenterPoint(window, control);
         window.MouseDown(point, button, modifiers);
         Dispatcher.UIThread.RunJobs();
         window.MouseUp(point, button, modifiers);
@@ -3128,6 +3148,22 @@ public class RoadmapGraphUiTests
         return point.Value;
     }
 
+    private static Point GetRoadmapNodePointerPoint(Visual relativeTo, Control control)
+    {
+        const double nodePaddingHitOffset = 2;
+        var localPoint = new Point(
+            Math.Min(nodePaddingHitOffset, Math.Max(1, control.Bounds.Width / 2)),
+            Math.Min(nodePaddingHitOffset, Math.Max(1, control.Bounds.Height / 2)));
+        var point = control.TranslatePoint(localPoint, relativeTo);
+
+        if (!point.HasValue)
+        {
+            throw new InvalidOperationException($"Cannot translate roadmap node point for {control.GetType().Name}.");
+        }
+
+        return point.Value;
+    }
+
     private static Rect GetControlBounds(Visual relativeTo, Control control)
     {
         var point = control.TranslatePoint(new Point(0, 0), relativeTo);
@@ -3158,7 +3194,9 @@ public class RoadmapGraphUiTests
     {
         return root.GetVisualDescendants()
             .OfType<Border>()
-            .Where(border => border.DataContext is RoadmapNode)
+            .Where(border =>
+                border.Classes.Contains("roadmapNode") &&
+                border.DataContext is RoadmapNode)
             .ToArray();
     }
 
@@ -3339,11 +3377,49 @@ public class RoadmapGraphUiTests
         window.KeyRelease(key, modifiers, physicalKey, null);
     }
 
-    private static Button FindButtonForCommand(Control root, ICommand command)
+    private static void ExecuteCreateCommandThroughMenu(Control root, string menuItemAutomationId)
     {
-        return root.GetVisualDescendants()
-            .OfType<Button>()
-            .First(button => ReferenceEquals(button.Command, command));
+        var createMenuButton = root.GetVisualDescendants()
+            .OfType<DropDownButton>()
+            .First(button =>
+                string.Equals(
+                    AutomationProperties.GetAutomationId(button),
+                    "GlobalTaskCreateMenuButton",
+                    StringComparison.Ordinal) &&
+                button.IsVisible &&
+                button.IsEnabled);
+
+        if (createMenuButton.Flyout is not MenuFlyout menuFlyout)
+        {
+            throw new InvalidOperationException("Global create button should use a MenuFlyout.");
+        }
+
+        menuFlyout.ShowAt(createMenuButton);
+        Dispatcher.UIThread.RunJobs();
+
+        try
+        {
+            var menuItem = menuFlyout.Items
+                .OfType<MenuItem>()
+                .First(item => string.Equals(
+                    AutomationProperties.GetAutomationId(item),
+                    menuItemAutomationId,
+                    StringComparison.Ordinal));
+
+            if (!menuItem.IsVisible || !menuItem.IsEnabled)
+            {
+                throw new InvalidOperationException(
+                    $"Expected create menu item '{menuItemAutomationId}' to be visible and enabled.");
+            }
+
+            menuItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent, menuItem));
+            Dispatcher.UIThread.RunJobs();
+        }
+        finally
+        {
+            menuFlyout.Hide();
+            Dispatcher.UIThread.RunJobs();
+        }
     }
 
     private static TaskItemViewModel AddVisibleRoadmapFilterEmoji(MainWindowViewModel vm)
@@ -3461,6 +3537,7 @@ public class RoadmapGraphUiTests
             border = root.GetVisualDescendants()
                 .OfType<Border>()
                 .FirstOrDefault(candidate =>
+                    candidate.Classes.Contains("roadmapNode") &&
                     candidate.DataContext is RoadmapNode node &&
                     node.Id == taskId &&
                     candidate.GetVisualDescendants()
@@ -3663,6 +3740,36 @@ public class RoadmapGraphUiTests
         return await WaitForAsync(
             () => graphControl.RoadmapGraphUpdateCount > previousUpdateCount,
             timeoutMilliseconds);
+    }
+
+    private static async Task<bool> DeactivateRoadmapGraphAsync(
+        GraphControl? graphControl,
+        int timeoutMilliseconds = 5000)
+    {
+        if (graphControl == null)
+        {
+            return true;
+        }
+
+        graphControl.DataContext = null;
+        return await WaitForAsync(
+            () => !graphControl.RoadmapGraphBuildInProgress &&
+                  GetRoadmapActiveBuildCountForTest(graphControl) == 0,
+            timeoutMilliseconds);
+    }
+
+    private static int GetRoadmapActiveBuildCountForTest(GraphControl graphControl)
+    {
+        var field = typeof(GraphControl).GetField(
+            "roadmapActiveBuildCount",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+        if (field == null)
+        {
+            throw new InvalidOperationException("GraphControl.roadmapActiveBuildCount was not found.");
+        }
+
+        return (int)field.GetValue(graphControl)!;
     }
 
     private static bool IsVisibleAndArranged(Control control)

--- a/src/Unlimotion.Test/SafeHeadlessUnitTestSessionTests.cs
+++ b/src/Unlimotion.Test/SafeHeadlessUnitTestSessionTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using Unlimotion;
+
+namespace Unlimotion.Test;
+
+[NotInParallel("AvaloniaHeadless")]
+[ParallelLimiter<SharedUiStateParallelLimit>]
+public class SafeHeadlessUnitTestSessionTests
+{
+    [Test]
+    public async Task Dispatch_AwaitsAsyncCallbackBeforeReturning()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        var actionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseAction = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dispatchTask = session.Dispatch(async () =>
+        {
+            actionStarted.SetResult();
+            await releaseAction.Task;
+        }, CancellationToken.None);
+
+        try
+        {
+            await actionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await Task.Delay(50);
+            await Assert.That(dispatchTask.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            releaseAction.TrySetResult();
+            await dispatchTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
+    public async Task DispatchAsync_PreservesUiThreadAcrossAwait()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+
+        await session.DispatchAsync(async () =>
+        {
+            await Assert.That(Dispatcher.UIThread.CheckAccess()).IsTrue();
+
+            await Task.Delay(50);
+
+            await Assert.That(Dispatcher.UIThread.CheckAccess()).IsTrue();
+        }, CancellationToken.None);
+    }
+}

--- a/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
+++ b/src/Unlimotion.Test/SettingsControlResponsiveUiTests.cs
@@ -63,7 +63,7 @@ public class SettingsControlResponsiveUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -108,7 +108,7 @@ public class SettingsControlResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -119,7 +119,7 @@ public class SettingsControlResponsiveUiTests
         var session = HeadlessUnitTestSession.StartNew(typeof(App));
         try
         {
-            await session.Dispatch(async () =>
+            await session.DispatchAsync(async () =>
             {
                 var fixture = new MainWindowViewModelFixture();
                 Window? window = null;
@@ -189,7 +189,7 @@ public class SettingsControlResponsiveUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }
@@ -248,7 +248,7 @@ public class SettingsControlResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -327,7 +327,7 @@ public class SettingsControlResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -400,7 +400,7 @@ public class SettingsControlResponsiveUiTests
             {
                 Dialogs.PlatformOpenFolderDialogAsync = previousPlatformPicker;
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -450,7 +450,7 @@ public class SettingsControlResponsiveUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -912,6 +912,8 @@ public class SettingsControlResponsiveUiTests
 
     private static async Task ClickControlAsync(Window window, Control control)
     {
+        control.BringIntoView();
+        Dispatcher.UIThread.RunJobs();
         var point = control.TranslatePoint(
             new Point(control.Bounds.Width / 2, control.Bounds.Height / 2),
             window);
@@ -919,6 +921,11 @@ public class SettingsControlResponsiveUiTests
         if (!point.HasValue)
         {
             throw new InvalidOperationException($"Cannot translate point for control {control.GetType().Name}.");
+        }
+
+        if (!window.Bounds.Contains(point.Value))
+        {
+            throw new InvalidOperationException($"Control {control.GetType().Name} is outside the test window viewport.");
         }
 
         window.MouseDown(point.Value, MouseButton.Left, RawInputModifiers.None);

--- a/src/Unlimotion.Test/TaskImportanceUiTests.cs
+++ b/src/Unlimotion.Test/TaskImportanceUiTests.cs
@@ -69,7 +69,7 @@ public class TaskImportanceUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -113,7 +113,7 @@ public class TaskImportanceUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }
@@ -171,7 +171,7 @@ public class TaskImportanceUiTests
             finally
             {
                 CloseWindow(window);
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
+++ b/src/Unlimotion.Test/TaskListRepeaterMarkerUiTests.cs
@@ -72,7 +72,7 @@ public class TaskListRepeaterMarkerUiTests
                 finally
                 {
                     window?.Close();
-                    fixture.CleanTasks();
+                    await fixture.CleanTasksAsync();
                 }
             }, CancellationToken.None);
         }

--- a/src/Unlimotion.Test/ToastNotificationUiTests.cs
+++ b/src/Unlimotion.Test/ToastNotificationUiTests.cs
@@ -54,7 +54,7 @@ public class ToastNotificationUiTests
             finally
             {
                 window?.Close();
-                fixture.CleanTasks();
+                await fixture.CleanTasksAsync();
             }
         }, CancellationToken.None);
     }

--- a/src/Unlimotion.ViewModel/AssemblyInfo.cs
+++ b/src/Unlimotion.ViewModel/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Unlimotion.Test")]

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -67,6 +67,8 @@ namespace Unlimotion.ViewModel
         private readonly SerialDisposable _completionCriteriaPropertyChangedSubscription = new();
         private readonly object _pendingSavesLock = new();
         private readonly HashSet<Task> _pendingSaves = [];
+        private bool _acceptingSaves = true;
+        private Task? _sealedPendingSavesTask;
         private bool _isUpdatingFromModel;
         public bool IsHighlighted { get; set; }
         private TimeSpan? plannedPeriod;
@@ -1052,13 +1054,30 @@ namespace Unlimotion.ViewModel
 
         private void ExecuteSaveCommand()
         {
-            var saveTask = SaveItemCommand.Execute().ToTask();
+            Task saveTask;
             lock (_pendingSavesLock)
             {
+                if (!_acceptingSaves)
+                {
+                    return;
+                }
+
+                saveTask = SaveItemCommand.Execute().ToTask();
                 _pendingSaves.Add(saveTask);
             }
 
             _ = ObserveSaveCompletionAsync(saveTask);
+        }
+
+        internal Task SealPendingSaves()
+        {
+            lock (_pendingSavesLock)
+            {
+                _acceptingSaves = false;
+                return _sealedPendingSavesTask ??= _pendingSaves.Count == 0
+                    ? Task.CompletedTask
+                    : Task.WhenAll(_pendingSaves.ToArray());
+            }
         }
 
         public Task WaitForPendingSavesAsync()


### PR DESCRIPTION
## Summary
- Make `MainWindowViewModelFixture` cleanup a single awaitable, idempotent lifecycle operation.
- Seal and drain registered `TaskItemViewModel` saves before storage disposal and fixture-directory deletion.
- Remove the Headless `Task<Task>` false-await that allowed async callbacks to outlive their tests.

## Changes
- Add a same-lock, friend-only save seal in `TaskItemViewModel` and aggregate cleanup failures without hiding terminal delete errors.
- Migrate all 147 fixture cleanup consumers to awaited cleanup, with an explicit TUnit `After(Test)` owner for `BaseModelTests`.
- Add four deterministic lifecycle regressions and two Safe Headless dispatch regressions.
- Repair Roadmap/Settings test-only interactions, including real create-menu items and an explicit Roadmap background-build drain.
- Record the approved contract, findings, and exact evidence manifest in `specs/2026-07-17-test-fixture-lifecycle.md`.

## Validation
- Deterministic pre-fix RED matched only `cleanup completed before controlled save release`.
- `dotnet build src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug --no-restore`: PASS, 0 errors.
- Lifecycle target: 4/4; stress: 20 consecutive runs × 4/4, residual directories 0 after every run.
- Safe Headless: 2/2; Settings: 12/12; Roadmap: 31/31; focused real CreateMenu: 1/1.
- Full `Unlimotion.Test`: 606/606, 0 failed, 11m58s.
- Full `Unlimotion.UiTests.Headless`: 31/31, 0 failed, 58s.
- Exact eight-log marker scan: 0 lifecycle markers; final `MainWindowViewModelFixture_*` directories: 0.
- Static gates: 147/147 cleanup consumers awaited; old `CleanTasks()` 0; unsafe raw `Dispatch(async ...)` outside regression 0; added `async void` 0; 28/28 paths allowlisted; clean post-commit worktree.
- Independent lifecycle, migration/UI, and evidence reviews: PASS.

- UI video: N/A — production UI and user-visible flows are unchanged; only Headless test automation was repaired. Next-best evidence: Safe 2/2, Settings 12/12, Roadmap 31/31, focused CreateMenu 1/1, and full Headless 31/31.

## Risks / Rollback
- Production-visible UI, storage schema, workflows, and Actions topology are unchanged. The only production-assembly seam is internal and friend-accessible only to `Unlimotion.Test`.
- Cleanup drains registered `TaskItemViewModel` saves; it is not a universal barrier for arbitrary already-running `ITaskStorage` operations or an already-running expansion-state timer callback.
- Roll back by reverting this PR; no data migration is required.

## Links
- Prerequisite for #274.
- Approved child spec: `specs/2026-07-17-test-fixture-lifecycle.md`.
- Original failing/timed-out run: https://github.com/Kibnet/Unlimotion/actions/runs/29584922060