### PR TITLE
fix(tasks): create independent recurring task subtrees

### DIFF
--- a/specs/2026-08-31-repeater-completion-without-start-date.md
+++ b/specs/2026-08-31-repeater-completion-without-start-date.md
@@ -1,0 +1,343 @@
+# Доступность повторения только при заданной дате начала
+
+## 0. Метаданные
+- Тип (профиль): UI bugfix; `dotnet-desktop-client` + `ui-automation-testing`, context `testing-dotnet`.
+- Владелец: пользователь; реализация и самопроверка — Codex.
+- Масштаб: small; видимость блока настроек и сброс зависимого поля в ViewModel.
+- Целевое семейство / behavior baseline: GPT-5.6; немодельная задача.
+- Поверхность: Codex desktop, Windows, PowerShell.
+- Effective runtime: model ID/effort не подтверждались и для результата приложения несущественны; SDK 10.0.400 проверен.
+- Eval baseline / evidence: не применимо к моделям; для приложения нужны regression и UI evidence до/после.
+- Целевой релиз / ветка: PR #287, `fix/repeater-requires-start-date`; исходный detached HEAD `f39b3245`, актуальная base после ребейза — `edf83000` (`origin/main`, PR #288).
+- Ограничения: до «Спеку подтверждаю» изменяется только эта spec; нет работы с пользовательскими данными или Git delivery.
+- Instruction stack: central AGENTS/routing; creator-vibe-lens; model-behavior-baseline; tool-execution-baseline; collaboration-baseline; quest-governance/mode; testing-baseline/dotnet; указанные профили; spec-linter/rubric/review-loops; локальный AGENTS.override.
+- Canonical template: `C:/Users/Kibnet/.codex/agents/templates/specs/_template.md`.
+- История решения: пользователь отклонил предложенное ранее создание повтора без начала. Эта редакция полностью заменяет прежний TO-BE; историческое имя файла сохранено, старый алгоритм не реализуется.
+
+## 1. Overview / Цель
+Не позволять интерфейсу обещать повторение, которое без даты начала не сработает. Пользователь выбрал правило: настройки повторения скрыты без начала; очистка начала отключает уже заданное повторение.
+
+Outcome contract:
+- Success means: нет начала — нет блока настройки; установили начало — блок появился; очистили начало — повтор сброшен и это сохранено.
+- Итоговый артефакт / output: минимальные изменения ViewModel/XAML, regression/UI tests и evidence.
+- Stop rules: SPEC заканчивается approval gate; EXEC — только после red/green, UI evidence, сборки, полных suites и review. Старое предложение fallback даты не выполнять.
+
+## 2. Текущее состояние (AS-IS)
+- `TaskTreeManager.HandleTaskStatusChange` создаёт повтор только при активном Repeater и заполненном PlannedBeginDateTime. По уточнению пользователя это условие остаётся правильным.
+- `MainControl.axaml`: внешний блок `CurrentTaskRepeaterSection` не зависит от даты, поэтому настройки доступны и без неё.
+- Поле `CurrentTaskPlannedBeginPicker` и команда `DateCommands.SetBeginNone` меняют одно свойство `TaskItemViewModel.PlannedBeginDateTime`.
+- Подписка изменения начала в TaskItemViewModel сейчас обрабатывает перенос конца/длительности, но не сбрасывает Repeater при null.
+- Изменения PlannedBeginDateTime и Repeater уже входят в общий throttled autosave. Model getter включает оба поля.
+- Конструктор присваивает Model до Init. `WhenAnyValue` испускает начальное значение, а `Update(TaskItem)` поднимает изменения при `_isUpdatingFromModel=true` и загружает Repeater после дат. Это важно для защиты от сброса при загрузке.
+- Существующие маркеры ↻ зависят от Repeater; присваивание null уведомляет UI и меняет подписку на параметры.
+- В прошлой фазе выполнен baseline TaskStatusTransitionTests: 18/18, exit 0. Это проверка старого handler, не нового UI правила.
+
+## 3. Проблема
+UI допускает настройку повторения без обязательной даты начала и оставляет повтор включённым после удаления этой даты.
+
+## 4. Цели дизайна
+Единый сброс в ViewModel для обоих UI путей; скрытие всей секции без пустой рамки; сохранение через существующий autosave; отсутствие побочных записей при загрузке; неизменные календарные и серверные правила.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не создаём повтор без даты и не вводим fallback от завершения.
+- Не меняем TaskTreeManager, календарный алгоритм, правила статуса, API/CLI или серверную валидацию.
+- Не выполняем миграцию и автоматическую очистку старых записей при чтении.
+- Не меняем конец, длительность, отношения, статус или прочие поля при очистке начала.
+- Не добавляем подтверждающий диалог, новую настройку или автоматическое восстановление отменённого повтора.
+- Не меняем общий дизайн карточки, фильтры, Git delivery, установку и релиз.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- MainControl.axaml: видимость внешнего CurrentTaskRepeaterSection по наличию PlannedBeginDateTime.
+- TaskItemViewModel: синхронно сбросить Repeater при локальной очистке начала; не трогать его при model hydration/инициализации.
+- Существующие autosave и уведомления: сохранить оба поля и обновить маркер.
+- Tests: проверять UI, состояние модели, read-back, отсутствие ложного сброса и регрессии.
+
+### 6.2 Детальный дизайн
+1. Связать IsVisible внешнего Border CurrentTaskRepeaterSection с наличием даты. Использовать принятый nullable binding либо вычисляемый bool с корректными уведомлениями, если прямой binding неприменим.
+2. Скрывать всю секцию: шаблон, тип, период, «после выполнения», дни недели, рамку и занимаемое место. Элементы не участвуют в Tab-навигации.
+3. При локальном переходе начала из заданного значения в null присвоить `Repeater = null`. Сбросить объект целиком, а не только тип: старый период/дни/AfterComplete не должны возвращаться после повторной установки даты.
+4. Общий обработчик свойства покрывает очистку CalendarDatePicker и SetBeginNone. Не дублировать логику в команде/коде окна.
+5. Отличать изменение от начальной эмиссии WhenAnyValue и от Update(TaskItem): пропустить initial emission или проверять переход и учитывать _isUpdatingFromModel. Не запускать очищение сохранённых данных при открытии/синхронизации.
+6. После сброса общий autosave сохраняет null в начале и Repeater. Отдельный параллельный save не добавлять; использовать текущий lifecycle и drain в тестах. Не обещать новую атомарность concurrent/external updates.
+7. Повторная установка даты показывает блок с выключенным повторением; выбор режима остаётся действием пользователя.
+8. Замена одной непустой даты другой сохраняет выбранный повтор. Прежний перенос конца/длительности сохраняется.
+9. При очистке начала конец и PlannedDuration не меняются. Присваивание Repeater=null обновляет ↻ через существующие уведомления.
+10. Старые записи «нет начала + есть Repeater» при загрузке не мигрируются: секция скрыта, данные сохраняются как есть. Установка начала для такой старой записи делает её существующие настройки доступными. Это отдельно от восстановления повтора после нового пользовательского сброса, который сохраняет null.
+11. Ошибки сохранения идут через текущий SaveItemCommand/уведомления; скрытие секции само по себе не считается доказательством успешной записи.
+
+Visual planning artifact: текстовый storyboard; новая геометрия/контролы не вводятся:
+```text
+Начало: [не задано]     → секции «Повторение» нет, пустой рамки нет
+Начало: [дата]          → секция видна, можно выбрать повторение
+Начало: [дата], ↻       → очистить начало
+Начало: [не задано]     → секция исчезла, ↻ исчез, Repeater=null сохранён
+Начало: [другая дата]   → секция вернулась, повторение выключено
+```
+UI evidence: в EXEC записать автоматизированные «до» и «после» на синтетических данных через FlaUI и существующий подход recording handshake.
+Local-only пути: `artifacts/ui-evidence/repeater-start-date/before.mp4`, `after.mp4`.
+Fallback вместо видео только по установленной технической причине с командой и next-best screenshots/logs; headless assertion не называть записью окна.
+
+### 6.3 User-Observable Scenarios
+| Scenario | User action / trigger | Expected visible result / output | Evidence required | Covered by AC |
+| --- | --- | --- | --- | --- |
+| S1 | Открыть задачу без начала | Секции повторения нет | UI layout/Tab test | AC1 |
+| S2 | Установить начало | Секция появляется и доступна | UI test | AC1 |
+| S3 | Включить повтор, очистить начало полем или «Нет» | Секция и маркер исчезают; повтор отключён | UI + сохранённая модель | AC2, AC3 |
+| S4 | Установить начало снова | Повтор не восстанавливается автоматически | UI + reopen | AC3 |
+| S5 | Заменить дату другой датой | Повтор сохранён | Regression test | AC4 |
+
+### 6.4 State / Interaction Matrix
+| Current state | Trigger | Expected transition/result | Empty/error/disabled/concurrent case | Notes |
+| --- | --- | --- | --- | --- |
+| Начало null, Repeater null | Открыть | Секция скрыта | Нет записей от открытия | Новая/обычная задача |
+| Начало есть, повтор есть | Очистить локально | Оба поля null; секция скрыта | При ошибке save текущий error flow | CalendarDatePicker и команда |
+| Начало есть, повтор None/null | Очистить | Без исключения; секция скрыта | Повтор уже выключен | Нет лишних действий |
+| Начало null после сброса | Установить дату | Секция видна, повтор null | Не восстановить старый объект | Новый выбор вручную |
+| Начало есть | Другая непустая дата | Повтор сохранён | Прежний перенос конца | Без регрессии |
+| Любое | Update/initial hydration | Принять authoritative поля без локального autosave | Старый inconsistent snapshot не мигрируется | Сохранить read-only загрузку |
+| Дата+повтор корректны | Completed | Прежний следующий экземпляр | Прежние ограничения завершения | Handler не меняется |
+
+### 6.5 Decision Ledger
+| Decision | Owner | Default / chosen option | Confidence | Risk if assumed | Needs user before EXEC |
+| --- | --- | --- | ---: | --- | --- |
+| Начало обязательно | user | Скрыть настройки без даты | 1.00 | Нет — прямое уточнение | Нет |
+| Удаление начала | user | Отключить повтор | 1.00 | Нет — прямое уточнение | Нет |
+| Представление отключения | agent | Repeater=null | 0.98 | Возврат старых параметров при частичном сбросе | Нет |
+| Старые данные/синхронизация | agent | Не мигрировать при чтении | 0.95 | Неявная очистка данных выходит за запрос | Нет |
+| Отмена удаления даты | agent | Повтор не восстановить автоматически | 0.98 | Иначе сброс неустойчив | Нет |
+
+### 6.6 Runtime / Config / Data Contract Matrix
+| Contract area | Current source of truth | Expected change | Compatibility / migration | Verification |
+| --- | --- | --- | --- | --- |
+| Поля задачи | TaskItem → ViewModel → autosave | Очистка начала сохраняет Repeater=null | Формат прежний, без миграции | Save/read-back/reopen |
+| Видимость | MainControl binding | Наличие начала управляет секцией | Automation IDs сохраняются | UI at desktop/phone widths |
+| Hydration | Update + _isUpdatingFromModel | Без побочного reset/save | Старые данные неизменны | Identity/model assertions и проверка existing CanAutosave guard в исходном коде |
+| Генерация повтора | TaskTreeManager | Не меняется | Дата остаётся обязательной | Existing status tests |
+
+## 7. Бизнес-правила / Алгоритмы
+`Visible(RepeaterSection) = PlannedBeginDateTime.HasValue`.
+Локальный переход `date → null` сбрасывает Repeater; `date A → date B` не сбрасывает.
+После завершённого сброса последующая установка даты не включает повтор.
+Initial load/model hydration не считаются пользовательской очисткой.
+
+## 8. Точки интеграции и триггеры
+Наличие даты в XAML; общий обработчик PlannedBeginDateTime; существующие сохранение/notification при Repeater=null. Покрыть SetBeginNone и очистку поля, а не только прямое присваивание в тесте.
+
+## 9. Изменения модели данных / состояния
+Новых persisted полей нет. Repeater=null — существующее представление отсутствия повторения. Вычисляемый bool для binding допустим при необходимости; новая настройка не нужна.
+
+## 10. Миграция / Rollout / Rollback
+Миграции нет. Открытие старой записи не пишет данные. Откат кода восстанавливает прежний UI, но не воссоздаёт повтор, который пользователь уже явно сбросил. Не изменять пользовательское хранилище при разработке.
+
+## 11. Тестирование и критерии приёмки
+- AC1: без начала вся секция скрыта без пустой рамки и Tab-stop; с началом доступна. Desktop и узкая ширина.
+- AC2: очистка начала обоими UI путями сбрасывает Repeater/null и маркер; конец, длительность и прочие поля не изменяются.
+- AC3: autosave/read-back/reopen подтверждают сброс; повторная установка даты не возвращает прежний повтор. Покрыть Daily и Weekly с параметрами/AfterComplete.
+- AC4: date→date сохраняет повтор; initial load/Update не сбрасывают настройки и не вызывают лишнее сохранение; legacy snapshot проверен отдельно.
+- AC5: корректная повторяемая задача с датой завершается как прежде; сборка и полные CI suites green; новые UI tests и before/after evidence выполнены либо конкретный blocker явно отражён как незавершённая проверка.
+
+### Acceptance-to-Test Matrix
+| Acceptance criterion | Automated test | Manual / visual / log check | Evidence artifact | If not tested, why |
+| --- | --- | --- | --- | --- |
+| AC1 | MainControlRepeaterStartDateUiTests | Секция/рамка исчезают, скрытый ComboBox не получает focus; ширины 1400/390 | `artifacts/repeater-start-date-green.log`, `artifacts/ui-evidence/repeater-start-date/final/*.png` | PASS; native video заменено безопасными снимками |
+| AC2, AC3 | Тот же UI класс + TaskItemRepeaterStartDateTests; RepeaterStartDateFlaUiTests | Маркер, конец/длительность, JSON read-back и повторная установка даты | Targeted 12/12, native 1/1; логи в Post-EXEC | PASS |
+| AC4 | TaskItemRepeaterStartDateTests + existing layout/marker tests | Initial load/Update сохраняют модель и identity Repeater; CanAutosave guard просмотрен | Regression assertions + source review | PASS, включая расширенную identity assertion в полном прогоне |
+| AC5 | TaskStatusTransitionTests; полный Unlimotion.Test + UiTests.Headless; focused FlaUI | Ненулевой test count, exit 0 | `artifacts/repeater-full-unit.log`, `artifacts/repeater-full-headless.log`, native/build logs | PASS: 916/916 основной, 38/38 Headless, 1/1 FlaUI; build exit 0 |
+
+Команды EXEC, последовательно:
+```powershell
+dotnet --version
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -p:UseSharedCompilation=false -- --treenode-filter '/*/*/TaskItemRepeaterStartDateTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -p:UseSharedCompilation=false -- --treenode-filter '/*/*/MainControlRepeaterStartDateUiTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet test --project tests/Unlimotion.UiTests.FlaUI/Unlimotion.UiTests.FlaUI.csproj -c Debug -p:UseSharedCompilation=false -- --treenode-filter '/*/*/RepeaterStartDateFlaUiTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet build src/Unlimotion.Desktop/Unlimotion.Desktop.csproj -c Debug -p:UseSharedCompilation=false
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --output Detailed
+dotnet test --project tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj -c Debug -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --output Detailed
+git diff --check
+```
+Новые имена классов — план. Сначала воспроизводящие red UI/VM tests, затем fix, targeted green и full gates по .github/workflows/tests.yml. Сокращать throttle только test-local с восстановлением/изоляцией; проверять фактическое сохранение, а не ожидать произвольный sleep. До длинных запусков сообщать команду/progress, использовать реальные длительности этапов. Timeout/environment failure не product red; не повторять ту же команду без диагностики.
+
+## 12. Риски и edge cases
+- Начальная эмиссия WhenAnyValue может удалить старые настройки: исключить её и hydration.
+- Сброс только в SetBeginNone оставит неисправной очистку поля: общий ViewModel обработчик.
+- Скрытие внутренних контролов оставит рамку/отступ: скрыть внешний Border.
+- Утечка старого Repeater через сохранённый объект или события: проверить null/отписку/повторную установку даты.
+- Быстрые действия и autosave: ждать существующего сохранения, не вводить отдельную параллельную запись.
+- Layout tests, ожидающие видимую секцию у задач без начала, нужно актуализировать осмысленными fixtures с датой; остальные проверки не ослаблять.
+
+### Expected User Review Objections
+| Likely objection | Why likely | Mitigation in spec/code plan | Status |
+| --- | --- | --- | --- |
+| Настройки скрылись, а повтор остался | Одного IsVisible недостаточно | Repeater=null + save/read-back/reopen | mitigated |
+| После возврата даты вернулись старые дни/период | Частичный сброс мог оставить объект | Сбрасывать весь объект, S4 | mitigated |
+| Пропали настройки от открытия задачи | Подписка ловит initial/model values | Hydration guard и отдельные tests | mitigated |
+
+### Rework Prevention Checklist
+Сценарии S1–S5 видимы и связаны с AC; решения пользователя отделены от implementation choices; старый fallback отменён; guards для hydration/initial emission описаны; evidence включает UI и сохранение; роль UX применима.
+
+## 13. План выполнения
+1. Получить approval этой редакции.
+2. Добавить reproducing VM/UI tests, сохранить automated before evidence.
+3. Исправить видимость и общий сброс; актуализировать только затронутые fixtures.
+4. Проверить сохранение, повторное открытие, hydration и keyboard/layout; after evidence, build и полные suites.
+5. Post-EXEC review и итог с фактами/ограничениями; без Git delivery.
+
+## 14. Открытые вопросы
+Блокирующих продуктовых вопросов нет: пользователь выбрал правило и подтвердил эту редакцию фразой «Спеку подтверждаю».
+
+## 15. Соответствие профилю
+Async autosave без UI блокировок; automation IDs сохранены; обязательные UI tests и evidence; .NET build/full suites; только синтетические данные. Повторение с датой остаётся прежним.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| specs/2026-08-31-repeater-completion-without-start-date.md | Новая редакция и журнал | Уточнение пользователя |
+| src/Unlimotion.ViewModel/TaskItemViewModel.cs | Сброс повтора при локальной очистке начала | Общая реакция для UI путей |
+| src/Unlimotion/Views/MainControl.axaml | Видимость всей секции | Не показывать недоступные настройки |
+| src/Unlimotion.Test/TaskItemRepeaterStartDateTests.cs | Новые regression cases | Состояние/save/hydration |
+| src/Unlimotion.Test/MainControlRepeaterStartDateUiTests.cs | Новые UI cases | Поле, команда, видимость, маркер, reopen |
+| src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs | Fixture с датой для видимого блока | Сохранить layout coverage |
+| tests/Unlimotion.UiTests.FlaUI/Tests/RepeaterStartDateFlaUiTests.cs | Автоматизированный desktop flow с JSON read-back | Безопасные снимки окна из UI test run; fallback описан ниже |
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Нет начала | Настройки повторения доступны | Секция скрыта |
+| Очистка начала | Повтор остаётся | Повтор сбрасывается и сохраняется |
+| Новая установка после сброса | Мог остаться старый повтор | Нужно выбрать повтор заново |
+| Handler завершения | Требует дату | Без изменения |
+
+## 18. Альтернативы и компромиссы
+- Ранее предложенное создание без даты: отменено прямым уточнением пользователя.
+- Только скрыть секцию: не выполняет требование сброса.
+- Сбросить только Type: сохраняет параметры и риск восстановления; выбран null.
+- Нормализовать все старые записи при чтении: лишняя миграция; не выбрана.
+- Общий обработчик ViewModel + видимость Border: покрывает оба UI пути с минимальными production-правками.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+| Блок | Пункт | Статус | Комментарий |
+| --- | --- | --- | --- |
+| A | 1. Цель | PASS | Прямое уточнение пользователя |
+| A | 2. AS-IS | PASS | UI, даты, autosave и hydration просмотрены |
+| A | 3. Проблема | PASS | Доступность и очистка зависимого поля |
+| A | 4. Дизайн | PASS | Общий VM handler, внешний Border |
+| A | 5. Non-Goals | PASS | Генератор/миграция/delivery исключены |
+| B | 6. Ответственность | PASS | UI/VM/storage разграничены |
+| B | 7. Интеграция | PASS | Поле и SetBeginNone |
+| B | 8. Правила | PASS | Переходы и legacy явно описаны |
+| B | 9. Ошибки | PASS | Existing save error flow |
+| B | 10. Perf | PASS | Без новых обходов и таймеров |
+| C | 11. Данные | PASS | Repeater=null, без схемы |
+| C | 12. Миграция | PASS | Нет фоновой очистки |
+| C | 13. Rollback | PASS | Revert кода не воссоздаёт удалённую настройку |
+| D | 14. AC | PASS | Видимость + state + persistence |
+| D | 15. Tests | PASS | Red/green, UI, negative cases |
+| D | 16. Команды | PASS | Existing TUnit workflow |
+| E | 17. План | PASS | Approval → regression → fix → validation |
+| E | 18. Вопросы | PASS | Правило выбрано пользователем |
+| E | 19. Масштаб | PASS | Два production-файла |
+| F | 20. Профиль | PASS | UI evidence, build/full tests |
+Итог: ГОТОВО.
+
+### SPEC Rubric Result
+| Критерий | Балл (0/2/5) | Обоснование |
+| --- | ---: | --- |
+| Ясность цели/границ | 5 | Прямое уточнение, старый вариант отменён |
+| AS-IS | 5 | Изучены binding, команды, init/update/autosave |
+| TO-BE | 5 | Guard, сброс и поведение повторной установки |
+| Безопасность | 5 | Нет миграции/неявного стирания при чтении |
+| Тестируемость | 5 | UI, VM, save/reopen, hydration |
+| Готовность к EXEC | 5 | Нет открытых решений, файлы и команды заданы |
+Итог: 30/30; готово после approval. Это оценка spec, не подтверждение реализации.
+
+### Role-Based Review Result
+| Role | Applicability | Review question | Verdict | Required spec changes |
+| --- | --- | --- | --- | --- |
+| Business analyst / domain workflow | applicable | Соответствует уточнению пользователя? | PASS | Начало обязательно, сброс указан |
+| UX / designer | applicable | Скрыт ли весь блок, не потерян ли UI путь? | PASS | Border, Tab и оба способа очистки |
+| Tester / validation | applicable | Доказан ли устойчивый сброс? | PASS | Save/reopen/restore date и hydration |
+| Developer / architect | applicable | Не стираются ли данные от подписок? | PASS | Initial emission и model update guard |
+| Delivery / operations / security | not applicable | Есть ли внешние изменения? | PASS | Нет deployment/config/secrets/Git |
+
+### Post-SPEC Review
+- Статус: PASS.
+- Scope reviewed: текущая spec; ранее прочитанный central stack/override; MainControl repeater/planning blocks, TaskItemViewModel Init/Model/Update, DateCommands; layout/marker/deadline tests.
+- Decision: можно запросить подтверждение новой редакции.
+- Review passes:
+  - Scope/Evidence: требование взято из текущего сообщения пользователя; прежний handler fix убран из всех исполняемых разделов.
+  - Contract: требования скрытия/сброса соответствуют S1–S5 и AC1–AC5; old generation guard не меняется.
+  - Adversarial risk: initial emission, hydration order, null/None, date→date, очистка поля, stale repeater subscriptions, old snapshots, layout expectations.
+  - Role-Based: все применимые роли проверены, см. таблицу; self-review, не независимый review. Small change не требует отдельного reviewer.
+  - Fix and re-review: добавлены initial/hydration guards и явное отсутствие миграции; повторно сверены разделы 5–12 и AC.
+  - Stop decision: PASS для запроса approval; не переходить к коду.
+- Evidence inspected: live source snippets и git status; предыдущий baseline 18/18 относится к старому handler, повторно в этой редакции не запускался. Новые UI tests до EXEC не выполнялись.
+- Depth checklist: scope ограничен; все AC имеют evidence; предположения отражены; миграции/старый fallback исключены; UI на desktop/phone и keyboard предусмотрены; validation claims не опережают выполнение; релизные docs не меняются.
+- Manual-review challenge: открытие задачи запускает первую эмиссию и может стереть повтор без действия пользователя — предотвращается guard и AC4.
+- No-findings justification: неприменимо, ниже исправленные при review риски.
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| HIGH | data | Начальная эмиссия/Update могут стать ложной очисткой | Отличить локальный переход от загрузки | fixed в spec |
+| MEDIUM | coverage | Только команда «Нет» не покрывает очистку поля | Общий handler и два UI теста | fixed в spec |
+| MEDIUM | persistence | Скрытие не доказывает сброс | Null + read-back/reopen/установка даты снова | fixed в spec |
+- Fixed before continuing: guards, оба UI пути, persisted result.
+- Checks rerun: сверка сценариев/матриц/production allowlist и отсутствие противоречий с уточнением пользователя.
+- Needs human: только approval новой spec.
+- Residual risks: видео/полные suites остаются EXEC; old inconsistent snapshots не мигрируются.
+
+### Post-EXEC Review
+Статус: PASS. Self-review для small change; не независимый review.
+
+- Scope/Evidence: два production-файла, три новых test-файла, одна корректировка fixture и эта spec. TaskTreeManager, доменные правила, API, схемы и пользовательские данные не изменены.
+- Contract: локальное date→null синхронно присваивает Repeater=null; существующий autosave сохраняет оба поля; вся внешняя секция скрыта по null. Возврат даты не восстанавливает объект.
+- Adversarial: `.Skip(1)` защищает начальную эмиссию, `_isUpdatingFromModel` — hydration. Identity assertion обнаруживает даже временное удаление/воссоздание повторителя. Проверены None/null, date→date, Daily/Weekly, AfterComplete, отписка старого объекта, оба пути очистки, read-back и восстановление из диска.
+- Role-based: domain — правило пользователя соблюдено; UX — полный блок/рамка и focus, desktop/узкая ширина; validation — red/green, persisted JSON, реальное окно; architecture — существующие lifecycle/autosave без новых записывающих сервисов.
+- Fix and re-review: layout fixture получает дату, чтобы продолжить проверять полный набор контролов, не ослабляя assertions. Оконный тест проверен также без опционального сохранения снимков: 1/1, `artifacts/repeater-flaui-without-capture.log`, 29.721 s.
+- Manual-review challenge: скрытие UI могло замаскировать сохранённый повтор — это исключено JSON read-back после сброса и после повторной установки даты. Само чтение legacy данных не считается пользовательской очисткой.
+- Stop decision: EXEC завершён. Полные suites и focused desktop flow прошли; реализации и обязательных проверок больше не осталось. Git delivery не запрашивался.
+
+Production diff: 7 строк подписки в TaskItemViewModel и условие видимости внешней секции в MainControl.
+
+Итоговые проверки:
+- Expected red: 7/10 падений (3 VM reset + 4 UI hide), 3 контрольных PASS; `artifacts/repeater-start-date-red.log`.
+- Targeted green: 12/12 (6 VM + 6 UI, desktop/узкая ширина); `artifacts/repeater-start-date-green.log`.
+- Desktop build: exit 0, 0 errors; `artifacts/repeater-desktop-build.log`.
+- Финальный FlaUI flow: 1/1, 34.713 s, persisted reset и повторная установка даты; `artifacts/repeater-flaui-final.log`, `artifacts/ui-evidence/repeater-start-date/final/complete.json` (`Success=true`). Снимки `dated.png`, `cleared.png`, `restored-date.png` просмотрены: секция видна с датой, исчезает после очистки, возвращается без выбранного режима после установки даты. Интерфейс на русском, синтетическая задача.
+- Полный Unlimotion.Test: 916/916, 0 skipped, exit 0, 22m 11.147s; `artifacts/repeater-full-unit.log`, `.exit`. Включает новые VM/UI cases и прежние status/layout tests.
+- Полный UiTests.Headless: 38/38, 0 skipped, exit 0, 2m 13.368s; `artifacts/repeater-full-headless.log`. Запущен после отдельного restore/build с `--no-dependencies`, затем `dotnet test --no-build`, чтобы не перезаписывать зависимости активного основного test runner. Это проверка корректности, не измерение производительности.
+
+Применён разрешённый fallback вместо видео: desktop-region recorder (`ffmpeg -f gdigrab`) оказался небезопасен при перекрытии окна другим приложением, а координатный UI input зависел от DPI/focus. Неудачные media captures удалены и не являются evidence. Сценарий переведён на UIA/keyboard focus и безопасный `PrintWindow`, не читающий пиксели чужого окна. Next-best evidence — expected red logs, автоматизированные headless и FlaUI assertions, сохранённый JSON и просмотренные снимки конкретного HWND. Все три финальных снимка содержат нужную область планирования. UI test run завершён успешно; usable before/after MP4 нет.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| MEDIUM | test fixture | Full-card layout tests предполагают видимость повторителя | Задать дату в fixture, сохранить assertions | fixed, full suite PASS |
+| MEDIUM | UI evidence | Desktop-region recording включает перекрывающее окно | Удалить небезопасные media; UIA/keyboard + HWND capture | fixed, safe screenshots inspected, FlaUI PASS |
+| LOW | regression strength | Equality после hydration не отличает сохранение объекта от воссоздания | Дополнить identity assertion | fixed, full suite PASS |
+
+- Final checks: `git diff --check` без whitespace errors; новые файлы также проверены `git diff --no-index --check`. SHA-256 production DLL совпадают в основном и Headless output, то есть UI suite проверяла те же сборки.
+- Остаточные ограничения: нет миграции старых inconsistent записей; локальные результаты не являются CI/deployment evidence; видео заменено явно описанными безопасными снимками. Других незавершённых проверок или блокирующих findings нет.
+- Needs human: нет для завершения согласованного EXEC. Коммит, push, merge и release не выполнялись.
+
+### Актуализация после ребейза на `main` 01.09.2026
+- В `origin/main` смержен PR #288 (`edf83000`, `fix(status): preserve edits during status transitions`), который устраняет отдельно обнаруженную гонку между throttled autosave и сменой статуса. Он сохраняет актуальные editor fields и создаёт следующий экземпляр повторяющейся задачи при немедленном завершении.
+- Эта spec и PR #287 остаются самостоятельным UI-правилом: блок повторения скрыт без даты начала, а очистка даты сбрасывает `Repeater`. Генератор повторов и lifecycle смены статуса здесь не дублируются.
+- Локальная черновая spec `2026-09-01-flush-local-edits-before-status-transition.md` удалена как полностью покрытая canonical spec `2026-08-31-status-transition-latency.md` из PR #288.
+- После ребейза проверены 12/12 regression/UI tests этого изменения, file-backed сценарий `ImmediateRepeatingCompletion_FlushesEditorFieldsAndCreatesNextOccurrence` (1/1) и Headless `TaskStatusPicker_ImmediateRepeatingCompletion_PreservesEditorFieldsAndCreatesNextTask` (1/1). Все проверки прошли.
+- Приведённые выше полные результаты 916/916 и 38/38 относятся к исходному Post-EXEC прогону PR #287. Актуальный `main` перед merge PR #288 прошёл 932/932 и 38/38; новый CI PR #287 должен проверить итоговую комбинацию после force-push.
+
+## Approval
+Получено подтверждение пользователя: «Спеку подтверждаю». Разрешён EXEC этой редакции; Git delivery не запрошен.
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Инструкции/preflight/локализация | 0.98 | Дата в примере | Проследить UI command/cache | Нет | Нет | Найден guard даты | Чтение source/instructions |
+| SPEC | Первая гипотеза | 0.90 | Предпочтение пользователя | Baseline и первоначальная spec | Да | Вопрос о дате | Предлагалось создавать повтор без даты; теперь отменено | Только эта spec |
+| SPEC | Baseline/первый review | 0.95 | Approval | Запросить подтверждение | Да | Approval был запрошен, не получен | 18/18 старых status tests | Эта spec, runner output |
+| SPEC | Уточнение пользователя | 1.00 | Нет продуктовых вопросов | Переписать TO-BE и AC | Нет | Пользователь: скрыть без даты, сбросить повтор при очистке | Дата остаётся обязательной | Эта spec |
+| SPEC | Проверка UI/VM и повторный review | 0.98 | Approval | Запросить подтверждение новой редакции | Да | Будет запрошено в итоговом ответе | Общий date property, hydration/initial guards, save/reopen tests | Эта spec; код только прочитан |
+| EXEC | Approval и preflight | 1.00 | Red/green evidence | Добавить regression/UI tests | Нет | Пользователь: «Спеку подтверждаю» | Подтверждён scope видимости/сброса; исходный код ещё не изменён | Эта spec |
+| EXEC | Reproducing tests и минимальный fix | 0.99 | Green и UI evidence | Запустить targeted после baseline video | Нет | Нет | 7 ожидаемых падений (3 VM + 4 UI), 3 контрольных PASS; добавлены guards initial/model и IsVisible внешней секции | VM, XAML, новые tests, artifacts/repeater-start-date-red.log |
+| EXEC | Targeted green / desktop UI / fallback evidence | 0.99 | Full suites и final screenshots | Завершить полную валидацию | Нет | Сообщено о небезопасной записи перекрываемого окна и безопасном fallback | 12/12 focused, 1/1 native UI, build PASS; генератор повтора не менялся | Targeted/build/FlaUI logs, эта spec |
+| EXEC | Полная валидация и Post-EXEC review | 1.00 | Нет | Передать локальный результат пользователю | Нет | Сообщено об успешном завершении полного набора | 916/916 основной, 38/38 Headless, 1/1 native; снимки просмотрены, source scope и whitespace проверены | Эта spec, full logs, final PNG/complete.json |

--- a/specs/2026-09-01-repeat-occurrence-subtree-clone.md
+++ b/specs/2026-09-01-repeat-occurrence-subtree-clone.md
@@ -1,0 +1,430 @@
+# Сохранение повторения и клонирование поддерева для следующего экземпляра задачи
+
+## 0. Метаданные
+- Тип (профиль): domain/UI bugfix; `dotnet-desktop-client` + `ui-automation-testing`, context `testing-dotnet`.
+- Владелец: пользователь; реализация, тестирование и self-review — Codex.
+- Масштаб: medium; изменение доменного генератора следующего экземпляра и его regression/UI coverage.
+- Целевое семейство / behavior baseline: GPT-5.6; немодельная задача.
+- Поверхность: Codex desktop, Windows, PowerShell; приложение Unlimotion Desktop.
+- Effective runtime: текущая Codex-сессия; точный model ID/effort не влияет на runtime приложения. .NET SDK 10.0.400 — repository-proven baseline.
+- Eval baseline / evidence: не применимо к моделям; нужны characterization red, domain/file-backed/Headless UI green и полные suites.
+- Целевой релиз / ветка: `fix/repeater-requires-start-date`, PR #287; base `edf83000` (`origin/main`, PR #288), текущий HEAD `46af8611`.
+- Ограничения: до точной фразы «Спеку подтверждаю» разрешено менять только этот файл; `src/Tasks/` не читать сверх маскированной диагностики, не изменять, не удалять и не включать в Git.
+- Связанные ссылки: PR #287; PR #288; `specs/2026-08-31-repeater-completion-without-start-date.md`; canonical status lifecycle spec `specs/2026-08-31-status-transition-latency.md`.
+
+## 1. Overview / Цель
+Следующий экземпляр повторяемой задачи должен оставаться повторяемым и представлять новый независимый экземпляр всего её рабочего поддерева, а не ссылаться на подзадачи завершённого экземпляра.
+
+Outcome contract:
+- Success means: после завершения повторяемой задачи новая корневая задача содержит эквивалентную независимую настройку `Repeater`, а каждая достижимая через `ContainsTasks` подзадача создана заново с новым ID и связана только с соответствующими копиями внутри нового дерева.
+- Итоговый артефакт / output: минимальное изменение `TaskTreeManager`, domain/file-backed/Headless UI tests, актуализированные spec/PR evidence.
+- Stop rules: SPEC заканчивается approval gate. EXEC заканчивается только после expected-red, исправления, targeted/full tests, UI evidence и post-EXEC review. Не менять пользовательские данные и не merge/release.
+
+## 2. Текущее состояние (AS-IS)
+- `TaskTreeManager.HandleTaskStatusChange` при завершении создаёт только один новый `TaskItem`.
+- В manager поле `Repeater` сначала присваивается как `clone.Repeater = task.Repeater`, но `FileTaskStorage.SaveCore` сохраняет `TaskItemSnapshot.Clone`, который уже независимо копирует `Repeater`, `Pattern` и extension data.
+- `ContainsTasks`, `BlocksTasks` и `BlockedByTasks` копируются как списки старых ID.
+- Для `ContainsTasks` выполняется `CreateParentChildRelation(clone, child)`, поэтому новый экземпляр корневой задачи получает тех же детей, что завершённая задача. Новые дочерние `TaskItem` не создаются.
+- Встроенный ручной `CloneTask` также клонирует только один узел и привязывает его к существующим детям; использовать его как готовое deep-clone решение нельзя.
+- PR #288 гарантирует flush editor fields до смены статуса. File-backed и Headless тесты уже проверяют `next.Repeater.Type == Daily`, поэтому persisted loss на текущем HEAD пока не воспроизведён.
+- `MainControl.axaml` связывает первый шаблонный `ComboBox` как `ItemsSource="{Binding Repeaters}"` и `SelectedItem="{Binding Repeater}"`. `Repeaters` каждый раз создаёт новые `RepeaterPatternViewModel`, а hydrated `Repeater` является другим instance; у класса нет value equality. Поэтому persisted repeater может существовать и показывать маркер/детальные controls, но сам template selector визуально оставаться без выбранного элемента. Это сильная гипотеза, а не подтверждённая формулировка пользовательского симптома.
+- Текущий `TaskStatusTransitionTests.HandleTaskStatusChange_CompletedTaskWithRepeater_CreatesPreparedClone` прямо утверждает старое поведение: `clonedTask.ContainsTasks` эквивалентен списку старых child ID.
+- Маскированная локальная диагностика `src/Tasks/` содержит только старую запись предыдущего сбоя и не даёт evidence для двух новых сценариев; пользовательское сообщение считается authoritative reproduction report.
+
+## 3. Проблема
+Новый occurrence не является полной и однозначно отображаемой копией рабочего шаблона: UI может не сопоставить persisted repeater с template selector, а доменный генератор повторно использует старые дочерние связи вместо создания нового поддерева.
+
+## 4. Цели дизайна
+- Отображать hydrated `Repeater` в template selector по значению, а не по reference identity; persisted snapshot contract сохранить и усилить тестом.
+- Клонировать containment closure рекурсивно и детерминированно.
+- Сохранять симметрию `ContainsTasks` / `ParentTasks` без ссылок нового дерева на старые дочерние ID.
+- Сохранить DAG: один исходный узел, достижимый несколькими путями, клонируется один раз.
+- Сдвигать плановые даты всего нового поддерева на интервал корневого повторения.
+- Не дублировать алгоритм вычисления следующей даты и не переносить генерацию в ViewModel/UI.
+- Выполнять preflight исходного поддерева до первой записи, чтобы missing/cycle/duplicate/invalid graph не давал заведомо неполную копию.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не меняем правило обязательной даты начала и алгоритм `RepeaterPatternExtensions.GetNextOccurrence`.
+- Не меняем видимость секции повторения, layout, тексты и элементы управления.
+- Не меняем ручную команду `CloneTask`, drag/drop clone или clipboard outline.
+- Не клонируем внешних родителей и не превращаем `BlocksTasks` / `BlockedByTasks` в containment-поддерево.
+- Не мигрируем уже созданные некорректные экземпляры и не редактируем `src/Tasks/`.
+- Не меняем формат JSON, API/CLI/server contract, release/version/changelog.
+- Не копируем статус, даты завершения/архива и status history как историю нового экземпляра.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+- `TaskTreeManager.HandleTaskStatusChange` — вызывает единый helper создания следующего occurrence внутри существующего mutation lock.
+- `TaskGraphValidationReport` / `TaskAvailabilityService` — command-level containment-cycle validation вместе с existing missing/self/duplicate relation checks; invalid graph получает `ValidationFailed` до вызова manager mutation.
+- Новый private helper в `TaskTreeManager` — загружает уже валидный containment closure, строит source-ID -> clone mapping, remap связей, сохраняет узлы и пересчитывает availability.
+- `TaskItemViewModel`/`MainControl` — stable value-based состояние выбранного repeater template после hydration. Пользователь подтвердил, что у созданной задачи именно не указан шаблон повторения; persisted type/period остаются отдельными полями.
+- `TaskItemSnapshot.Clone` или локальный узкий helper — переиспользуется для независимой копии mutable nested values; для completion criteria создаётся отдельный fresh-occurrence helper с reset.
+- Existing `Storage`, relation helpers и availability service — persistence, обратные связи внешних blocking relations и нормализация статусов.
+- `TaskStatusTransitionTests`, `FileStorageTaskStatusTests`, `MainControlTaskStatusIconUiTests` — domain, persisted и user-visible regression evidence.
+
+### 6.2 Детальный дизайн
+1. UI-path: `TaskItemViewModel` хранит одну cached read-only collection шаблонов и отдельный `SelectedRepeaterTemplate` из этой же collection; `MainControl` bind `SelectedItem` к этому свойству. Matching key:
+   - `None`, `Daily`, `Monthly`, `Yearly` — по `Repeater.Type`;
+   - `WeeklyWorkDays` — только если type Weekly и pattern точно равен `{0,1,2,3,4}` без weekend/extra values;
+   - любой другой Weekly, включая pattern с Saturday/Sunday, — generic `Weekly`.
+   Setter применяет independent copy выбранного template только при реальном выборе пользователя; getter после hydration возвращает instance из cached collection и не сбрасывает persisted `Period`, `AfterComplete` или custom weekdays при простом открытии карточки. Изменение `Repeater` уведомляет `SelectedRepeaterTemplate`.
+2. После допустимого перехода root в `Completed` вычислить `nextRootBegin` существующим `GetNextOccurrence` и `dateOffset = nextRootBegin - sourceRoot.PlannedBeginDateTime`.
+3. Command-level validation до manager mutation отклоняет missing/duplicate/self containment relations и любой containment cycle через `TaskGraphValidationReport`, возвращая `ValidationFailed`.
+4. После успешной validation до первой записи обойти `ContainsTasks` от source root:
+   - загрузить каждый ID один раз;
+   - сохранить детерминированный порядок обхода;
+   - defensive guard повторно прекращает operation при расхождении с validated graph, но не является источником `ValidationFailed` contract;
+   - DAG с несколькими внутренними родителями разрешить.
+5. Для каждого узла построить новый `TaskItem` с новым ID и независимыми mutable values. Template-поля: `Title`, `Description`, `PlannedDuration`, `Wanted`, `Importance`, `Repeater`. Completion criteria получают новые ID, прежний text/extension data и `IsSatisfied=false`.
+6. Для root начало установить точно в `nextRootBegin`; конец root сохранить через прежнюю длительность между begin/end. Planned begin/end каждого descendant сдвинуть на `dateOffset`; null остаётся null.
+7. Внутренние containment связи remap на clone IDs:
+   - `clone.ContainsTasks` содержит только копии внутренних детей;
+   - `clone.ParentTasks` содержит только копии родителей, достижимых внутри closure;
+   - root не наследует внешние `ParentTasks`.
+8. Для узла, достижимого от двух родителей, создать один clone и связать его с обоими cloned parents.
+9. Blocking relations:
+   - если обе стороны входят в closure, remap ID на соответствующий clone;
+   - внешние `BlocksTasks` / `BlockedByTasks` не переносить на clones и не изменять reverse links внешних задач;
+   - внешние containment parents не копировать.
+10. `Repeater` каждого нового узла — independent persisted snapshot через существующий `TaskItemSnapshot` contract. Очистка/изменение повторения у исходного или нового экземпляра после операции не влияет на другой.
+11. Fresh lifecycle задаётся явно:
+   - root: новый ID/version/created time, `Status=Prepared`, одна fresh `Prepared` history entry, completed/archive timestamps null;
+   - descendants: новый ID/version/created time, `Status=NotReady`, одна fresh `NotReady` history entry, completed/archive timestamps null;
+   - все completion criteria независимы, имеют новые ID и `IsSatisfied=false`;
+   - `IsCanBeCompleted` и `UnlockedDateTime` пересчитываются existing availability service; leaf, middle/root, future date и blocker cases покрываются отдельно;
+   - `UpdatedDateTime` задаётся штатным save/recalculation path и не копируется из source.
+12. Сохранить все новые узлы внутри текущего mutation lock; вернуть их в `ChangedTasks`, чтобы Unified cache/UI получил всё новое дерево за одну команду. По решению 3A collections внешних relations не меняются и clone links в них не добавляются; существующий availability/unlock-пересчёт внешней задачи после завершения source сохраняется и может включить её в `ChangedTasks`.
+13. Command-level validation failure гарантирует ноль clone writes, source root остаётся в исходном authoritative status, `ChangedTasks` пуст, command возвращает `ValidationFailed`. Mid-write I/O failure не объявляется атомарным: допускается partial persistence, command возвращает `OutcomeUnknown`, а reconciliation/read-back должен показать фактическое authoritative состояние. Batch transaction не входит в эту spec.
+
+Нефункциональные требования:
+- Сложность обхода O(V+E) по containment closure; каждый исходный узел загружается не более одного раза.
+- Не использовать рекурсивный вызов без защиты глубины; предпочтителен явный stack/queue, чтобы глубокое дерево не переполнило call stack.
+- Все коллекции и nested records копируются независимо.
+
+Visual planning artifact — state storyboard, layout не меняется:
+
+```mermaid
+flowchart LR
+    A[Завершённая повторяемая задача<br/>Root + Child + Grandchild] -->|Complete| B[Новый Root<br/>новый ID, следующая дата,<br/>Repeater отображается]
+    B --> C[Новый Child<br/>новый ID,<br/>дата + root interval]
+    C --> D[Новый Grandchild<br/>новый ID,<br/>дата + root interval]
+    A -. исходное дерево не меняется .-> E[Старые Child/Grandchild<br/>остаются у старого Root]
+```
+
+UI video evidence: production layout/interaction не меняются, но итог виден в дереве и карточке. На EXEC нужен автоматизированный Headless flow; MP4 применим только если существующий безопасный window-focused recorder может стабильно показать выбор статуса и новое дерево. Если нет, fallback: expected-red/green Headless assertions, file-backed JSON read-back и безопасные HWND screenshots/structured test artifact с объяснением.
+
+### 6.3 User-Observable Scenarios
+| Scenario | User action / trigger | Expected visible result / output | Evidence required | Covered by AC |
+| --- | --- | --- | --- | --- |
+| S1 Повторение отображается | Завершить daily-задачу, выбрать новый экземпляр и открыть карточку | Новый экземпляр показывает ↻; template selector, period, after-complete и pattern соответствуют source до и после reload | Real `MainControl` Headless UI + file read-back | AC1, AC2 |
+| S2 Прямые подзадачи | Завершить root с двумя детьми | У нового root две новые подзадачи с новыми ID; старые дети остаются у старого root | Domain + file-backed + Headless tree | AC3, AC5 |
+| S3 Глубокое дерево | Завершить root -> child -> grandchild | Клонируются все уровни и внутренние связи указывают на копии | Domain/file-backed graph assertions | AC3, AC4 |
+| S4 Общий потомок DAG | Два внутренних родителя содержат одного child | Создан один child clone с двумя cloned parents | Domain test | AC4 |
+| S5 Изменение после клонирования | Очистить repeat/date у одного экземпляра | Другой экземпляр и его pattern не меняются | Persistence/aliasing regression | AC2 |
+| S6 Некорректное дерево | Завершить root с missing/duplicate/cycle child | Clone writes отсутствуют; source root не завершён | Command-level validation test | AC6 |
+| S7 Сбой записи | Storage падает после части saves | Result `OutcomeUnknown`; read-back честно показывает partial authoritative state для reconciliation | Fault-injection test | AC7 |
+
+### 6.4 State / Interaction Matrix
+| Current state | Trigger | Expected transition/result | Empty/error/disabled/concurrent case | Notes |
+| --- | --- | --- | --- | --- |
+| Repeat root без детей | Complete | Один новый root с independent repeater | Нет `ContainsTasks` — прежний простой путь | Backward compatible |
+| Repeat root с containment tree | Complete | Новое полное дерево | Missing/duplicate/cycle -> `ValidationFailed` before clone writes | AC3/AC6 |
+| Shared descendant DAG | Complete | Один clone, несколько cloned parents | Повтор ID в одной relation collection invalid; DAG paths не считаются duplicate | Mapping by source ID |
+| Descendant с датами | Complete | Begin/end сдвинуты на root occurrence offset | null остаётся null | Решение пользователя 2A |
+| Descendant с external parent | Complete | External parent не получает clone | Внутренние parents remap | Scope containment closure |
+| Internal/external blocker | Complete | Internal remap; external relation не переносится | Missing internal relation invalid | Решение пользователя 3A |
+| Concurrent status/save | Complete сразу после ввода | PR #288 flush + одна mutation | Failure возвращается existing result | Не ослаблять lifecycle fix |
+
+### 6.5 Decision Ledger
+| Decision | Owner | Default / chosen option | Confidence | Risk if assumed | Needs user before EXEC |
+| --- | --- | --- | ---: | --- | --- |
+| Глубина клонирования | user intent interpreted by agent | Всё достижимое поддерево, не только прямые дети | 0.95 | Прямой-only clone оставит смешанное дерево | Нет |
+| Что именно «отсутствует» в повторении | user | У созданной задачи не указан шаблон повторения; исправить value state template selector | 1.00 | Неверный UI-path оставил бы симптом | Нет, получен ответ 1 |
+| Даты потомков | user | Сдвигать begin/end на root occurrence offset | 1.00 | Другие варианты materially меняли бы расписание | Нет, выбран 2A |
+| Shared descendant | agent/domain invariant | Клонировать один раз, сохранить DAG | 0.98 | Дублирование одной логической подзадачи | Нет |
+| External containment parents | agent | Не копировать | 0.90 | Иначе occurrence появится в чужом старом дереве | Нет |
+| External blocking relations | user | Не переносить; сохранять только internal remap | 1.00 | Перенос повторно блокировал бы сторонние задачи | Нет, выбран 3A |
+| Invalid closure | agent/safety | ValidationFailed до first clone write | 0.95 | Частичный новый occurrence | Нет |
+| Mid-write storage failure | existing command contract | `OutcomeUnknown`, partial persistence возможно, затем reconciliation | 0.95 | Ложное обещание atomicity | Нет |
+| Existing generated bad tasks | user scope | Не мигрировать | 0.98 | Старые записи останутся как есть | Нет |
+
+### 6.6 Runtime / Config / Data Contract Matrix
+| Contract area | Current source of truth | Expected change | Compatibility / migration | Verification |
+| --- | --- | --- | --- | --- |
+| Repeat calculation | `RepeaterPatternExtensions` | Без изменений | Полная совместимость | Existing recurrence tests |
+| Containment graph | `ContainsTasks`/`ParentTasks` + relation helpers | Новые IDs и symmetric remap | JSON schema без изменений | Graph assertions + read-back |
+| Repeater persistence | `TaskItem.Repeater` JSON | Independent equal snapshot | Schema без изменений | Reference/mutation + file test |
+| Status lifecycle | `TaskGraphCommandService`/`TaskTreeManager` | ChangedTasks включает subtree | API type без изменений | Unified/Headless test |
+| User data | File storage | Только будущие operations | Миграции нет | Temp directories only |
+
+## 7. Бизнес-правила / Алгоритмы
+1. Следующий occurrence создаётся только для active repeater и заполненного root planned begin — существующее правило.
+2. Новый occurrence содержит весь containment closure source root на момент status command после editor flush.
+3. Каждому уникальному source ID соответствует ровно один новый clone ID.
+4. В новом containment closure не остаётся старых child IDs.
+5. Новый root сохраняет independent persisted repeater и отображает его template/type/period/after-complete/pattern после выбора карточки и reload.
+6. Root planned dates переходят на следующий occurrence; begin/end каждого descendant сдвигаются на тот же root occurrence offset; null остаётся null.
+7. Root создаётся `Prepared`; descendants — `NotReady`; history/timestamps fresh, completion criteria reset в false с новыми IDs; availability fields пересчитываются.
+8. Source tree и его relations не изменяются, кроме штатного завершения source root.
+9. Невозможность полностью прочитать/валидировать containment closure до записи даёт `ValidationFailed`, ноль clone writes и не завершает source root.
+10. Mid-write I/O failure допускает partial persistence и возвращает `OutcomeUnknown`; атомарность всего дерева не обещается.
+
+## 8. Точки интеграции и триггеры
+- Триггер: успешный переход repeat root в `Completed` через любой storage adapter/UI/Telegram path, который использует `TaskGraphCommandService` и `TaskTreeManager`.
+- Вызов нового helper — только из repeater-ветки `HandleTaskStatusChange`.
+- Unified cache получает весь returned changed set; отдельный UI refresh не добавляется.
+- Recalculation: после materialization связей выполнить availability bottom-up/до стабильного результата существующим сервисом.
+
+## 9. Изменения модели данных / состояния
+- Новых полей, таблиц и JSON schema нет.
+- Создаётся N новых task records вместо одной, где N — число уникальных узлов containment closure.
+- Mutable nested data каждого clone независимо.
+- Старые children больше не получают нового parent ID только из-за repeat occurrence.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция не требуется; поведение действует для будущих завершений после обновления.
+- Старые occurrences с потерянным repeater или shared old children автоматически не исправляются.
+- Rollback: revert implementation commit; schema/data migration отсутствует.
+- При откате уже созданные корректные деревья остаются валидными обычными задачами.
+
+## 11. Тестирование и критерии приёмки
+Acceptance Criteria:
+- AC1: persisted next root содержит тот же `Repeater` type/period/pattern/after-complete flags, что source на момент completion; после выбора next root в реальном `MainControl` template selector и детальные controls отображают эти значения до и после file-storage reload. Отдельно проверены Daily, exact WorkDays `{0..4}` и custom Weekly с weekend, который не должен отображаться как WorkDays.
+- AC2: source и clone repeaters/nested patterns не alias; изменение одного после операции не меняет другой.
+- AC3: прямые дети и все потомки клонируются с новыми уникальными ID; старое дерево не получает новых внутренних связей.
+- AC4: все новые `ContainsTasks`/`ParentTasks` symmetric; DAG descendant cloned once; internal blocking IDs remapped; external containment/blocking links отсутствуют у clones и reverse links внешних задач не изменены.
+- AC5: root planned dates переходят на следующий occurrence; begin/end descendants сдвинуты на тот же offset, null остаётся null. Root/descendant statuses, fresh history/timestamps, reset criteria, `IsCanBeCompleted` и `UnlockedDateTime` соответствуют разделу 6.2 для leaf/middle/root, future date и blocker cases.
+- AC6: missing/duplicate/cycle/self-reference command-level validation возвращает `ValidationFailed`, `ChangedTasks` пуст, source остаётся в прежнем authoritative status, clone save count равен нулю.
+- AC7: fault injection после части saves возвращает `OutcomeUnknown`; read-back/reconciliation подтверждает фактически сохранённые records без ложного rollback claim.
+- AC8: реальный `TaskStatusPicker` flow после мгновенного редактирования открывает next root в `MainControl`, проверяет repeater controls и cloned child wrappers/IDs, затем повторяет после reload.
+- AC9: existing no-child recurrence, status lifecycle, availability, Unified ordering и PR #287 start-date UI regressions остаются зелёными.
+
+План тестов:
+- Expected-red domain tests в `TaskStatusTransitionTests`: direct/deep subtree, DAG, chosen date/blocking policy, lifecycle/reset criteria, source unchanged, invalid closure.
+- File-backed regression в `FileStorageTaskStatusTests`: immediate editor fields + root/child/grandchild persisted JSON read-back после status command.
+- Headless UI regressions в `MainControlTaskStatusIconUiTests` и `MainControlRepeaterStartDateUiTests`: реальный click status picker создаёт next root и cloned child wrappers/IDs; real `MainControl` проверяет `CurrentTaskRepeaterSelector`, pattern type, period, after-complete/weekday flags и повторную hydration из заново инициализированного file-backed repository. Cases: Daily, exact WorkDays и custom Weekly with weekend. Expected-red должен падать по фактическому пустому/неверному control state, не по `ReferenceEquals`.
+- Existing targeted suites: `TaskStatusTransitionTests`, `FileStorageTaskStatusTests`, `TaskGraphCommandServiceTests`, `MainControlTaskStatusIconUiTests`, `TaskItemRepeaterStartDateTests`.
+- Full `Unlimotion.Test` и `Unlimotion.UiTests.Headless`; focused FlaUI/window evidence, если UI tree flow стабилен и безопасен.
+
+Acceptance-to-Test Matrix:
+| Acceptance criterion | Automated test | Manual / visual / log check | Evidence artifact | If not tested, why |
+| --- | --- | --- | --- | --- |
+| AC1/AC2 | Domain + file-backed equality/NotSame/mutation | Проверить persisted JSON без пользовательских данных | targeted log/TRX | — |
+| AC3/AC4 | Deep tree + DAG + external relation assertions | Structured ID mapping/reverse-link summary | targeted log | — |
+| AC5 | Leaf/middle/root lifecycle, criteria, date/future/blocker assertions | Проверить visible planned dates/status в Headless state | targeted log | — |
+| AC6 | Command-level malformed graph tests | DeniedKind/source status/save-count evidence | targeted log | — |
+| AC7 | Mid-write fault/reconciliation test | OutcomeUnknown + authoritative read-back | targeted log | — |
+| AC8 | Real MainControl/TaskStatusPicker + reload | Safe screenshot/video fallback | UI test artifact | — |
+| AC9 | Build + targeted + full Main/Headless | CI checks после push | logs + PR checks | — |
+
+Repository-proven commands на EXEC:
+```powershell
+dotnet --info
+dotnet build src/Unlimotion.Desktop/Unlimotion.Desktop.csproj -c Debug -p:UseSharedCompilation=false
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -- --treenode-filter '/*/*/TaskStatusTransitionTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -- --treenode-filter '/*/*/FileStorageTaskStatusTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -- --treenode-filter '/*/*/MainControlTaskStatusIconUiTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -- --treenode-filter '/*/*/MainControlRepeaterStartDateUiTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet test --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -- --maximum-parallel-tests 1 --output Detailed
+dotnet test --project tests/Unlimotion.UiTests.Headless/Unlimotion.UiTests.Headless.csproj -c Debug -- --maximum-parallel-tests 1 --output Detailed
+git diff --check
+```
+
+Test stop rules:
+- UI expected-red обязан падать по control state реального выбранного next root/reload; domain expected-red — по отсутствию deep clones, не по setup/environment или `ReferenceEquals`.
+- Partial write запрещена только для validation/preflight failure. Для mid-write I/O failure ожидаются `OutcomeUnknown` и truthful reconciliation.
+- Любая lost relation, duplicate clone или stale old-child ID в успешной операции — блокирующая regression.
+- Full suites запускаются после targeted green и review fixes; ненулевой test count обязателен.
+- UI evidence не заменяет persisted graph assertions.
+- Ожидаемая длительность: targeted 1–5 минут каждый; full Main примерно 20–25 минут; full Headless примерно 2–4 минуты. Длинные прогоны пишут detailed log/TRX и сообщают progress не реже раза в минуту.
+
+## 12. Риски и edge cases
+- Deep tree/DAG может вызвать дублирование или бесконечный обход — mapping + visiting/visited sets.
+- Один child с двумя внутренними parents — clone once, обе reverse relations.
+- External parent у descendant — не включать в new containment graph.
+- Internal blocking relation — remap обеих сторон; external blockers/blocked tasks не переносятся и не получают reverse links на clones.
+- Child со своим repeater — независимая копия сохраняется как template field; его future completion остаётся обычным recurrence behavior.
+- Child begin/end сдвигаются на root occurrence offset; null остаётся null.
+- Missing/dangling child — preflight failure до materialization.
+- Storage failure во время batch save — существующее storage не даёт общей транзакции; минимизировать риск полным preflight и deterministic order, а post-write failure reconciliation оставить существующему command/storage lifecycle. Это residual risk, проверяемый fault-injection test.
+- Большое дерево увеличивает число записей и UI updates — O(V+E), ChangedTasks deduplicated.
+
+### Expected User Review Objections
+| Likely objection | Why likely | Mitigation in spec/code plan | Status |
+| --- | --- | --- | --- |
+| «Повторение опять визуально пропало» | Предыдущий баг воспроизводился через UI | Headless status picker + persisted read-back + independent snapshot | mitigated |
+| «Скопировались старые подзадачи, а не новые» | Текущее поведение именно такое | Assertions новых ID на всех уровнях и отсутствие old IDs | mitigated |
+| «Скопировались только прямые дети» | Простая реализация может остановиться на одном уровне | Closure traversal + grandchild/DAG tests | mitigated |
+| «У подзадач неверные даты» | Schedule policy могла быть неоднозначна | Пользователь выбрал shift root offset; закрепить begin/end/null tests | mitigated |
+| «Общая подзадача продублировалась» | Модель допускает multiple parents | One source-ID -> one clone-ID mapping | mitigated |
+| «Новые подзадачи снова заблокировали сторонние задачи» | External blocking policy materially меняет graph | Пользователь выбрал не переносить; проверить отсутствие reverse links | mitigated |
+| «При validation error появилось полдерева» | Ошибка известна до writes | Preflight + zero-save command test | mitigated |
+| «При I/O error появилось полдерева» | File storage не batch-транзакционный | OutcomeUnknown + reconciliation, без ложного atomic claim | accepted-risk |
+
+### Rework Prevention Checklist
+- User-visible result описан в S1–S7 и storyboard.
+- Каждый сценарий имеет automated/persisted/UI evidence.
+- Agent-owned и три user-owned решения перечислены в Decision Ledger; все ответы получены.
+- Вероятные возражения покрыты tests/design.
+- Применимы domain, UX, tester, architect и delivery-review роли.
+- AC являются проверками результата.
+- EXEC имеет red/green/full/UI путь доказательства.
+
+## 13. План выполнения
+1. Добавить expected-red tests для independent repeater и containment subtree semantics.
+2. Выделить private occurrence-clone helper и preflight closure traversal внутри `TaskTreeManager` mutation lock.
+3. Реализовать value-based repeater selection, ID mapping, единый date offset и только internal relation remap.
+4. Нормализовать availability/status и returned ChangedTasks.
+5. Добавить file-backed и Headless UI regression.
+6. Запустить targeted tests, full suites и доступное safe UI evidence.
+7. Выполнить post-EXEC review, исправить findings, повторить затронутые проверки.
+8. После зелёного результата обновить тот же PR #287 и дождаться CI; merge/release не выполнять.
+
+## 14. Открытые вопросы
+Блокирующих вопросов нет. Пользователь решил:
+1. Дефект повторения — у созданной задачи не указан шаблон повторения; исправляется value-based state первого selector.
+2. Planned begin/end descendants сдвигаются на root occurrence offset (вариант 2A).
+3. Внешние `BlocksTasks`/`BlockedByTasks` не переносятся; клонируются/remap только внутренние связи (вариант 3A).
+
+Под «подзадачами» понимается всё рекурсивное containment-поддерево.
+
+## 15. Соответствие профилю
+- Профиль: `dotnet-desktop-client` + `ui-automation-testing`, context `testing-dotnet`.
+- Выполненные требования: SPEC-first, UI-facing scenarios, storyboard, Headless coverage, persisted state evidence, TUnit `--treenode-filter`, full suites, video/fallback contract, post-SPEC/post-EXEC review.
+
+## 16. Таблица изменений файлов
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.TaskTreeManager/TaskTreeManager.cs` | occurrence subtree preflight/clone/remap | Основной bugfix |
+| `src/Unlimotion.TaskTreeManager/TaskAvailabilityService.cs` | containment-cycle validation issue | Command-level zero-write contract |
+| `src/Unlimotion.TaskTreeManager/TaskAvailabilityAnalyzer.cs` | новый тип containment-cycle issue | `ValidationFailed` evidence |
+| `src/Unlimotion.ViewModel/TaskItemViewModel.cs` | value-based selected repeater template contract | Отображение hydrated repeat setting |
+| `src/Unlimotion.ViewModel/RepeaterPatternViewModel.cs` | exact WorkDays означает только Monday-Friday | Стабильное сопоставление шаблона |
+| `src/Unlimotion/Views/MainControl.axaml` | binding selector, если нужен для value contract | Реальный UI symptom пункта 1 |
+| `src/Unlimotion.Test/TaskStatusTransitionTests.cs` | domain tree/repeater/date/failure regressions | AC1–AC6 |
+| `src/Unlimotion.Test/TaskItemRepeaterStartDateTests.cs` | stable templates, value selection и isolation | AC1/AC2 |
+| `src/Unlimotion.Test/TaskAvailabilityParityTests.cs` | cycle/duplicate validation | AC6 validator contract |
+| `src/Unlimotion.Test/TaskGraphCommandServiceTests.cs` | command-level cycle returns ValidationFailed/zero writes | AC6 end-to-end contract |
+| `src/Unlimotion.Test/UnlimotionCliIntegrationTests.cs` | CLI completion возвращает независимый occurrence subtree | CLI end-to-end regression |
+| `src/Unlimotion.Test/FileStorageTaskStatusTests.cs` | file-backed read-back | AC1–AC5/AC7 |
+| `src/Unlimotion.Test/MainControlRepeaterStartDateUiTests.cs` | Real MainControl repeater controls/status picker/reload | AC1/AC8/AC9 |
+| `src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs` | Реальный click status picker и cloned child wrappers | AC3/AC8/AC9 |
+| `specs/2026-09-01-repeat-occurrence-subtree-clone.md` | evidence и review journal | QUEST contract |
+
+Дополнительный production/test файл допустим только если review покажет, что отдельный internal helper существенно уменьшает риск; public API не добавлять.
+
+## 17. Таблица соответствий (было -> стало)
+| Область | Было | Стало |
+| --- | --- | --- |
+| Repeater UI | Persisted repeater есть, но hydrated instance не входит в новый `Repeaters` list | Cached templates + value-key selected template |
+| Repeater persistence | Storage deep snapshot уже существует | Contract сохраняется и покрывается reload/mutation tests |
+| Подзадачи | Старые child IDs прикрепляются к новому root | Новые IDs всего containment closure |
+| Глубина | Только root | Root + все descendants |
+| DAG | Не применимо к clone | Один clone на source ID, несколько cloned parents |
+| Даты descendants | Старые задачи переиспользуются | Новые даты с единым occurrence offset |
+| Invalid closure | Частичное skipping возможно | Preflight fail до clone writes |
+| UI | Может показать старых children/неподтверждённый repeat | Новый root с ↻ и новым поддеревом |
+
+## 18. Альтернативы и компромиссы
+- Только добавить assertion/копию `Repeater`: закрывает пункт 1, но оставляет старые children; отклонено.
+- Клонировать только прямых детей: дешевле, но смешивает новые и старые уровни; отклонено.
+- Вызывать существующий `CloneTask` рекурсивно: он прикрепляет существующих детей и external relations до построения mapping, что затрудняет DAG/remap и partial-failure control; отклонено.
+- Сериализовать всё дерево в JSON и заменить ID: просто на вид, но обходит domain relation/availability helpers и повышает риск скрытых полей; отклонено.
+- Выбран двухфазный graph clone: preflight + materialization по mapping. Он лучше сохраняет инварианты и тестируется без нового public API.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, границы, files и lifecycle зафиксированы |
+| B. Качество дизайна | 6-10 | PASS | Closure/mapping/lifecycle, date offset и internal-only relation policy определены |
+| C. Безопасность изменений | 11-13 | PASS | Нет schema migration/user data; preflight и rollback |
+| D. Проверяемость | 14-16 | PASS | Domain/file/UI/full tests и stop rules |
+| E. Готовность к автономной реализации | 17-19 | PASS | User-owned решения получены; план и tests конкретны |
+| F. Соответствие профилю | 20 | PASS | UI tests, storyboard и evidence fallback |
+
+Итог: ГОТОВО после re-review и пользовательского approval.
+
+### SPEC Rubric Result
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Два дефекта сведены к одному occurrence-template контракту |
+| 2. Понимание текущего состояния | 5 | Прослежены status handler, clone path, relations и текущие tests |
+| 3. Конкретность целевого дизайна | 5 | Двухфазный clone, ID map, date offset и internal-only relations конкретны |
+| 4. Безопасность | 5 | Preflight, no migration, rollback, residual mid-write risk |
+| 5. Тестируемость | 5 | AC-to-test + UI/persisted evidence |
+| 6. Готовность к автономной реализации | 5 | Все продуктовые решения закрыты |
+
+Итоговый балл: 30 / 30. Зона: готово к автономному выполнению после re-review и approval.
+
+### Role-Based Review Result
+| Role | Applicability | Review question | Verdict | Required spec changes |
+| --- | --- | --- | --- | --- |
+| Business analyst / domain workflow | applicable | Новый occurrence является независимым повтором всего рабочего дерева? | PASS | Recursive closure, shifted dates, internal-only relations и fresh lifecycle |
+| UX / designer | applicable | Исправляется ли наблюдаемый пустой template selector? | PASS | Value-based selection + real MainControl/reload test |
+| Tester / validation | applicable | Все ID/date/relation/failure cases проверяемы? | PASS | AC1–AC9 и matrices после выбора policies |
+| Developer / architect | applicable | DAG/remap/lifecycle/failure semantics coherent? | PASS | Mapping, exact fresh state, preflight vs OutcomeUnknown разделены |
+| Delivery / operations / security | applicable | PR/user-data/rollback/CI boundaries ясны? | PASS | Same PR after EXEC, no merge/release/user data |
+
+### Post-SPEC Review
+- Статус: PASS.
+- Scope reviewed: эта spec; central QUEST/testing/profile stack; локальный UI override; `TaskTreeManager.HandleTaskStatusChange`, `CloneTask`, relation/availability helpers; `TaskItemSnapshot`, `TaskGraphCommandService`; `TaskItemViewModel.Repeaters`; `MainControl` repeater bindings; current status/repeater/file/UI tests; Git status и masked `src/Tasks/` summary.
+- Decision: однозначные findings исправлены, пользовательские решения встроены, финальный adversarial re-review вернул PASS; можно запрашивать approval.
+- Review passes:
+  - Scope/Evidence pass: добавлены реальный `MainControl` selector path и command/storage failure contracts; PR #288 lifecycle не дублируется.
+  - Contract pass: S1–S7 соответствуют AC1–AC9; validation failure отделён от mid-write failure.
+  - Adversarial risk pass: проверены UI identity mismatch, DAG/cycle/duplicate/dangling child, exact lifecycle/criteria reset, external parents/blockers, deep tree и OutcomeUnknown.
+  - Role-Based pass: после ответов пользователя все роли PASS.
+  - Fix and re-review: исправлены diagnosis, lifecycle, atomicity, UI/external coverage, build contract и duplicate semantics; повторно сверены sections 2–12 и AC.
+  - Stop decision: PASS; можно запросить точную фразу «Спеку подтверждаю».
+- Evidence inspected: `TaskTreeManager` clone/status/relation/availability paths; `TaskItemSnapshot`; `FileTaskStorage.SaveCore` evidence reviewer; `TaskGraphCommandService`; `TaskItemViewModel`, `RepeaterPatternViewModel`, `MainControl` bindings; current TaskStatusTransition/FileStorage/MainControl tests; current branch/base/PR; relevant prior rollout memory.
+- Depth checklist:
+  - Scope drift / unrelated changes: `src/Tasks/` untracked и исключён; planned production scope — command validation/TaskTreeManager + value-based repeater selection.
+  - Acceptance criteria: каждый AC имеет automated evidence.
+  - User-observable scenarios / Decision ledger / Expected objections: заполнены.
+  - Validation evidence: на SPEC только existing source/tests; red/green относится к EXEC.
+  - Unsupported claims: фактическое новое reproduction не найдено в локальных данных и не заявлено как найденное.
+  - Regression / edge case: DAG/cycle/date/blocking/availability включены.
+  - Comments/docs/changelog: changelog не нужен до release; helper comments только для неочевидных invariants.
+  - Hidden contract change: external containment parent исключён; external blocking/date policies оставлены пользователю.
+  - Manual-review challenge: наиболее вероятные дефекты — починить не тот repeat symptom, скопировать satisfied criteria, обещать атомарность, shared child cloned twice или накопить external reverse links; все отражены в вопросах/AC.
+- Independent-review limitation: reviewer был отдельным agent role и процедурно не менял файлы, но его effective filesystem был unrestricted, поэтому по QUEST результат считается adversarial fallback, а не технически подтверждённым read-only independent review.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| BLOCKER | diagnosis/UI | Storage/tests уже сохраняют Daily; aliasing не объясняет symptom | Уточнить symptom; real MainControl selector/reload expected-red | fixed: user confirmed missing template selector |
+| HIGH | relations | Старый test закрепляет reuse old child IDs | Заменить contract на deep-clone IDs и проверить source unchanged | fixed in spec |
+| HIGH | graph | Наивная рекурсия дублирует DAG/зацикливается | Source-ID mapping + visiting/visited + tests | fixed in spec |
+| HIGH | lifecycle | Availability не задаёт status; satisfied criteria могли копироваться | Exact root/descendant lifecycle + fresh reset criteria + tests | fixed in spec |
+| HIGH | atomicity | Zero-write validation и mid-write failure были смешаны | ValidationFailed/zero writes vs OutcomeUnknown/reconciliation | fixed in spec |
+| HIGH | product policy | Dates/external blockers не следуют однозначно из запроса | Запросить два выбора пользователя | fixed: 2A/3A |
+| MEDIUM | UI/relation coverage | Маркер/VM не доказывают controls и external policy | Real MainControl + reload; external AC | fixed: user chose 3A |
+| MEDIUM | validation | Не было обязательного build/progress contract | Добавить dotnet build/toolchain/durations/logs | fixed in spec |
+| LOW | duplicate graph | Spec обещала dedup, command запрещает duplicate relation | Считать duplicate invalid и тестировать command-level | fixed in spec |
+
+- Fixed before continuing: diagnosis no longer claims storage aliasing; added value-based UI hypothesis, exact lifecycle/criteria reset, recursive closure/DAG/remap, duplicate invalidation, split failure semantics, real MainControl/reload coverage and build contract.
+- Checks rerun: affected SPEC linter/rubric/contract/adversarial/role passes; финальный reviewer: PASS, BLOCKER/HIGH/MEDIUM отсутствуют.
+- Needs human: только approval.
+- Residual risks / follow-ups: storage-wide atomic transaction не вводится; mid-write storage failure остаётся ограниченным existing recovery и проверяется fault injection.
+
+## Approval
+Получено 02.09.2026 точной фразой пользователя: «Спеку подтверждаю». Разрешён EXEC утверждённого контракта; merge/release не разрешены.
+
+## 20. Журнал действий агента
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | ---: | --- | --- | --- | --- | --- | --- |
+| SPEC | Preflight/instruction routing | 1.00 | Нет | Проследить current generator/tests | Нет | Нет | QUEST + .NET desktop/UI profiles обязательны | Read-only instructions/source |
+| SPEC | AS-IS diagnosis | 0.98 | Локального нового reproduction нет | Спроектировать graph clone | Нет | Нет | Root clone reuses old child IDs; current tests cover only shallow repeater type | Read-only source/tests/masked data |
+| SPEC | TO-BE и quality gate | 0.92 | Reviewer findings и user-owned policies | Передать spec reviewer | Нет | Нет | Выбран preflight + source-ID mapping; date/blocking policy ещё не была проверена | Только эта spec |
+| SPEC | Adversarial reviewer | 0.97 | UI symptom + date/blocking choices | Исправить однозначные findings, задать 3 вопроса | Да | Обращение к пользователю будет следующим сообщением | Reviewer выявил неподтверждённый aliasing diagnosis, lifecycle/atomicity gaps и product decisions | Только эта spec; reviewer read-only procedural fallback |
+| SPEC | Решения пользователя | 1.00 | Re-review | Встроить selector symptom, shifted dates, internal-only blockers | Нет | Пользователь: шаблон не указан; 2A; 3A | Все product decisions закрыты | Только эта spec |
+| SPEC | Финальный re-review | 1.00 | Approval | Запросить точное подтверждение | Да | Будет запрошено в итоговом сообщении | Command-level cycle validation, duplicate semantics и stable selector contract проверены; reviewer PASS | Только эта spec; procedural read-only fallback |
+| EXEC | Approval и preflight | 1.00 | Expected-red evidence | Добавить regression tests до production fix | Нет | Пользователь: «Спеку подтверждаю» | Разрешён утверждённый selector/subtree contract | Эта spec; source/tests далее по плану |
+| EXEC | Rebase перед реализацией | 1.00 | Нет | Запустить expected-red tests | Нет | Пользователь: «Сначала сделай ребейз на мейн» | Ветка успешно перебазирована на актуальный `origin/main` `e00ab60c`, конфликтов нет | Git branch; user-owned `src/Tasks/` исключён |
+| EXEC | Expected-red | 1.00 | Нет | Реализовать утверждённый контракт | Нет | Нет | Tests зафиксировали отсутствие `SelectedRepeaterTemplate`, `ContainmentCycle` и clone descendants | Затронутые tests |
+| EXEC | Реализация selector и occurrence subtree | 0.98 | Full-suite и review evidence | Запустить целевые и полные проверки | Нет | Нет | Stable value selection; preflight closure; source-ID mapping; fresh lifecycle; internal relation remap | Production source и tests из таблицы изменений |
+| EXEC | Целевые проверки | 1.00 | Full-suite и post-EXEC review | Запустить полный serial suite | Нет | Нет | Selector/cycle/domain/command/file/UI/status/marker проверки зелёные | `Unlimotion.Test`: 9+4+39+17+22+8+21+3+4 tests |
+| EXEC | Полная регрессия | 1.00 | Post-EXEC review | Передать финальный diff reviewer | Нет | Нет | `Unlimotion.Test` 952/952 и Headless 38/38 зелёные; единственный устаревший CLI assertion первого прогона обновлён и полный suite повторно зелёный | Test reports; CLI integration contract |
+| EXEC | Solution build audit | 1.00 | Restore assets для незатронутых targets отсутствуют | Не блокировать проверенные desktop/test targets; явно сообщить ограничение | Нет | Нет | `dotnet build src/Unlimotion.sln --no-restore` собрал затронутые проекты, но завершился NETSDK1004 для iOS/Android/Browser/ReadmeMedia/Performance без `project.assets.json` | Build output; production/test projects |
+| EXEC | Post-EXEC adversarial review | 1.00 | Acceptance evidence gaps | Усилить UI/lifecycle/persisted tests и уточнить external contract | Нет | Нет | Первый review: production BLOCKER/HIGH нет; MEDIUM gaps исправлены. Re-review: PASS, новых BLOCKER/HIGH/MEDIUM нет | Spec; production diff; UI/domain/file/command tests; procedural fallback reviewer |
+| EXEC | Финальная регрессия после review fixes | 1.00 | CI после push | Commit и обновить PR #287 | Нет | Нет | `Unlimotion.Test` 953/953; Headless clean rerun 38/38. Два промежуточных Headless запуска аварийно завершились в existing background UI-thread race `TaskItemViewModel.SynchronizeCollections`, без assertion failures; следующий полный rerun зелёный | HTML test reports; console logs |

--- a/src/Unlimotion.TaskTreeManager/TaskAvailabilityAnalyzer.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskAvailabilityAnalyzer.cs
@@ -93,7 +93,8 @@ public enum TaskGraphReferenceIssueKind
     MissingReverseLink,
     SelfRelation,
     DuplicateRelation,
-    DuplicateCriterionId
+    DuplicateCriterionId,
+    ContainmentCycle
 }
 
 public sealed record TaskAvailabilityMismatch

--- a/src/Unlimotion.TaskTreeManager/TaskAvailabilityService.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskAvailabilityService.cs
@@ -150,6 +150,8 @@ public sealed class TaskAvailabilityService
             ValidateRelation(referenceIssues, task, nameof(TaskItem.BlockedByTasks), task.BlockedByTasks, nameof(TaskItem.BlocksTasks));
         }
 
+        ValidateContainmentCycles(referenceIssues);
+
         var availabilityMismatches = _tasks.Values
             .Select(Analyze)
             .Where(analysis => analysis.StoredIsCanBeCompleted != analysis.IsCanBeCompleted)
@@ -181,6 +183,76 @@ public sealed class TaskAvailabilityService
             DuplicateIdIssues = duplicateIds
         };
     }
+
+    private void ValidateContainmentCycles(ICollection<TaskGraphReferenceIssue> issues)
+    {
+        var states = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var start in _tasks.Values.OrderBy(static task => task.Id, StringComparer.Ordinal))
+        {
+            if (states.ContainsKey(start.Id))
+            {
+                continue;
+            }
+
+            states[start.Id] = 1;
+            var stack = new Stack<ContainmentTraversalFrame>();
+            stack.Push(CreateContainmentFrame(start));
+            while (stack.Count > 0)
+            {
+                var frame = stack.Pop();
+                if (frame.NextChildIndex >= frame.ChildIds.Length)
+                {
+                    states[frame.TaskId] = 2;
+                    continue;
+                }
+
+                var childId = frame.ChildIds[frame.NextChildIndex];
+                stack.Push(frame with { NextChildIndex = frame.NextChildIndex + 1 });
+                if (!_tasks.TryGetValue(childId, out var child) ||
+                    string.Equals(frame.TaskId, childId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (!states.TryGetValue(childId, out var childState))
+                {
+                    states[childId] = 1;
+                    stack.Push(CreateContainmentFrame(child));
+                    continue;
+                }
+
+                if (childState == 1)
+                {
+                    var source = _tasks[frame.TaskId];
+                    issues.Add(new TaskGraphReferenceIssue
+                    {
+                        Kind = TaskGraphReferenceIssueKind.ContainmentCycle,
+                        SourceTaskId = source.Id,
+                        SourceTaskTitle = source.Title,
+                        Relation = nameof(TaskItem.ContainsTasks),
+                        TargetTaskId = child.Id,
+                        TargetTaskTitle = child.Title,
+                        InverseRelation = nameof(TaskItem.ParentTasks),
+                        Details = $"{nameof(TaskItem.ContainsTasks)} contains a cycle through task '{child.Id}'."
+                    });
+                }
+            }
+        }
+    }
+
+    private static ContainmentTraversalFrame CreateContainmentFrame(TaskItem task) => new(
+        task.Id,
+        task.ContainsTasks?
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static id => id, StringComparer.Ordinal)
+            .ToArray() ?? Array.Empty<string>(),
+        0);
+
+    private readonly record struct ContainmentTraversalFrame(
+        string TaskId,
+        string[] ChildIds,
+        int NextChildIndex);
 
     private void ValidateRelation(
         ICollection<TaskGraphReferenceIssue> issues,

--- a/src/Unlimotion.TaskTreeManager/TaskTreeManager.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskTreeManager.cs
@@ -1114,6 +1114,214 @@ public class TaskTreeManager
         }
     }
 
+    private async Task<List<TaskItem>> CreateNextOccurrenceSubtree(TaskItem root, DateTimeOffset now)
+    {
+        if (root.Repeater == null || !root.PlannedBeginDateTime.HasValue)
+        {
+            return [];
+        }
+
+        var sources = new Dictionary<string, TaskItem>(StringComparer.Ordinal)
+        {
+            [root.Id] = TaskItemSnapshot.Clone(root)
+        };
+        var sourceOrder = new List<string> { root.Id };
+        var queue = new Queue<string>();
+        queue.Enqueue(root.Id);
+        while (queue.Count > 0)
+        {
+            var sourceId = queue.Dequeue();
+            var source = sources[sourceId];
+            EnsureNoDuplicateRelationIds(source, source.ContainsTasks, nameof(TaskItem.ContainsTasks));
+            foreach (var childId in source.ContainsTasks ?? [])
+            {
+                if (sources.ContainsKey(childId))
+                {
+                    continue;
+                }
+
+                var child = await Storage.Load(childId) ??
+                            throw new InvalidOperationException(
+                                $"Cannot clone repeating task '{root.Id}' because contained task '{childId}' is missing.");
+                sources.Add(childId, TaskItemSnapshot.Clone(child));
+                sourceOrder.Add(childId);
+                queue.Enqueue(childId);
+            }
+        }
+
+        EnsureAcyclicContainment(root.Id, sources);
+        var nextRootBegin = root.Repeater.GetNextOccurrence(root.PlannedBeginDateTime.Value);
+        var dateOffset = nextRootBegin - root.PlannedBeginDateTime.Value;
+        var clonesBySourceId = new Dictionary<string, TaskItem>(StringComparer.Ordinal);
+        foreach (var sourceId in sourceOrder)
+        {
+            clonesBySourceId[sourceId] = CreateOccurrenceClone(
+                sources[sourceId],
+                isRoot: string.Equals(sourceId, root.Id, StringComparison.Ordinal),
+                dateOffset,
+                now);
+        }
+
+        foreach (var sourceId in sourceOrder)
+        {
+            var source = sources[sourceId];
+            var clone = clonesBySourceId[sourceId];
+            foreach (var childId in source.ContainsTasks ?? [])
+            {
+                var childClone = clonesBySourceId[childId];
+                clone.ContainsTasks.Add(childClone.Id);
+                childClone.ParentTasks.Add(clone.Id);
+            }
+
+            foreach (var blockedId in source.BlocksTasks ?? [])
+            {
+                if (!clonesBySourceId.TryGetValue(blockedId, out var blockedClone))
+                {
+                    continue;
+                }
+
+                AddRelationId(clone.BlocksTasks, blockedClone.Id);
+                AddRelationId(blockedClone.BlockedByTasks, clone.Id);
+            }
+
+            foreach (var blockerId in source.BlockedByTasks ?? [])
+            {
+                if (!clonesBySourceId.TryGetValue(blockerId, out var blockerClone))
+                {
+                    continue;
+                }
+
+                AddRelationId(clone.BlockedByTasks, blockerClone.Id);
+                AddRelationId(blockerClone.BlocksTasks, clone.Id);
+            }
+        }
+
+        foreach (var sourceId in sourceOrder.AsEnumerable().Reverse())
+        {
+            await Storage.Save(clonesBySourceId[sourceId]);
+        }
+
+        var result = new Dictionary<string, TaskItem>(StringComparer.Ordinal);
+        result.AddOrUpdateRange(clonesBySourceId.Values);
+        result.AddOrUpdateRange(await CalculateAndUpdateAvailability(clonesBySourceId[root.Id]));
+        return result.Values.ToList();
+    }
+
+    private static TaskItem CreateOccurrenceClone(
+        TaskItem source,
+        bool isRoot,
+        TimeSpan dateOffset,
+        DateTimeOffset now)
+    {
+        var snapshot = TaskItemSnapshot.Clone(source);
+        var clone = new TaskItem
+        {
+            Id = Guid.NewGuid().ToString(),
+            UserId = snapshot.UserId,
+            Title = snapshot.Title,
+            Description = snapshot.Description,
+            Status = isRoot ? DomainTaskStatus.Prepared : DomainTaskStatus.NotReady,
+            StatusHistory = [],
+            CompletionCriteria = snapshot.CompletionCriteria
+                .Where(static criterion => criterion != null)
+                .Select(static criterion => new TaskCompletionCriterion
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Text = criterion.Text,
+                    IsSatisfied = false,
+                    ExtensionData = criterion.ExtensionData?.ToDictionary(
+                        static pair => pair.Key,
+                        static pair => pair.Value == null ? null! : pair.Value.DeepClone())
+                })
+                .ToList(),
+            IsCanBeCompleted = true,
+            CreatedDateTime = now,
+            UpdatedDateTime = null,
+            UnlockedDateTime = null,
+            PlannedBeginDateTime = snapshot.PlannedBeginDateTime?.Add(dateOffset),
+            PlannedEndDateTime = snapshot.PlannedEndDateTime?.Add(dateOffset),
+            PlannedDuration = snapshot.PlannedDuration,
+            ContainsTasks = [],
+            ParentTasks = [],
+            BlocksTasks = [],
+            BlockedByTasks = [],
+            Repeater = snapshot.Repeater,
+            Importance = snapshot.Importance,
+            Wanted = snapshot.Wanted,
+            Version = 1,
+            ExtensionData = snapshot.ExtensionData
+        };
+        clone.EnsureStatusHistory("System");
+        return clone;
+    }
+
+    private static void EnsureNoDuplicateRelationIds(
+        TaskItem source,
+        IEnumerable<string>? relationIds,
+        string relationName)
+    {
+        var duplicate = relationIds?
+            .Where(static id => !string.IsNullOrWhiteSpace(id))
+            .GroupBy(static id => id, StringComparer.Ordinal)
+            .FirstOrDefault(static group => group.Count() > 1);
+        if (duplicate != null)
+        {
+            throw new InvalidOperationException(
+                $"Cannot clone task '{source.Id}': {relationName} contains duplicate task '{duplicate.Key}'.");
+        }
+    }
+
+    private static void EnsureAcyclicContainment(
+        string rootId,
+        IReadOnlyDictionary<string, TaskItem> sources)
+    {
+        var states = new Dictionary<string, int>(StringComparer.Ordinal) { [rootId] = 1 };
+        var stack = new Stack<OccurrenceTraversalFrame>();
+        stack.Push(CreateOccurrenceFrame(sources[rootId]));
+        while (stack.Count > 0)
+        {
+            var frame = stack.Pop();
+            if (frame.NextChildIndex >= frame.ChildIds.Length)
+            {
+                states[frame.TaskId] = 2;
+                continue;
+            }
+
+            var childId = frame.ChildIds[frame.NextChildIndex];
+            stack.Push(frame with { NextChildIndex = frame.NextChildIndex + 1 });
+            if (!states.TryGetValue(childId, out var childState))
+            {
+                states[childId] = 1;
+                stack.Push(CreateOccurrenceFrame(sources[childId]));
+                continue;
+            }
+
+            if (childState == 1)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot clone repeating task '{rootId}' because containment has a cycle through '{childId}'.");
+            }
+        }
+    }
+
+    private static OccurrenceTraversalFrame CreateOccurrenceFrame(TaskItem task) => new(
+        task.Id,
+        task.ContainsTasks?.ToArray() ?? Array.Empty<string>(),
+        0);
+
+    private static void AddRelationId(ICollection<string> relation, string id)
+    {
+        if (!relation.Contains(id, StringComparer.Ordinal))
+        {
+            relation.Add(id);
+        }
+    }
+
+    private readonly record struct OccurrenceTraversalFrame(
+        string TaskId,
+        string[] ChildIds,
+        int NextChildIndex);
+
     /// <summary>
     /// Handles logic when a task's Status property changes
     /// </summary>
@@ -1164,78 +1372,7 @@ public class TaskTreeManager
                     if (task.Repeater != null && task.Repeater.Type != RepeaterType.None &&
                         task.PlannedBeginDateTime.HasValue)
                     {
-                        var clone = new TaskItem
-                        {
-                            BlocksTasks = task.BlocksTasks.ToList(),
-                            BlockedByTasks =
-                                task.BlockedByTasks.ToList(), //TODO добавить тест на срабатывание блокировки
-                            ContainsTasks = task.ContainsTasks.ToList(),
-                            Description = task.Description,
-                            Title = task.Title,
-                            PlannedDuration = task.PlannedDuration,
-                            Repeater = task.Repeater,
-                            Status = DomainTaskStatus.Prepared,
-                            Wanted = task.Wanted,
-                        };
-                        clone.SetStatus(DomainTaskStatus.Prepared, now, "System");
-                        clone.PlannedBeginDateTime = task.Repeater.GetNextOccurrence(task.PlannedBeginDateTime.Value);
-                        if (task.PlannedEndDateTime.HasValue)
-                        {
-                            clone.PlannedEndDateTime =
-                                clone.PlannedBeginDateTime.Value.Add(task.PlannedEndDateTime.Value -
-                                                                     task.PlannedBeginDateTime.Value);
-                        }
-
-                        // Save the cloned task
-                        clone.Version = 1;
-                        clone.UpdatedDateTime ??= clone.CreatedDateTime;
-                        await Storage.Save(clone);
-                        result.AddOrUpdate(clone);
-
-                        // Restore reverse links for cloned relations, so model stays symmetric:
-                        // child.ParentTasks, blocker.BlocksTasks, blocked.BlockedByTasks.
-                        if (clone.ContainsTasks?.Count > 0)
-                        {
-                            foreach (var containsId in clone.ContainsTasks)
-                            {
-                                var child = await Storage.Load(containsId);
-                                if (child != null)
-                                {
-                                    result.AddOrUpdateRange(
-                                        await CreateParentChildRelation(clone, child));
-                                }
-                            }
-                        }
-
-                        if (clone.BlockedByTasks?.Count > 0)
-                        {
-                            foreach (var blockerId in clone.BlockedByTasks)
-                            {
-                                var blocker = await Storage.Load(blockerId);
-                                if (blocker != null)
-                                {
-                                    result.AddOrUpdateRange(
-                                        await CreateBlockingBlockedByRelation(clone, blocker));
-                                }
-                            }
-                        }
-
-                        if (clone.BlocksTasks?.Count > 0)
-                        {
-                            foreach (var blockedId in clone.BlocksTasks)
-                            {
-                                var blocked = await Storage.Load(blockedId);
-                                if (blocked != null)
-                                {
-                                    result.AddOrUpdateRange(
-                                        await CreateBlockingBlockedByRelation(blocked, clone));
-                                }
-                            }
-                        }
-
-                        // Always normalize clone availability even if it has no relations.
-                        result.AddOrUpdateRange(
-                            await CalculateAndUpdateAvailability(clone));
+                        result.AddOrUpdateRange(await CreateNextOccurrenceSubtree(task, now));
                     }
                 }
 

--- a/src/Unlimotion.Test/FileStorageTaskStatusTests.cs
+++ b/src/Unlimotion.Test/FileStorageTaskStatusTests.cs
@@ -69,18 +69,38 @@ public class FileStorageTaskStatusTests
         try
         {
             var storage = new CountingFileStorage(tempDir, new RecordingDatabaseWatcher());
+            var plannedBegin = DateTime.Now.AddDays(-1);
+            var grandchild = new TaskItem
+            {
+                Id = "immediate-repeating-grandchild",
+                Title = "Daily review nested subtask",
+                Status = DomainTaskStatus.Completed,
+                ParentTasks = ["immediate-repeating-child"],
+                PlannedBeginDateTime = plannedBegin.AddHours(3)
+            };
+            var child = new TaskItem
+            {
+                Id = "immediate-repeating-child",
+                Title = "Daily review subtask",
+                Status = DomainTaskStatus.Completed,
+                ParentTasks = ["immediate-repeating-completion"],
+                ContainsTasks = [grandchild.Id],
+                PlannedBeginDateTime = plannedBegin.AddHours(2)
+            };
             var source = new TaskItem
             {
                 Id = "immediate-repeating-completion",
                 Status = DomainTaskStatus.Prepared,
-                IsCanBeCompleted = true
+                IsCanBeCompleted = true,
+                ContainsTasks = [child.Id]
             };
+            await storage.Save(grandchild);
+            await storage.Save(child);
             await storage.Save(source);
             using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
             await unified.Init();
             var viewModel = unified.Tasks.Lookup(source.Id).Value;
             viewModel.IsInitializedProvider = () => true;
-            var plannedBegin = DateTime.Now.AddDays(-1);
 
             viewModel.Title = "Daily review";
             viewModel.PlannedBeginDateTime = plannedBegin;
@@ -95,7 +115,12 @@ public class FileStorageTaskStatusTests
                 "tester");
             var graph = await storage.ReadGraphAsync();
             var persistedSource = graph.TasksById[source.Id];
-            var next = graph.Tasks.Single(task => task.Id != source.Id);
+            var persistedChild = graph.TasksById[child.Id];
+            var persistedGrandchild = graph.TasksById[grandchild.Id];
+            var next = graph.Tasks.Single(task => task.Id != source.Id && task.Title == "Daily review");
+            var nextChild = graph.Tasks.Single(task => task.Id != child.Id && task.Title == child.Title);
+            var nextGrandchild = graph.Tasks.Single(task =>
+                task.Id != grandchild.Id && task.Title == grandchild.Title);
 
             using (Assert.Multiple())
             {
@@ -107,7 +132,19 @@ public class FileStorageTaskStatusTests
                 await Assert.That(next.Status).IsEqualTo(DomainTaskStatus.Prepared);
                 await Assert.That(next.PlannedBeginDateTime?.LocalDateTime).IsEqualTo(plannedBegin.AddDays(1));
                 await Assert.That(next.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+                await Assert.That(next.ContainsTasks).IsEquivalentTo([nextChild.Id]);
+                await Assert.That(nextChild.ParentTasks).IsEquivalentTo([next.Id]);
+                await Assert.That(nextChild.ContainsTasks).IsEquivalentTo([nextGrandchild.Id]);
+                await Assert.That(nextGrandchild.ParentTasks).IsEquivalentTo([nextChild.Id]);
+                await Assert.That(nextChild.Status).IsEqualTo(DomainTaskStatus.NotReady);
+                await Assert.That(nextGrandchild.Status).IsEqualTo(DomainTaskStatus.NotReady);
+                await Assert.That(nextChild.PlannedBeginDateTime?.LocalDateTime)
+                    .IsEqualTo(persistedChild.PlannedBeginDateTime?.LocalDateTime.AddDays(1));
+                await Assert.That(nextGrandchild.PlannedBeginDateTime?.LocalDateTime)
+                    .IsEqualTo(persistedGrandchild.PlannedBeginDateTime?.LocalDateTime.AddDays(1));
                 await Assert.That(unified.Tasks.Lookup(next.Id).HasValue).IsTrue();
+                await Assert.That(unified.Tasks.Lookup(nextChild.Id).HasValue).IsTrue();
+                await Assert.That(unified.Tasks.Lookup(nextGrandchild.Id).HasValue).IsTrue();
             }
         }
         finally

--- a/src/Unlimotion.Test/MainControlRepeaterStartDateUiTests.cs
+++ b/src/Unlimotion.Test/MainControlRepeaterStartDateUiTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -12,9 +13,13 @@ using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Newtonsoft.Json;
+using Unlimotion;
 using Unlimotion.Domain;
+using Unlimotion.Storage;
+using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
 using Unlimotion.Views;
+using DomainTaskStatus = Unlimotion.Domain.TaskStatus;
 
 namespace Unlimotion.Test;
 
@@ -22,6 +27,189 @@ namespace Unlimotion.Test;
 [ParallelLimiter<SharedUiStateParallelLimit>]
 public class MainControlRepeaterStartDateUiTests
 {
+    [Test]
+    public async Task CompletingRepeatingTask_SelectsTemplateAfterReload()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            await using var fixture = new MainWindowViewModelFixture();
+            var vm = fixture.MainWindowViewModelTest;
+            await vm.Connect();
+            vm.AllTasksMode = true;
+            vm.DetailsAreOpen = true;
+            var source = TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RepeateTask9Id);
+            source.Title = "UI repeating source";
+            source.Status = DomainTaskStatus.Prepared;
+            source.IsCanBeCompleted = true;
+            source.PlannedBeginDateTime = DateTime.Today.AddDays(-1);
+            source.Repeater = new RepeaterPatternViewModel
+            {
+                Type = RepeaterType.Daily,
+                Period = 3,
+                AfterComplete = true
+            };
+            var readySource = source.Model;
+            readySource.Status = DomainTaskStatus.Prepared;
+            readySource.IsCanBeCompleted = true;
+            await vm.taskRepository!.TaskTreeManager.Storage.Save(readySource);
+            source.Update(readySource);
+            vm.CurrentTaskItem = source;
+            vm.SelectCurrentTask();
+
+            var countBeforeCompletion = vm.taskRepository.Tasks.Count;
+            var view = new MainControl { DataContext = vm };
+            var window = new Window { Width = 1400, Height = 1000, Content = view };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                var statusPicker = Find<TaskStatusPicker>(view, "CurrentTaskStatusButton");
+                var buildFlyout = typeof(TaskStatusPicker).GetMethod(
+                    "BuildStatusFlyout",
+                    BindingFlags.NonPublic | BindingFlags.Static)
+                    ?? throw new InvalidOperationException("TaskStatusPicker.BuildStatusFlyout was not found.");
+                var flyout = (MenuFlyout)buildFlyout.Invoke(null, [source])!;
+                statusPicker.Flyout = flyout;
+                flyout.ShowAt(statusPicker);
+                Dispatcher.UIThread.RunJobs();
+                var completed = flyout.Items.OfType<MenuItem>().Single(item =>
+                    AutomationProperties.GetAutomationId(item) == "TaskStatusOptionCompleted");
+                await Assert.That(completed.IsEnabled).IsTrue();
+                completed.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent, completed));
+                Dispatcher.UIThread.RunJobs();
+
+                await WaitAsync(() =>
+                    source.Status == DomainTaskStatus.Completed &&
+                    vm.taskRepository.Tasks.Count == countBeforeCompletion + 1);
+                var next = vm.taskRepository.Tasks.Items.Single(task =>
+                    task.Id != source.Id && task.Title == source.Title);
+                TestHelpers.SetCurrentTask(vm, next.Id);
+                vm.SelectCurrentTask();
+                Dispatcher.UIThread.RunJobs();
+
+                var selector = Find<ComboBox>(view, "CurrentTaskRepeaterSelector");
+                var selected = selector.SelectedItem as RepeaterPatternViewModel;
+                using (Assert.Multiple())
+                {
+                    await Assert.That(selected).IsNotNull();
+                    await Assert.That(selected!.Type).IsEqualTo(RepeaterType.Daily);
+                    await Assert.That(next.Repeater!.Period).IsEqualTo(3);
+                    await Assert.That(next.Repeater.AfterComplete).IsTrue();
+                }
+
+                var path = Path.Combine(fixture.DefaultTasksFolderPath, next.Id);
+                await WaitAsync(() => File.Exists(path));
+                using var reloadedRepository = new UnifiedTaskStorage(new TaskTreeManager(
+                    new FileTaskStorage(new FileTaskStorageOptions
+                    {
+                        Path = fixture.DefaultTasksFolderPath,
+                        UseWatcher = false
+                    })));
+                await reloadedRepository.Init();
+                var reloadedNext = reloadedRepository.Tasks.Lookup(next.Id).Value;
+                vm.CurrentTaskItem = reloadedNext;
+                Dispatcher.UIThread.RunJobs();
+                selected = selector.SelectedItem as RepeaterPatternViewModel;
+                await Assert.That(selected).IsNotNull();
+                await Assert.That(selected!.Type).IsEqualTo(RepeaterType.Daily);
+            }
+            finally
+            {
+                window.Content = null;
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task HydratedWeeklyRepeaters_SelectExactTemplatesInComboBox()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            await using var fixture = new MainWindowViewModelFixture();
+            var vm = fixture.MainWindowViewModelTest;
+            await vm.Connect();
+            vm.DetailsAreOpen = true;
+            TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RepeateTask9Id);
+            vm.SelectCurrentTask();
+            var task = vm.CurrentTaskItem!;
+            var view = new MainControl { DataContext = vm };
+            var window = new Window { Width = 1400, Height = 1000, Content = view };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                var selector = Find<ComboBox>(view, "CurrentTaskRepeaterSelector");
+
+                task.Repeater = new RepeaterPatternViewModel
+                {
+                    Type = RepeaterType.Weekly,
+                    WorkDays = true
+                };
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(selector.SelectedItem).IsSameReferenceAs(task.Repeaters[2]);
+
+                task.Repeater = new RepeaterPatternViewModel
+                {
+                    Type = RepeaterType.Weekly,
+                    Monday = true,
+                    Saturday = true
+                };
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(selector.SelectedItem).IsSameReferenceAs(task.Repeaters[3]);
+            }
+            finally
+            {
+                window.Content = null;
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task HydratedDailyRepeater_IsSelectedInTemplateComboBox()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            await using var fixture = new MainWindowViewModelFixture();
+            var vm = fixture.MainWindowViewModelTest;
+            await vm.Connect();
+            vm.DetailsAreOpen = true;
+            TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RepeateTask9Id);
+            vm.SelectCurrentTask();
+            var task = vm.CurrentTaskItem!;
+            task.Repeater = new RepeaterPatternViewModel
+            {
+                Type = RepeaterType.Daily,
+                Period = 3,
+                AfterComplete = true
+            };
+            var view = new MainControl { DataContext = vm };
+            var window = new Window { Width = 1400, Height = 1000, Content = view };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                var selector = Find<ComboBox>(view, "CurrentTaskRepeaterSelector");
+                await Assert.That(selector.SelectedItem)
+                    .IsSameReferenceAs(task.SelectedRepeaterTemplate);
+                await Assert.That(task.Repeater.Period).IsEqualTo(3);
+                await Assert.That(task.Repeater.AfterComplete).IsTrue();
+            }
+            finally
+            {
+                window.Content = null;
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        }, CancellationToken.None);
+    }
+
     [Test]
     [Arguments(1400)]
     [Arguments(390)]

--- a/src/Unlimotion.Test/MainControlRepeaterStartDateUiTests.cs
+++ b/src/Unlimotion.Test/MainControlRepeaterStartDateUiTests.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Automation;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Newtonsoft.Json;
+using Unlimotion.Domain;
+using Unlimotion.ViewModel;
+using Unlimotion.Views;
+
+namespace Unlimotion.Test;
+
+[NotInParallel("AvaloniaHeadless")]
+[ParallelLimiter<SharedUiStateParallelLimit>]
+public class MainControlRepeaterStartDateUiTests
+{
+    [Test]
+    [Arguments(1400)]
+    [Arguments(390)]
+    public async Task OpeningWithoutStart_HidesSection_WithoutErasingLegacyPattern(int width)
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            await using var fixture = new MainWindowViewModelFixture();
+            var vm = fixture.MainWindowViewModelTest;
+            await vm.Connect();
+            vm.DetailsAreOpen = true;
+            TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RepeateTask9Id);
+            vm.SelectCurrentTask();
+            var task = vm.CurrentTaskItem!;
+            var authoritative = task.Model;
+            authoritative.PlannedBeginDateTime = null;
+            task.Update(authoritative);
+            var view = new MainControl { DataContext = vm };
+            var window = new Window { Width = width, Height = 1000, Content = view };
+            try
+            {
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(Find<Border>(view, "CurrentTaskRepeaterSection").IsVisible).IsFalse();
+                await Assert.That(task.Repeater!.Model.Equals(authoritative.Repeater)).IsTrue();
+                await Assert.That(Find<ComboBox>(view, "CurrentTaskRepeaterSelector").Focus()).IsFalse();
+            }
+            finally
+            {
+                window.Content = null;
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    [Arguments(1400, false)]
+    [Arguments(1400, true)]
+    [Arguments(390, false)]
+    [Arguments(390, true)]
+    public async Task ClearingStart_HidesSectionAndPersistsReset_WithoutRestoringRepeater(int width, bool viaMenu)
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            var previousThrottle = TaskItemViewModel.DefaultThrottleTime;
+            TaskItemViewModel.DefaultThrottleTime = TimeSpan.FromMilliseconds(30);
+            try
+            {
+                await using var fixture = new MainWindowViewModelFixture();
+                var vm = fixture.MainWindowViewModelTest;
+                await vm.Connect();
+                vm.AllTasksMode = true;
+                vm.DetailsAreOpen = true;
+                TestHelpers.SetCurrentTask(vm, MainWindowViewModelFixture.RepeateTask9Id);
+                vm.SelectCurrentTask();
+                var task = vm.CurrentTaskItem!;
+                var end = task.PlannedEndDateTime;
+                var duration = task.PlannedDuration;
+                var view = new MainControl { DataContext = vm };
+                var window = new Window { Width = width, Height = 1000, Content = view };
+                try
+                {
+                    window.Show();
+                    Dispatcher.UIThread.RunJobs();
+                    var section = Find<Border>(view, "CurrentTaskRepeaterSection");
+                    var picker = Find<CalendarDatePicker>(view, "CurrentTaskPlannedBeginPicker");
+                    await Assert.That(section.IsVisible).IsTrue();
+                    await Assert.That(task.Repeater).IsNotNull();
+
+                    if (viaMenu)
+                    {
+                        var button = Find<DropDownButton>(view, "CurrentTaskSetBeginButton");
+                        button.Flyout!.ShowAt(button);
+                        Dispatcher.UIThread.RunJobs();
+                        var menu = (MenuFlyout)button.Flyout;
+                        var none = menu.Items.OfType<MenuItem>()
+                            .Single(item => ReferenceEquals(item.Command, task.Commands.SetBeginNone));
+                        none.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+                        menu.Hide();
+                    }
+                    else
+                    {
+                        // Edit the actual picker text to exercise its two-way binding and commit.
+                        var editor = picker.GetVisualDescendants().OfType<TextBox>().First();
+                        editor.Focus();
+                        editor.Text = string.Empty;
+                        window.KeyPress(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, null);
+                        window.KeyRelease(Key.Enter, RawInputModifiers.None, PhysicalKey.Enter, null);
+                        picker.Focus();
+                    }
+
+                    await WaitAsync(() => task.PlannedBeginDateTime == null);
+                    await Assert.That(section.IsVisible).IsFalse();
+                    await Assert.That(section.GetVisualDescendants().OfType<Control>().Any(c => c.IsEffectivelyVisible)).IsFalse();
+                    await Assert.That(Find<ComboBox>(view, "CurrentTaskRepeaterSelector").Focus()).IsFalse();
+                    await Assert.That(task.Repeater).IsNull();
+                    await Assert.That(task.RepeaterListMarker).IsEqualTo(string.Empty);
+                    await Assert.That(task.PlannedEndDateTime).IsEqualTo(end);
+                    await Assert.That(task.PlannedDuration).IsEqualTo(duration);
+
+                    var path = Path.Combine(fixture.DefaultTasksFolderPath, task.Id);
+                    await WaitAsync(() => ReadTask(path) is { PlannedBeginDateTime: null, Repeater: null });
+                    await task.WaitForPendingSavesAsync();
+                    var persisted = ReadTask(path)!;
+                    await Assert.That(persisted.PlannedEndDateTime?.LocalDateTime).IsEqualTo(end);
+                    await Assert.That(persisted.PlannedDuration).IsEqualTo(duration);
+
+                    // Reopen from disk, then restore only the date through the picker.
+                    task.Update(persisted);
+                    picker.SelectedDate = DateTime.Today;
+                    await WaitAsync(() => section.IsVisible);
+                    await Assert.That(task.Repeater).IsNull();
+                    await WaitAsync(() => ReadTask(path) is { PlannedBeginDateTime: not null, Repeater: null });
+                }
+                finally
+                {
+                    window.Content = null;
+                    window.Close();
+                    Dispatcher.UIThread.RunJobs();
+                }
+            }
+            finally
+            {
+                TaskItemViewModel.DefaultThrottleTime = previousThrottle;
+            }
+        }, CancellationToken.None);
+    }
+
+    private static T Find<T>(Control root, string id) where T : Control => root.GetVisualDescendants()
+        .OfType<T>().Single(control => AutomationProperties.GetAutomationId(control) == id);
+
+    private static TaskItem? ReadTask(string path)
+    {
+        try { return JsonConvert.DeserializeObject<TaskItem>(File.ReadAllText(path)); }
+        catch (IOException) { return null; }
+        catch (JsonException) { return null; }
+    }
+
+    private static async Task WaitAsync(Func<bool> condition)
+    {
+        var succeeded = await TestHelpers.WaitUntilAsync(() =>
+        {
+            Dispatcher.UIThread.RunJobs();
+            return condition();
+        }, TimeSpan.FromSeconds(5), TimeSpan.FromMilliseconds(20));
+        await Assert.That(succeeded).IsTrue();
+    }
+}

--- a/src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTaskCardLayoutUiTests.cs
@@ -911,6 +911,8 @@ public class MainControlTaskCardLayoutUiTests
         vm.AllTasksMode = true;
         vm.DetailsAreOpen = true;
         var currentTask = TestHelpers.SetCurrentTask(vm, selectedTaskId);
+        // Full-card layout checks include the repeater section, which requires a start date.
+        currentTask.PlannedBeginDateTime ??= DateTime.Today;
         configureCurrentTask?.Invoke(currentTask);
 
         var view = new MainControl

--- a/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
@@ -931,13 +931,24 @@ public class MainControlTaskStatusIconUiTests
         {
             var storage = new InMemoryStorage();
             var repository = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            var storedChild = new TaskItem
+            {
+                Id = "status-picker-immediate-repeat-child",
+                Title = "Daily review child",
+                Status = DomainTaskStatus.Completed,
+                IsCanBeCompleted = true,
+                ParentTasks = ["status-picker-immediate-repeat"]
+            };
+            storedChild.EnsureStatusHistory("owner");
             var storedTask = new TaskItem
             {
                 Id = "status-picker-immediate-repeat",
                 Status = DomainTaskStatus.Prepared,
-                IsCanBeCompleted = true
+                IsCanBeCompleted = true,
+                ContainsTasks = [storedChild.Id]
             };
             storedTask.EnsureStatusHistory("owner");
+            await storage.Save(storedChild);
             await storage.Save(storedTask);
             await repository.Init();
             Window? window = null;
@@ -977,9 +988,11 @@ public class MainControlTaskStatusIconUiTests
                 var completed = await TestHelpers.WaitUntilAsync(() =>
                 {
                     Dispatcher.UIThread.RunJobs();
-                    return task.Status == DomainTaskStatus.Completed && repository.Tasks.Count == 2;
+                    return task.Status == DomainTaskStatus.Completed && repository.Tasks.Count == 4;
                 }, TimeSpan.FromSeconds(2));
-                var next = repository.Tasks.Items.Single(item => item.Id != task.Id);
+                var next = repository.Tasks.Items.Single(item => item.Id != task.Id && item.Title == "Daily review");
+                var nextChild = repository.Tasks.Items.Single(item =>
+                    item.Id != storedChild.Id && item.Title == storedChild.Title);
 
                 using (Assert.Multiple())
                 {
@@ -991,6 +1004,10 @@ public class MainControlTaskStatusIconUiTests
                     await Assert.That(next.Status).IsEqualTo(DomainTaskStatus.Prepared);
                     await Assert.That(next.PlannedBeginDateTime).IsEqualTo(plannedBegin.AddDays(1));
                     await Assert.That(next.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+                    await Assert.That(next.Contains).IsEquivalentTo([nextChild.Id]);
+                    await Assert.That(nextChild.Parents).IsEquivalentTo([next.Id]);
+                    await Assert.That(nextChild.Status).IsEqualTo(DomainTaskStatus.NotReady);
+                    await Assert.That(nextChild.Id).IsNotEqualTo(storedChild.Id);
                 }
             }
             finally

--- a/src/Unlimotion.Test/TaskAvailabilityParityTests.cs
+++ b/src/Unlimotion.Test/TaskAvailabilityParityTests.cs
@@ -109,6 +109,22 @@ public sealed class TaskAvailabilityParityTests
             .Contains(TaskGraphReferenceIssueKind.DuplicateCriterionId);
     }
 
+    [Test]
+    public async Task Validate_ReportsContainmentCycle()
+    {
+        var first = CreateTask("first", DomainTaskStatus.Prepared);
+        var second = CreateTask("second", DomainTaskStatus.Prepared);
+        first.ContainsTasks = [second.Id];
+        first.ParentTasks = [second.Id];
+        second.ContainsTasks = [first.Id];
+        second.ParentTasks = [first.Id];
+
+        var validation = new TaskAvailabilityService([first, second]).Validate();
+
+        await Assert.That(validation.ReferenceIssues.Select(static issue => issue.Kind))
+            .Contains(TaskGraphReferenceIssueKind.ContainmentCycle);
+    }
+
     private static IReadOnlyList<ParityScenario> CreateScenarios()
     {
         var available = CreateTask("available", DomainTaskStatus.Prepared);

--- a/src/Unlimotion.Test/TaskGraphCommandServiceTests.cs
+++ b/src/Unlimotion.Test/TaskGraphCommandServiceTests.cs
@@ -516,7 +516,38 @@ public sealed class TaskGraphCommandServiceTests
     }
 
     [Test]
-    public async Task TrySetStatus_RepeatingCompletionReturnsOriginalCloneAndReverseLinkTasks()
+    public async Task TrySetStatus_ContainmentCycleFailsValidationWithoutWrites()
+    {
+        var source = CreateTask("cycle-source", DomainTaskStatus.Prepared);
+        var child = CreateTask("cycle-child", DomainTaskStatus.Completed);
+        source.ContainsTasks = [child.Id];
+        source.ParentTasks = [child.Id];
+        child.ContainsTasks = [source.Id];
+        child.ParentTasks = [source.Id];
+        var storage = new DiagnosticStorage([source, child]);
+
+        var result = await new TaskGraphCommandService(storage)
+            .TrySetStatusAsync(source.Id, DomainTaskStatus.Completed, "tester");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Success).IsFalse();
+            await Assert.That(result.DeniedReason?.Kind)
+                .IsEqualTo(TaskOperationDeniedKind.ValidationFailed);
+            await Assert.That(result.Validation?.ReferenceIssues.Any(issue =>
+                    issue.Kind == TaskGraphReferenceIssueKind.ContainmentCycle))
+                .IsTrue();
+            await Assert.That(result.ChangedTasks).IsEmpty();
+            await Assert.That(storage.SaveCount).IsEqualTo(0);
+            await Assert.That(result.AuthoritativeTask).IsNull();
+        }
+
+        var persisted = await storage.Load(source.Id);
+        await Assert.That(persisted!.Status).IsEqualTo(DomainTaskStatus.Prepared);
+    }
+
+    [Test]
+    public async Task TrySetStatus_RepeatingCompletionReturnsOriginalAndClonedSubtree()
     {
         using var temp = TempTaskDirectory.Create();
         var plannedBegin = DateTimeOffset.UtcNow.AddDays(-1);
@@ -550,18 +581,24 @@ public sealed class TaskGraphCommandServiceTests
         var changedIds = result.ChangedTasks.Select(static task => task.Id).ToHashSet(StringComparer.Ordinal);
         var allTasks = await LoadAllTasks(storage);
         var clone = allTasks.Single(task => task.Id != source.Id && task.Title == source.Title);
+        var childClone = allTasks.Single(task => task.Id != child.Id && task.Title == child.Title);
         await Assert.That(changedIds).Contains(source.Id);
         await Assert.That(changedIds).Contains(clone.Id);
-        await Assert.That(changedIds).Contains(child.Id);
-        await Assert.That(changedIds).Contains(blocker.Id);
+        await Assert.That(changedIds).Contains(childClone.Id);
         await Assert.That(changedIds).Contains(blocked.Id);
+        await Assert.That(clone.ContainsTasks).IsEquivalentTo([childClone.Id]);
+        await Assert.That(childClone.ParentTasks).IsEquivalentTo([clone.Id]);
+        await Assert.That(clone.BlockedByTasks).IsEmpty();
+        await Assert.That(clone.BlocksTasks).IsEmpty();
 
         var childAfter = await storage.Load(child.Id, forced: true);
         var blockerAfter = await storage.Load(blocker.Id, forced: true);
         var blockedAfter = await storage.Load(blocked.Id, forced: true);
-        await Assert.That(childAfter!.ParentTasks).Contains(clone.Id);
-        await Assert.That(blockerAfter!.BlocksTasks).Contains(clone.Id);
-        await Assert.That(blockedAfter!.BlockedByTasks).Contains(clone.Id);
+        await Assert.That(childAfter!.ParentTasks).IsEquivalentTo([source.Id]);
+        await Assert.That(blockerAfter!.BlocksTasks).IsEquivalentTo([source.Id]);
+        await Assert.That(blockedAfter!.BlockedByTasks).IsEquivalentTo([source.Id]);
+        await Assert.That(blockedAfter.IsCanBeCompleted).IsTrue();
+        await Assert.That(blockedAfter.UnlockedDateTime).IsNotNull();
     }
 
     [Test]

--- a/src/Unlimotion.Test/TaskItemRepeaterStartDateTests.cs
+++ b/src/Unlimotion.Test/TaskItemRepeaterStartDateTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Unlimotion.Domain;
+using Unlimotion.TaskTree;
+using Unlimotion.ViewModel;
+
+namespace Unlimotion.Test;
+
+public class TaskItemRepeaterStartDateTests
+{
+    [Test]
+    [Arguments(RepeaterType.Daily, false)]
+    [Arguments(RepeaterType.Weekly, true)]
+    [Arguments(RepeaterType.None, false)]
+    public async Task ClearingStart_DropsEntireRepeater_WithoutChangingOtherPlanningFields(
+        RepeaterType type, bool afterComplete)
+    {
+        using var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        using var task = new TaskItemViewModel(CreateModel(type, afterComplete), storage, () => false);
+        var end = task.PlannedEndDateTime;
+        var duration = task.PlannedDuration;
+        var previousRepeater = task.Repeater!;
+
+        task.PlannedBeginDateTime = null;
+
+        await Assert.That(task.Repeater).IsNull();
+        await Assert.That(task.Model.Repeater).IsNull();
+        await Assert.That(task.IsHaveRepeater).IsFalse();
+        await Assert.That(task.RepeaterListMarker).IsEqualTo(string.Empty);
+        await Assert.That(task.PlannedEndDateTime).IsEqualTo(end);
+        await Assert.That(task.PlannedDuration).IsEqualTo(duration);
+
+        var notifications = new List<string?>();
+        ((INotifyPropertyChanged)task).PropertyChanged += (_, args) => notifications.Add(args.PropertyName);
+        previousRepeater.Period = 9;
+        await Assert.That(notifications).DoesNotContain(nameof(TaskItemViewModel.RepeaterListMarker));
+
+        task.PlannedBeginDateTime = DateTime.Today.AddDays(2);
+        await Assert.That(task.Repeater).IsNull();
+    }
+
+    [Test]
+    public async Task ClearingStart_WithNoRepeater_IsSafe()
+    {
+        using var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        var model = CreateModel();
+        model.Repeater = null;
+        using var task = new TaskItemViewModel(model, storage, () => false);
+        task.Commands.SetBeginNone.Execute(null);
+        await Assert.That(task.PlannedBeginDateTime).IsNull();
+        await Assert.That(task.Repeater).IsNull();
+    }
+
+    [Test]
+    public async Task ChangingNonEmptyStart_PreservesRepeater()
+    {
+        using var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        var model = CreateModel();
+        using var task = new TaskItemViewModel(model, storage, () => false);
+        task.PlannedBeginDateTime = DateTime.Today.AddDays(4);
+        await Assert.That(task.Repeater!.Model.Equals(model.Repeater)).IsTrue();
+    }
+
+    [Test]
+    public async Task LoadingAndHydratingLegacyTask_DoesNotErasePersistedRepeater()
+    {
+        using var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        var model = CreateModel();
+        using var task = new TaskItemViewModel(model, storage, () => false);
+        var originalRepeater = task.Repeater;
+        model.PlannedBeginDateTime = null;
+        task.Update(model);
+        await Assert.That(ReferenceEquals(task.Repeater, originalRepeater)).IsTrue();
+        await Assert.That(task.Repeater!.Model.Equals(model.Repeater)).IsTrue();
+
+        using var loaded = new TaskItemViewModel(model, storage, () => false);
+        await Assert.That(loaded.Repeater!.Model.Equals(model.Repeater)).IsTrue();
+        loaded.PlannedBeginDateTime = DateTime.Today;
+        await Assert.That(loaded.Repeater!.Model.Equals(model.Repeater)).IsTrue();
+    }
+
+    private static TaskItem CreateModel(RepeaterType type = RepeaterType.Weekly, bool afterComplete = true) => new()
+    {
+        Id = "repeater-start-date",
+        Title = "Repeatable task",
+        PlannedBeginDateTime = DateTime.Today,
+        PlannedEndDateTime = DateTime.Today.AddDays(1),
+        PlannedDuration = TimeSpan.FromHours(2),
+        Repeater = new RepeaterPattern { Type = type, Period = 3, Pattern = [0, 2, 4], AfterComplete = afterComplete }
+    };
+}

--- a/src/Unlimotion.Test/TaskItemRepeaterStartDateTests.cs
+++ b/src/Unlimotion.Test/TaskItemRepeaterStartDateTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Unlimotion.Domain;
 using Unlimotion.TaskTree;
@@ -10,6 +11,61 @@ namespace Unlimotion.Test;
 
 public class TaskItemRepeaterStartDateTests
 {
+    [Test]
+    public async Task HydratedRepeater_SelectsStableTemplateWithoutChangingPattern()
+    {
+        using var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        var model = CreateModel(RepeaterType.Daily, afterComplete: true);
+        model.Repeater!.Period = 3;
+        using var task = new TaskItemViewModel(model, storage, () => false);
+
+        var templates = task.Repeaters;
+        var dailyTemplate = templates.Single(template => template.Type == RepeaterType.Daily);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(task.Repeaters).IsSameReferenceAs(templates);
+            await Assert.That(task.SelectedRepeaterTemplate).IsSameReferenceAs(dailyTemplate);
+            await Assert.That(task.Repeater!.Period).IsEqualTo(3);
+            await Assert.That(task.Repeater.AfterComplete).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task WeeklyTemplateSelection_DistinguishesExactWorkDaysFromCustomPattern()
+    {
+        using var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        var workDaysModel = CreateModel();
+        workDaysModel.Repeater!.Pattern = [0, 1, 2, 3, 4];
+        using var workDays = new TaskItemViewModel(workDaysModel, storage, () => false);
+
+        var workDaysTemplate = workDays.Repeaters[2];
+        await Assert.That(workDays.SelectedRepeaterTemplate).IsSameReferenceAs(workDaysTemplate);
+
+        var customModel = CreateModel();
+        customModel.Repeater!.Pattern = [0, 5];
+        using var custom = new TaskItemViewModel(customModel, storage, () => false);
+        await Assert.That(custom.SelectedRepeaterTemplate).IsSameReferenceAs(custom.Repeaters[3]);
+    }
+
+    [Test]
+    public async Task SelectingTemplate_CopiesItIntoEditableRepeater()
+    {
+        using var storage = new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage()));
+        using var task = new TaskItemViewModel(CreateModel(), storage, () => false);
+        var dailyTemplate = task.Repeaters.Single(template => template.Type == RepeaterType.Daily);
+
+        task.SelectedRepeaterTemplate = dailyTemplate;
+        task.Repeater!.Period = 4;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(task.Repeater).IsNotSameReferenceAs(dailyTemplate);
+            await Assert.That(task.Repeater.Type).IsEqualTo(RepeaterType.Daily);
+            await Assert.That(dailyTemplate.Period).IsEqualTo(1);
+        }
+    }
+
     [Test]
     [Arguments(RepeaterType.Daily, false)]
     [Arguments(RepeaterType.Weekly, true)]

--- a/src/Unlimotion.Test/TaskStatusTransitionTests.cs
+++ b/src/Unlimotion.Test/TaskStatusTransitionTests.cs
@@ -81,126 +81,159 @@ public class TaskStatusTransitionTests
     }
 
     [Test]
-    public async Task HandleTaskStatusChange_CompletedTaskWithRepeater_CreatesPreparedClone()
+    public async Task HandleTaskStatusChange_CompletedRepeater_ClonesContainedDagAndInternalRelations()
     {
         var storage = new InMemoryStorage();
         var manager = new TaskTreeManager(storage);
-
-        var task = new TaskItem
+        var plannedBegin = new DateTimeOffset(2026, 1, 5, 9, 0, 0, TimeSpan.Zero);
+        var futureRightBegin = DateTimeOffset.UtcNow.AddDays(30);
+        var externalBlocker = new TaskItem
         {
-            Id = "test-task",
+            Id = "external-blocker",
+            Title = "external blocker",
             Status = DomainTaskStatus.Completed,
-            Repeater = new RepeaterPattern
-            {
-                Type = RepeaterType.Daily,
-                Period = 1
-            },
-            PlannedBeginDateTime = DateTimeOffset.UtcNow.AddDays(-1),
-            PlannedEndDateTime = DateTimeOffset.UtcNow,
-            ContainsTasks = new List<string> { "child1" },
-            BlocksTasks = new List<string> { "blocked1" },
-            BlockedByTasks = new List<string> { "blocker1" },
-            Description = "Test task",
-            Title = "Test Task"
+            BlocksTasks = ["source"]
         };
-
-        var result = await manager.HandleTaskStatusChange(task);
-        var clonedTask = result.First(taskItem => taskItem.Id != task.Id && taskItem.Title == task.Title);
-
-        await Assert.That(task.CompletedDateTime).IsNotNull();
-        await Assert.That(task.ArchiveDateTime).IsNull();
-        await Assert.That(result).Contains(task);
-        await Assert.That(clonedTask.Id).IsNotNull();
-        await Assert.That(clonedTask.Status).IsEqualTo(DomainTaskStatus.Prepared);
-        await Assert.That(clonedTask.StatusHistory.Last().Status).IsEqualTo(DomainTaskStatus.Prepared);
-        await Assert.That(clonedTask.Title).IsEqualTo(task.Title);
-        await Assert.That(clonedTask.Description).IsEqualTo(task.Description);
-        await Assert.That(clonedTask.ContainsTasks).IsEquivalentTo(task.ContainsTasks);
-        await Assert.That(clonedTask.BlocksTasks).IsEquivalentTo(task.BlocksTasks);
-        await Assert.That(clonedTask.BlockedByTasks).IsEquivalentTo(task.BlockedByTasks);
-        await Assert.That(result).Contains(clonedTask);
-    }
-
-    [Test]
-    public async Task HandleTaskStatusChange_CompletedTaskWithRepeater_ShouldSyncCloneRelationsAndAvailability()
-    {
-        var storage = new InMemoryStorage();
-        var manager = new TaskTreeManager(storage);
-
-        var child = new TaskItem
+        var externalBlocked = new TaskItem
         {
-            Id = "child",
-            Status = DomainTaskStatus.Completed,
-            ParentTasks = new List<string> { "source" }
-        };
-
-        var blocker = new TaskItem
-        {
-            Id = "blocker",
-            Status = DomainTaskStatus.Completed,
-            BlocksTasks = new List<string> { "source" }
-        };
-
-        var blocked = new TaskItem
-        {
-            Id = "blocked",
+            Id = "external-blocked",
+            Title = "external blocked",
             Status = DomainTaskStatus.NotReady,
-            IsCanBeCompleted = true,
-            UnlockedDateTime = DateTimeOffset.UtcNow,
-            BlockedByTasks = new List<string> { "source" }
+            BlockedByTasks = ["source"]
         };
-
+        var sharedLeaf = new TaskItem
+        {
+            Id = "shared-leaf",
+            Title = "shared leaf",
+            Status = DomainTaskStatus.Completed,
+            ParentTasks = ["left", "right"],
+            PlannedBeginDateTime = plannedBegin.AddHours(3),
+            PlannedEndDateTime = plannedBegin.AddHours(4),
+            CompletionCriteria =
+            [
+                new TaskCompletionCriterion
+                {
+                    Id = "old-criterion",
+                    Text = "Verify leaf",
+                    IsSatisfied = true
+                }
+            ]
+        };
+        var left = new TaskItem
+        {
+            Id = "left",
+            Title = "left",
+            Status = DomainTaskStatus.Completed,
+            ParentTasks = ["source"],
+            ContainsTasks = [sharedLeaf.Id],
+            BlocksTasks = ["right"],
+            PlannedBeginDateTime = plannedBegin.AddHours(1)
+        };
+        var right = new TaskItem
+        {
+            Id = "right",
+            Title = "right",
+            Status = DomainTaskStatus.Completed,
+            ParentTasks = ["source"],
+            ContainsTasks = [sharedLeaf.Id],
+            BlockedByTasks = ["left"],
+            PlannedBeginDateTime = futureRightBegin
+        };
         var source = new TaskItem
         {
             Id = "source",
+            Title = "source",
+            Description = "Source description",
             Status = DomainTaskStatus.Prepared,
+            IsCanBeCompleted = true,
             Repeater = new RepeaterPattern
             {
                 Type = RepeaterType.Daily,
-                Period = 1
+                Period = 1,
+                AfterComplete = false,
+                Pattern = [1, 3]
             },
-            PlannedBeginDateTime = DateTimeOffset.UtcNow.AddDays(-1),
-            PlannedEndDateTime = DateTimeOffset.UtcNow,
-            ContainsTasks = new List<string> { "child" },
-            BlocksTasks = new List<string> { "blocked" },
-            BlockedByTasks = new List<string> { "blocker" },
-            Description = "Source description",
-            Title = "Source title"
+            PlannedBeginDateTime = plannedBegin,
+            PlannedEndDateTime = plannedBegin.AddHours(8),
+            ContainsTasks = [left.Id, right.Id],
+            BlocksTasks = [externalBlocked.Id],
+            BlockedByTasks = [externalBlocker.Id]
         };
 
-        await storage.Save(child);
-        await storage.Save(blocker);
-        await storage.Save(blocked);
+        await storage.Save(externalBlocker);
+        await storage.Save(externalBlocked);
+        await storage.Save(sharedLeaf);
+        await storage.Save(left);
+        await storage.Save(right);
         await storage.Save(source);
         source.Status = DomainTaskStatus.Completed;
 
         var result = await manager.HandleTaskStatusChange(source);
+        var cloneRoot = result.Single(item => item.Id != source.Id && item.Title == source.Title);
+        var cloneLeft = result.Single(item => item.Title == left.Title && item.Id != left.Id);
+        var cloneRight = result.Single(item => item.Title == right.Title && item.Id != right.Id);
+        var cloneLeaf = result.Single(item => item.Title == sharedLeaf.Title && item.Id != sharedLeaf.Id);
 
-        var clone = result.FirstOrDefault(t => t.Id != source.Id && t.Title == source.Title);
-        await Assert.That(clone).IsNotNull();
+        using (Assert.Multiple())
+        {
+            await Assert.That(cloneRoot.Status).IsEqualTo(DomainTaskStatus.Prepared);
+            await Assert.That(cloneRoot.StatusHistory).Count().IsEqualTo(1);
+            await Assert.That(cloneRoot.StatusHistory[0].Status).IsEqualTo(DomainTaskStatus.Prepared);
+            await Assert.That(cloneRoot.Repeater).IsNotNull();
+            await Assert.That(cloneRoot.Repeater!.Type).IsEqualTo(RepeaterType.Daily);
+            await Assert.That(cloneRoot.Repeater).IsNotSameReferenceAs(source.Repeater);
+            await Assert.That(cloneRoot.ContainsTasks).IsEquivalentTo([cloneLeft.Id, cloneRight.Id]);
+            await Assert.That(cloneRoot.BlocksTasks).IsEmpty();
+            await Assert.That(cloneRoot.BlockedByTasks).IsEmpty();
+            await Assert.That(cloneRoot.IsCanBeCompleted).IsFalse();
+            await Assert.That(cloneRoot.UnlockedDateTime).IsNull();
+            await Assert.That(cloneRoot.CompletedDateTime).IsNull();
+            await Assert.That(cloneRoot.ArchiveDateTime).IsNull();
 
-        var cloneFromStorage = await storage.Load(clone!.Id);
-        var childFromStorage = await storage.Load(child.Id);
-        var blockerFromStorage = await storage.Load(blocker.Id);
-        var blockedFromStorage = await storage.Load(blocked.Id);
+            await Assert.That(cloneLeft.Status).IsEqualTo(DomainTaskStatus.NotReady);
+            await Assert.That(cloneRight.Status).IsEqualTo(DomainTaskStatus.NotReady);
+            await Assert.That(cloneLeaf.Status).IsEqualTo(DomainTaskStatus.NotReady);
+            await Assert.That(cloneLeft.StatusHistory).Count().IsEqualTo(1);
+            await Assert.That(cloneRight.StatusHistory).Count().IsEqualTo(1);
+            await Assert.That(cloneLeaf.StatusHistory).Count().IsEqualTo(1);
+            await Assert.That(cloneLeft.StatusHistory[0].Status).IsEqualTo(DomainTaskStatus.NotReady);
+            await Assert.That(cloneRight.StatusHistory[0].Status).IsEqualTo(DomainTaskStatus.NotReady);
+            await Assert.That(cloneLeaf.StatusHistory[0].Status).IsEqualTo(DomainTaskStatus.NotReady);
+            await Assert.That(cloneLeft.IsCanBeCompleted).IsFalse();
+            await Assert.That(cloneRight.IsCanBeCompleted).IsFalse();
+            await Assert.That(cloneLeaf.IsCanBeCompleted).IsFalse();
+            await Assert.That(cloneLeft.UnlockedDateTime).IsNull();
+            await Assert.That(cloneRight.UnlockedDateTime).IsNull();
+            await Assert.That(cloneLeaf.UnlockedDateTime).IsNull();
+            await Assert.That(cloneLeaf.CompletedDateTime).IsNull();
+            await Assert.That(cloneLeaf.ArchiveDateTime).IsNull();
+            await Assert.That(cloneLeaf.ParentTasks).IsEquivalentTo([cloneLeft.Id, cloneRight.Id]);
+            await Assert.That(cloneLeft.ContainsTasks).IsEquivalentTo([cloneLeaf.Id]);
+            await Assert.That(cloneRight.ContainsTasks).IsEquivalentTo([cloneLeaf.Id]);
+            await Assert.That(cloneLeft.BlocksTasks).IsEquivalentTo([cloneRight.Id]);
+            await Assert.That(cloneRight.BlockedByTasks).IsEquivalentTo([cloneLeft.Id]);
 
-        await Assert.That(cloneFromStorage).IsNotNull();
-        await Assert.That(cloneFromStorage!.Status).IsEqualTo(DomainTaskStatus.Prepared);
-        await Assert.That(cloneFromStorage.ContainsTasks).Contains(child.Id);
-        await Assert.That(cloneFromStorage.BlockedByTasks).Contains(blocker.Id);
-        await Assert.That(cloneFromStorage.BlocksTasks).Contains(blocked.Id);
+            await Assert.That(cloneRoot.PlannedBeginDateTime).IsEqualTo(plannedBegin.AddDays(1));
+            await Assert.That(cloneRoot.PlannedEndDateTime).IsEqualTo(plannedBegin.AddDays(1).AddHours(8));
+            await Assert.That(cloneLeft.PlannedEndDateTime).IsNull();
+            await Assert.That(cloneRight.PlannedBeginDateTime).IsEqualTo(futureRightBegin.AddDays(1));
+            await Assert.That(cloneLeaf.PlannedBeginDateTime).IsEqualTo(sharedLeaf.PlannedBeginDateTime!.Value.AddDays(1));
+            await Assert.That(cloneLeaf.PlannedEndDateTime).IsEqualTo(sharedLeaf.PlannedEndDateTime!.Value.AddDays(1));
+            await Assert.That(cloneLeaf.CompletionCriteria).Count().IsEqualTo(1);
+            await Assert.That(cloneLeaf.CompletionCriteria[0].Id).IsNotEqualTo("old-criterion");
+            await Assert.That(cloneLeaf.CompletionCriteria[0].Text).IsEqualTo("Verify leaf");
+            await Assert.That(cloneLeaf.CompletionCriteria[0].IsSatisfied).IsFalse();
+        }
 
-        await Assert.That(childFromStorage).IsNotNull();
-        await Assert.That(childFromStorage!.ParentTasks).Contains(clone.Id);
+        cloneRoot.Repeater!.Period = 7;
+        cloneRoot.Repeater.Pattern.Add(6);
+        await Assert.That(source.Repeater!.Period).IsEqualTo(1);
+        await Assert.That(source.Repeater.Pattern).IsEquivalentTo([1, 3]);
 
-        await Assert.That(blockerFromStorage).IsNotNull();
-        await Assert.That(blockerFromStorage!.BlocksTasks).Contains(clone.Id);
-
-        await Assert.That(blockedFromStorage).IsNotNull();
-        await Assert.That(blockedFromStorage!.BlockedByTasks).Contains(clone.Id);
-        await Assert.That(blockedFromStorage.IsCanBeCompleted).IsFalse();
-
-        await Assert.That(cloneFromStorage.Status).IsEqualTo(DomainTaskStatus.Prepared);
+        var externalBlockerAfter = await storage.Load(externalBlocker.Id);
+        var externalBlockedAfter = await storage.Load(externalBlocked.Id);
+        await Assert.That(externalBlockerAfter!.BlocksTasks).IsEquivalentTo([source.Id]);
+        await Assert.That(externalBlockedAfter!.BlockedByTasks).IsEquivalentTo([source.Id]);
     }
 
     [Test]

--- a/src/Unlimotion.Test/UnlimotionCliIntegrationTests.cs
+++ b/src/Unlimotion.Test/UnlimotionCliIntegrationTests.cs
@@ -61,7 +61,7 @@ public sealed class UnlimotionCliIntegrationTests
     }
 
     [Test]
-    public async Task Complete_RepeatingTaskCreatesNextOccurrenceAndRestoresReverseLinks()
+    public async Task Complete_RepeatingTaskCreatesIndependentOccurrenceSubtree()
     {
         using var temp = TempTaskDirectory.Create();
         var plannedBegin = DateTimeOffset.UtcNow.AddDays(-1);
@@ -92,18 +92,21 @@ public sealed class UnlimotionCliIntegrationTests
         await Assert.That(result.ExitCode).IsEqualTo(0);
         var allTasks = await LoadAllTasks(temp.DirectoryPath);
         var clone = allTasks.Single(task => task.Id != source.Id && task.Title == source.Title);
+        var childClone = allTasks.Single(task => task.Id != child.Id && task.Title == child.Title);
         var childAfter = await LoadTask(temp.DirectoryPath, child.Id);
         var blockerAfter = await LoadTask(temp.DirectoryPath, blocker.Id);
         var blockedAfter = await LoadTask(temp.DirectoryPath, blocked.Id);
 
         await Assert.That(clone.Status).IsEqualTo(DomainTaskStatus.Prepared);
         await Assert.That(clone.PlannedBeginDateTime!.Value.ToUnixTimeSeconds()).IsEqualTo(plannedBegin.AddDays(1).ToUnixTimeSeconds());
-        await Assert.That(clone.ContainsTasks).Contains(child.Id);
-        await Assert.That(clone.BlockedByTasks).Contains(blocker.Id);
-        await Assert.That(clone.BlocksTasks).Contains(blocked.Id);
-        await Assert.That(childAfter.ParentTasks).Contains(clone.Id);
-        await Assert.That(blockerAfter.BlocksTasks).Contains(clone.Id);
-        await Assert.That(blockedAfter.BlockedByTasks).Contains(clone.Id);
+        await Assert.That(clone.ContainsTasks).IsEquivalentTo([childClone.Id]);
+        await Assert.That(clone.BlockedByTasks).IsEmpty();
+        await Assert.That(clone.BlocksTasks).IsEmpty();
+        await Assert.That(childClone.Status).IsEqualTo(DomainTaskStatus.NotReady);
+        await Assert.That(childClone.ParentTasks).IsEquivalentTo([clone.Id]);
+        await Assert.That(childAfter.ParentTasks).IsEquivalentTo([source.Id]);
+        await Assert.That(blockerAfter.BlocksTasks).IsEquivalentTo([source.Id]);
+        await Assert.That(blockedAfter.BlockedByTasks).IsEquivalentTo([source.Id]);
     }
 
     [Test]

--- a/src/Unlimotion.ViewModel/RepeaterPatternViewModel.cs
+++ b/src/Unlimotion.ViewModel/RepeaterPatternViewModel.cs
@@ -89,7 +89,7 @@ public class RepeaterPatternViewModel
 
     public bool WorkDays
     {
-        get => Monday && Tuesday && Wednesday && Thursday && Friday;
+        get => Monday && Tuesday && Wednesday && Thursday && Friday && !Saturday && !Sunday;
         set
         {
             Monday = value;

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -255,6 +255,13 @@ namespace Unlimotion.ViewModel
                     .AddToDispose(this);
             }
 
+            // Loading an authoritative model (including legacy data) must not clear its repeater.
+            this.WhenAnyValue(m => m.PlannedBeginDateTime)
+                .Skip(1)
+                .Where(begin => !begin.HasValue && !_isUpdatingFromModel)
+                .Subscribe(_ => Repeater = null)
+                .AddToDispose(this);
+
             //При изменении начала
             this.WhenAnyValue(m => m.PlannedBeginDateTime)
                 .Subscribe(b =>

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -59,6 +59,7 @@ namespace Unlimotion.ViewModel
 
         private readonly ObservableCollectionExtended<TaskItemViewModel> _containsTasksSource = new();
         private readonly ObservableCollectionExtended<TaskItemViewModel> _parentsTasksSource = new();
+        private readonly IReadOnlyList<RepeaterPatternViewModel> _repeaters = CreateRepeaterTemplates();
         private readonly ObservableCollectionExtended<TaskItemViewModel> _blocksTasksSource = new();
         private readonly ObservableCollectionExtended<TaskItemViewModel> _blockedByTasksSource = new();
         private readonly ReadOnlyObservableCollection<TaskItemViewModel> _containsTasks;
@@ -362,6 +363,7 @@ namespace Unlimotion.ViewModel
             OnPropertyChanged(nameof(IsHaveRepeater));
             OnPropertyChanged(nameof(RepeaterListMarker));
             OnPropertyChanged(nameof(RepeaterListMarkerToolTip));
+            OnPropertyChanged(nameof(SelectedRepeaterTemplate));
         }
 
         private void OnPropertyChanged(string propertyName)
@@ -785,7 +787,7 @@ namespace Unlimotion.ViewModel
             return orderedParents;
         }
 
-        [AlsoNotifyFor(nameof(IsHaveRepeater), nameof(RepeaterListMarker), nameof(RepeaterListMarkerToolTip))]
+        [AlsoNotifyFor(nameof(IsHaveRepeater), nameof(RepeaterListMarker), nameof(RepeaterListMarkerToolTip), nameof(SelectedRepeaterTemplate))]
         public RepeaterPatternViewModel? Repeater { get; set; }
 
         public bool IsHaveRepeater => Repeater != null && Repeater.Type != RepeaterType.None;
@@ -794,15 +796,55 @@ namespace Unlimotion.ViewModel
 
         public string? RepeaterListMarkerToolTip => IsHaveRepeater ? Repeater!.Title : null;
 
-        public List<RepeaterPatternViewModel> Repeaters => new()
+        public IReadOnlyList<RepeaterPatternViewModel> Repeaters => _repeaters;
+
+        public RepeaterPatternViewModel SelectedRepeaterTemplate
         {
-            new RepeaterPatternViewModel { Type = RepeaterType.None },
-            new RepeaterPatternViewModel { Type = RepeaterType.Daily },
-            new RepeaterPatternViewModel { Type = RepeaterType.Weekly, WorkDays = true },
-            new RepeaterPatternViewModel { Type = RepeaterType.Weekly },
-            new RepeaterPatternViewModel { Type = RepeaterType.Monthly },
-            new RepeaterPatternViewModel { Type = RepeaterType.Yearly },
-        };
+            get
+            {
+                var repeater = Repeater;
+                if (repeater == null || repeater.Type == RepeaterType.None)
+                {
+                    return _repeaters[0];
+                }
+
+                if (repeater.Type == RepeaterType.Weekly)
+                {
+                    return IsExactWorkDays(repeater) ? _repeaters[2] : _repeaters[3];
+                }
+
+                return _repeaters.FirstOrDefault(template => template.Type == repeater.Type) ?? _repeaters[0];
+            }
+            set
+            {
+                if (value == null || ReferenceEquals(value, SelectedRepeaterTemplate))
+                {
+                    return;
+                }
+
+                Repeater = new RepeaterPatternViewModel(value.Model);
+            }
+        }
+
+        private static IReadOnlyList<RepeaterPatternViewModel> CreateRepeaterTemplates() =>
+            Array.AsReadOnly(new[]
+            {
+                new RepeaterPatternViewModel { Type = RepeaterType.None },
+                new RepeaterPatternViewModel { Type = RepeaterType.Daily },
+                new RepeaterPatternViewModel { Type = RepeaterType.Weekly, WorkDays = true },
+                new RepeaterPatternViewModel { Type = RepeaterType.Weekly },
+                new RepeaterPatternViewModel { Type = RepeaterType.Monthly },
+                new RepeaterPatternViewModel { Type = RepeaterType.Yearly },
+            });
+
+        private static bool IsExactWorkDays(RepeaterPatternViewModel repeater) =>
+            repeater.Monday &&
+            repeater.Tuesday &&
+            repeater.Wednesday &&
+            repeater.Thursday &&
+            repeater.Friday &&
+            !repeater.Saturday &&
+            !repeater.Sunday;
 
         /// <summary>
         /// Команды для быстрого выбора дат, ленивая загрузка

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -2053,7 +2053,7 @@
                                                 <ComboBox Grid.Column="0"
                                                           Classes="RepeaterSelector"
                                                           ItemsSource="{Binding Repeaters}"
-                                                          SelectedItem="{Binding Repeater}"
+                                                          SelectedItem="{Binding SelectedRepeaterTemplate}"
                                                           PlaceholderText="{DynamicResource RepeaterTemplates}"
                                                           AutomationProperties.AutomationId="CurrentTaskRepeaterSelector">
                                                     <ComboBox.ItemTemplate>

--- a/src/Unlimotion/Views/MainControl.axaml
+++ b/src/Unlimotion/Views/MainControl.axaml
@@ -2044,7 +2044,8 @@
                                     <Border Classes="TaskCardSection"
                                             AutomationProperties.ControlTypeOverride="Group"
                                             AutomationProperties.IsControlElementOverride="True"
-                                            AutomationProperties.AutomationId="CurrentTaskRepeaterSection">
+                                            AutomationProperties.AutomationId="CurrentTaskRepeaterSection"
+                                            IsVisible="{Binding PlannedBeginDateTime, Converter={x:Static ObjectConverters.IsNotNull}}">
                                         <StackPanel Classes="TaskCardSectionContent">
                                             <Grid Classes="RepeaterControls RepeaterPatternControls"
                                                   ColumnDefinitions="*,*,Auto,*"

--- a/tests/Unlimotion.UiTests.FlaUI/Tests/RepeaterStartDateFlaUiTests.cs
+++ b/tests/Unlimotion.UiTests.FlaUI/Tests/RepeaterStartDateFlaUiTests.cs
@@ -1,0 +1,167 @@
+using AppAutomation.FlaUI.Session;
+using AppAutomation.Session.Contracts;
+using FlaUI.Core.AutomationElements;
+using FlaUI.Core.Definitions;
+using FlaUI.Core.Input;
+using FlaUI.Core.WindowsAPI;
+using System.ComponentModel;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using TUnit.Core;
+using Unlimotion.AppAutomation.TestHost;
+
+namespace Unlimotion.UiTests.FlaUI.Tests;
+
+public sealed class RepeaterStartDateFlaUiTests
+{
+    [Test]
+    [NotInParallel("DesktopUi")]
+    public async Task ClearingStart_HidesRepeater_AndRestoringDateDoesNotRestorePattern()
+    {
+        EnsurePhysicalPixelDpiAwareness();
+        const string taskId = "3445eef8-4382-4607-b2fb-37a820467f1c";
+        var evidence = Environment.GetEnvironmentVariable("UNLIMOTION_REPEATER_EVIDENCE_DIR");
+        if (evidence is not null) Directory.CreateDirectory(evidence);
+        var options = UnlimotionAppLaunchHost.CreateDesktopLaunchOptions(
+            currentTaskId: taskId, language: "ru", buildBeforeLaunch: false,
+            windowPlacement: DesktopWindowPlacement.Centered(1280, 800));
+        var configPath = options.Arguments.Single(arg => arg.StartsWith("--config="))[9..];
+        var config = JsonNode.Parse(File.ReadAllText(configPath))!;
+        config["Appearance"]!["Language"] = "ru";
+        File.WriteAllText(configPath, config.ToJsonString());
+        var tasksPath = config["TaskStorage"]!["Path"]!.GetValue<string>();
+        var taskPath = Path.Combine(tasksPath, taskId);
+        var seed = JsonNode.Parse(File.ReadAllText(taskPath))!;
+        seed["Title"] = "Проверка повторения";
+        File.WriteAllText(taskPath, seed.ToJsonString());
+
+        using var session = DesktopAppSession.Launch(options);
+        session.MainWindow.Focus();
+        var failures = new List<string>();
+        Exception? scenarioFailure = null;
+        try
+        {
+            await Until(() => Find(session, "CurrentTaskSetBeginButton") is not null, 30);
+            Capture(session, evidence, "dated.png");
+            Check(IsVisible(session, "CurrentTaskRepeaterSection"), "Initial repeater section is missing.");
+
+            // The date picker itself has no UIA peer; use its stable quick-action button.
+            await SelectBeginMenuItem("Нет");
+            await Until(() => ReadTask(taskPath) is { } cleared && cleared["PlannedBeginDateTime"] is null, 20);
+            Capture(session, evidence, "cleared.png");
+            Check(!IsVisible(session, "CurrentTaskRepeaterSection"), "Repeater section remains visible after clearing start.");
+            Check(ReadTask(taskPath) is { } clearedTask && clearedTask["Repeater"] is null,
+                "Repeater was not reset in the saved task.");
+
+            await SelectBeginMenuItem("Сегодня");
+            await Until(() => ReadTask(taskPath)?["PlannedBeginDateTime"] is not null, 20);
+            Capture(session, evidence, "restored-date.png");
+            Check(IsVisible(session, "CurrentTaskRepeaterSection"), "Repeater section did not return with the date.");
+            Check(ReadTask(taskPath) is { } restoredTask && restoredTask["Repeater"] is null,
+                "Restoring date revived the old repeater.");
+            await Assert.That(failures).IsEmpty();
+        }
+        catch (Exception exception)
+        {
+            scenarioFailure = exception;
+            try { Capture(session, evidence, "failure.png"); }
+            catch (Exception captureFailure) { Console.Error.WriteLine(captureFailure); }
+            throw;
+        }
+        finally
+        {
+            if (evidence is not null)
+            {
+                File.WriteAllText(Path.Combine(evidence, "complete.json"), JsonSerializer.Serialize(new
+                {
+                    Success = scenarioFailure is null, Error = scenarioFailure?.ToString(), Failures = failures
+                }));
+            }
+        }
+
+        void Check(bool value, string message)
+        {
+            if (!value) failures.Add(message);
+        }
+
+        async Task SelectBeginMenuItem(string name)
+        {
+            session.MainWindow.Focus();
+            Find(session, "CurrentTaskSetBeginButton")!.AsButton().Invoke();
+            AutomationElement? item = null;
+            await Until(() => (item = session.MainWindow.FindFirstDescendant(
+                session.ConditionFactory.ByControlType(ControlType.MenuItem).And(
+                session.ConditionFactory.ByName(name)))) is { IsOffscreen: false });
+            item!.Focus();
+            await Until(() => item.Properties.HasKeyboardFocus.ValueOrDefault);
+            Keyboard.Press(VirtualKeyShort.RETURN);
+        }
+    }
+
+    private static AutomationElement? Find(DesktopAppSession session, string id) =>
+        session.MainWindow.FindFirstDescendant(session.ConditionFactory.ByAutomationId(id));
+
+    private static bool IsVisible(DesktopAppSession session, string id) =>
+        Find(session, id) is { IsOffscreen: false };
+
+    private static JsonNode? ReadTask(string path)
+    {
+        try { return JsonNode.Parse(File.ReadAllText(path)); }
+        catch (IOException) { return null; }
+        catch (JsonException) { return null; }
+    }
+
+    private static void Capture(DesktopAppSession session, string? directory, string name)
+    {
+        if (directory is null) return;
+        Find(session, "CurrentTaskDetailsScrollViewer")?.Patterns.Scroll.PatternOrDefault?.SetScrollPercent(-1, 50);
+        Thread.Sleep(150); // Let the scrolled planning section render before PrintWindow captures it.
+        var handle = session.MainWindow.Properties.NativeWindowHandle.Value;
+        if (!GetWindowRect(handle, out var bounds)) throw new Win32Exception(Marshal.GetLastWin32Error());
+        using var bitmap = new Bitmap(bounds.Right - bounds.Left, bounds.Bottom - bounds.Top);
+        using var graphics = Graphics.FromImage(bitmap);
+        var dc = graphics.GetHdc();
+        try
+        {
+            // Never fall back to desktop pixels: another application may obscure this window.
+            if (!PrintWindow(handle, dc, 2)) throw new InvalidOperationException("Safe window capture failed.");
+        }
+        finally { graphics.ReleaseHdc(dc); }
+        bitmap.Save(Path.Combine(directory, name));
+    }
+
+    private static async Task Until(Func<bool> condition, int seconds = 10)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(seconds);
+        while (!condition())
+        {
+            if (DateTime.UtcNow >= deadline) throw new TimeoutException("Repeater UI condition did not become true.");
+            await Task.Delay(100);
+        }
+    }
+
+    private static void EnsurePhysicalPixelDpiAwareness()
+    {
+        if (!SetProcessDpiAwarenessContext(new IntPtr(-4)) &&
+            GetAwarenessFromDpiAwarenessContext(GetThreadDpiAwarenessContext()) != 2)
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "Per-monitor DPI awareness is required for UI evidence.");
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetProcessDpiAwarenessContext(IntPtr context);
+    [DllImport("user32.dll")]
+    private static extern IntPtr GetThreadDpiAwarenessContext();
+    [DllImport("user32.dll")]
+    private static extern int GetAwarenessFromDpiAwarenessContext(IntPtr context);
+    [StructLayout(LayoutKind.Sequential)]
+    private struct NativeRect { public int Left, Top, Right, Bottom; }
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetWindowRect(IntPtr handle, out NativeRect bounds);
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PrintWindow(IntPtr handle, IntPtr dc, uint flags);
+}


### PR DESCRIPTION
## Проблема

У повторяющейся задачи после завершения создавался следующий экземпляр, но UI не показывал его сохранённый шаблон повторения. Подзадачи при этом не становились независимым поддеревом нового occurrence: повтор использовал связи исходного дерева.

Также интерфейс позволял настраивать повторение без даты начала, хотя генератор требует дату, и не сбрасывал повторение при очистке даты.

## Что изменено

- Секция повторения скрывается без даты начала; очистка даты сбрасывает и сохраняет `Repeater`.
- Выбранный шаблон определяется по значению сохранённого pattern, поэтому Daily, точные WorkDays и custom Weekly корректно отображаются после hydration/reload.
- При завершении клонируется всё рекурсивное containment-поддерево с новыми task/criterion ID и одним clone на source ID, включая DAG с общими descendants.
- Root нового occurrence получает `Prepared`, descendants — `NotReady`; history и критерии создаются заново, даты всего дерева сдвигаются на offset следующего root occurrence.
- Внутренние containment/blocking relations remap на новые ID. Внешние relation collections не копируются и не получают clone links; обычный availability-пересчёт после завершения source сохраняется.
- Containment cycles валидируются до записи и возвращают `ValidationFailed` без частично созданного дерева.
- Добавлены domain, file-backed, CLI и Headless UI regressions, включая реальный status click, child/grandchild, reload и selector cases.

## Интеграция с main

- Ветка перебазирована на актуальный `origin/main` `e00ab60c` (PR #286), конфликтов нет.
- Post-EXEC adversarial re-review: PASS, BLOCKER/HIGH/MEDIUM findings отсутствуют.

## Проверка

- `Unlimotion.Test`: **953/953 passed** (serial).
- `Unlimotion.UiTests.Headless`: **38/38 passed** на финальном чистом rerun.
- Целевые: TaskStatusTransition **17/17**, FileStorageTaskStatus **22/22**, TaskGraphCommandService **39/39**, status UI **21/21**, repeater UI **9/9**, CLI **12/12**.
- `git diff --check`: passed.

Два промежуточных повторных Headless-запуска аварийно завершились без test assertion failures в существующем background UI-thread race (`TaskItemViewModel.SynchronizeCollections`); следующий полный запуск прошёл 38/38. Полный solution build с `--no-restore` ограничен отсутствующими `project.assets.json` у незатронутых iOS/Android/Browser/ReadmeMedia/Performance targets; затронутые desktop/domain/test проекты собираются тестовыми командами.
