### PR TITLE
fix(status): preserve edits during status transitions

### DIFF
--- a/specs/2026-08-31-status-transition-latency.md
+++ b/specs/2026-08-31-status-transition-latency.md
@@ -1,0 +1,331 @@
+# Восстановить смену статуса через загруженный кеш
+
+> Переработанная спецификация. Прежний вариант с ускорением полных чтений отозван после замечания пользователя и не входит в план реализации.
+
+## 0. Метаданные
+- Bugfix; medium, multi-module риск согласованности данных.
+- Checkout: b577/Unlimotion, detached HEAD f39b3245. Production tasks и другой checkout daily-feed не изменять.
+- Профили: dotnet-desktop-client, ui-automation-testing; performance-optimization для измерений.
+- Stack: central AGENTS → routing-matrix/core baselines → QUEST → testing-dotnet/testing-baseline → profiles → spec-linter/spec-rubric/review-loops → локальный AGENTS.override.md.
+- Canonical template: C:/Users/Kibnet/.codex/agents/templates/specs/_template.md.
+- Runtime: Codex Desktop, Windows/PowerShell, SDK 10.0.400, Avalonia 12.0.3, TUnit 1.44.0. Reviewer sandbox не имеет технической read-only изоляции.
+- Фаза EXEC. Пользователь подтвердил спецификацию точной фразой «Спеку подтверждаю» 2026-09-01. Разрешены изменения исходников и тестов в утверждённых границах; Git delivery/release по-прежнему не разрешены.
+
+## 1. Overview / Цель
+В загруженном локальном пространстве выбор доступного статуса сохраняет результат и обновляет UI без полного чтения задач с диска. Проверки используют уже загруженный доменный кеш, поддерживаемый подпиской на изменения файлов.
+
+Outcome contract: сохранить правила, историю, обработку ошибок и подтверждение результата; убрать три полных чтения из обычной локальной операции; подтвердить результат тестами и измерением на копии рабочего объёма данных.
+
+## 2. Текущее состояние (AS-IS)
+- В 1.27 StatusOption немедленно менял VM. Commit b7166d6b подключил desktop к общему TaskGraphCommandService; UI ждёт подтверждённого результата.
+- Путь: TaskStatusPicker → TaskItemViewModel → UnifiedTaskStorage → TaskGraphCommandService → TaskTreeManager → FileTaskStorage.
+- Три полных чтения: ReadGraphAsync перед командой, GetAll в CanTransitionToStatus, ReadGraphAsync после записи. Все идут на диск, хотя обычный Load уже использует _tasks.
+- FileStorage.OnUpdatingAsync принудительно читает изменённый файл перед событием UI; отсутствующий/нечитаемый файл не удаляется из _tasks.
+- FileDbWatcher задерживает доставку, игнорирует имя до 60 секунд после собственной записи через глобальный MemoryCache, не обрабатывает Renamed; Error только уведомляет.
+- Init включает watcher после загрузки; нет барьера snapshot → initial VM hydration → replay.
+- TaskItem изменяем: нельзя использовать общие экземпляры сохранённого кеша для мутаций до подтверждения Save.
+- Контракт specs/2026-07-17-status-availability-contract.md сохраняется для правил, stale/no-op/denied hydration и remote outcome verification. Здесь уточняется источник подтверждённых данных локального живого storage.
+
+Подтверждённый baseline на временной копии:
+- CLI, 2843 файла, NotReady → Prepared: success за 41.864 с.
+- Простое ReadAllText 2844 файлов: 11.094 с; отдельный IO baseline, не время status command.
+- Desktop на одной синтетической задаче: реальный выбор работает.
+- Desktop на полной копии: после Prepared → InProgress значок ещё старый через 51.243 с, новый через 71.236 с. Это интервал наблюдения, не точная длительность.
+- 6/6 TaskStatusPicker tests и 12/12 UnifiedTaskStorageStatusCommandTests прошли. Маленький InMemory dataset не ловит файловую регрессию.
+- Рабочие файлы не менялись. Копия: C:/Users/Kibnet/AppData/Local/Temp/unlimotion-status-repro-4ff4f415fb844152b055a2c5ee4d66c9.
+- UI logs/config/status-diagnostic.json/status-after-confirmed.png: C:/Users/Kibnet/AppData/Local/Temp/unlimotion-status-ui-0ab0da8e775545aa89197765b7ffa38d. Данные локальные, не публиковать.
+
+## 3. Проблема
+Desktop использует полный диагностический путь CLI вместо загруженного доменного кеша. Распараллеливание сохраняет причину. Bare _tasks.Values небезопасно без полноты, диагностики и согласования событий/мутаций.
+
+## 4. Цели дизайна
+- Ready status = 0 перечислений каталога и 0 полных чтений файлов задач.
+- Один владелец подтверждённых доменных моделей; VM — проекция/редактор.
+- Внешние изменения применяются точечно; потеря событий требует восстановления.
+- Сохранить graph validation, историю, mapping файлов, unarchive, save failure и изоляцию пространств.
+- Не менять внешний вид и формат файлов.
+
+## 5. Non-Goals (чего НЕ делаем)
+Не вводить optimistic success/spinner, новые статусы, второй граф из VM.Model, глобальный кеш или периодический полный polling. Не ускорять cold CLI массовым чтением, не переделывать server, миграции/JSON/settings/CI. Не обещать CAS с внешним редактором. Не оптимизировать все O(N) вычисления в памяти. Не менять daily-feed checkout, рабочие задачи, не выполнять commit/push/release.
+
+## 6. Предлагаемое решение (TO-BE)
+
+### 6.1 Распределение ответственности
+- FileTaskStorage — единственный domain cache owner: модели, исходные файлы, errors/duplicates; cold disk mode по умолчанию.
+- FileStorage — live lifecycle и связь существующего watcher с кешем.
+- FileDbWatcher — немедленная регистрация dirty paths/потери событий; debounce не является барьером актуальности графа.
+- UnifiedTaskStorage — lifecycle/VM hydration и существующий statusCommandGate, удерживаемый до hydration.
+- TaskGraphCommandService/TaskTreeManager — прежние правила/операции, получают snapshot через storage; remote/cold поведение сохраняется.
+
+### 6.2 Детальный дизайн
+**Один кеш и чтения.**
+1. Продвинуть существующий кеш FileTaskStorage в полный кеш графа; допустим внутренний helper этого storage. Не оставлять два независимо обновляемых набора задач.
+2. Хранить состояние по source file: TaskItem либо load error. Индекс Id → file и duplicate diagnostics выводить из того же состояния. Дубликаты нельзя потерять при свёртке в Dictionary<Id,TaskItem>. Full load, raw targeted refresh и forced read используют один file-admission predicate: прямые дочерние непустые файлы без расширения либо .json, без скрытых/служебных артефактов. Сохранить прежнее исключение zero-length из графа; прежний TaskItem такого пути больше не актуален. Посторонние README.md/tmp/report и файлы вне корня не превращаются в load errors. Rename из допустимого имени в исключённое удаляет прежний путь из графа; обратный rename добавляет новый.
+3. Full load строит новый набор и атомарно заменяет старый; отсутствующие задачи удаляются. Сохранить детерминированный порядок source mapping/diagnostics текущего ReadDirectoryAsync. Ready означает полноту учёта файлов, а не write safety: известные corrupt/duplicate записи остаются диагностикой Ready-графа и блокируют write без нового full scan. Ошибка самого перечисления/неполный snapshot оставляет NeedsReload.
+4. В Ready ReadGraphAsync возвращает snapshot с diagnostics, GetAll — тот же логический граф без файлового перечисления, Load — данные того же владельца. Явный ReadDirectoryAsync остаётся дисковым diagnostic API; публикация его результата в live cache возможна только как полный согласованный refresh.
+5. На границах кеша изолировать изменяемые TaskItem и вложенные history/criteria/lists/repeater/ExtensionData. Мутация полученного объекта или аргумента Save после возврата не меняет сохранённый snapshot. Null/legacy history обрабатывать по текущему контракту.
+6. Полный scan допустим для startup, explicit refresh/reinit, recovery после потери событий и cold mode без живой подписки. У обычной команды нет TTL-rescan.
+
+**Барьер команд, изменения файлов, подтверждение.**
+7. Использовать существующий per-directory mutation lock для публикации snapshot, применения внешних изменений и локальных записей. Raw watcher callback только регистрирует путь/поколение, не ждёт IO, UI или этот lock. Не создавать обратный порядок lock относительно statusCommandGate.
+8. Синхронно регистрировать dirty path/generation до debounce. Rename регистрирует old/new пути. Очередь принадлежит конкретному source. Повторные события пути объединяются; позднее поколение не стирается снятием раннего.
+9. Перед первой validation команда под directory lock применяет все уже зарегистрированные пути. Читать фактическое содержимое/отсутствие файла, не доверять последнему типу события. При нормальной доставке это точечная операция.
+10. Входящие во время мутации события накапливаются. Перед финальной validation применить зарегистрированные изменения. Checkpoint ограничен тремя попытками; при непрерывных изменениях — контролируемая ошибка/OutcomeUnknown, не зависание и не заведомо stale success.
+11. Save/Remove публикуют подтверждённое состояние в кеш только после дисковой операции под тем же lock. До IO регистрировать attempted path в области текущей команды, включая newly-generated task Id; при failed/partial cascade перечитать все попытанные пути и вернуть существующую ошибку. Нельзя брать этот список только из result.ChangedTasks: при исключении результата ещё нет. Не изображать all-or-nothing и не менять mutable cache до Save.
+12. Финальная локальная проверка перечитывает только попытанные/изменённые файлы, затем анализирует обновлённый граф в памяти. Warm no-op/denied без событий не пишет и не делает readback. Объём IO зависит от changed/dirty paths, не общего числа задач. Remote verification не менять.
+13. Убрать подавление всех событий имени на 60 секунд: внешний edit сразу после Save обязан учитываться. Собственные echoes объединяются/читаются точечно; подтверждённый fingerprint содержимого файла позволяет не публиковать повторное UI hydration при совпадении. Fingerprint привязан к конкретному source/path, не только имени или timestamp. Иначе собственное эхо могло бы перетереть ещё несохранённую правку VM. Отличающееся внешнее содержимое не подавляется.
+14. Delete очищает domain entry/mapping. Rename/Id change обновляет оба направления, удаляя старый Id лишь если его больше нет в другом файле. Corrupt файл хранится как load error и запрещает запись; старый TaskItem не считается актуальным. Исправление/удаление снимает diagnostics точечно. Forced Load обновляет того же владельца.
+15. Error/overflow/реальная остановка raw наблюдения → NeedsReload. Reload выполняет первый запрос, который вошёл в directory lock и обнаружил NeedsReload; следующие после захвата lock повторно проверяют state и используют уже опубликованный результат. Запрещено под этим lock ждать shared refresh Task, который сам ожидает тот же lock; отдельный фоновый lock-waiting owner не нужен. Failed reload запрещает статусную запись, не объявляет старый snapshot Ready. Обычный SetEnable(false) из Git backup при активном live-cache приостанавливает публикацию UI, но не raw сбор путей. Live-cache держит отдельную подписку/lease на тот же FileSystemWatcher; второй watcher не создавать. При SetEnable(true) накопленные пути обрабатываются точечно и replay выполняется без full reload. ForceUpdateFile проходит через ту же регистрацию пути. Реальное освобождение raw lease при завершении storage lifetime прекращает наблюдение; повторный запуск требует reload.
+
+**Lifecycle и UI.**
+16. После существующих миграций включить наблюдение до полного live snapshot, буферизовать UI updates до окончания initial VM hydration. После подписки UnifiedTaskStorage проиграть события между snapshot и публикацией VM: не терять их и не перетирать более новую модель initial batch.
+17. Dispose/source switch прекращает применение и доставку старых событий; raw lease освобождается после существующего seal/drain pending saves/status commands. Возврат к source после реальной остановки raw наблюдения требует reload до Ready. Пауза только UI-доставки при сохранённом raw наблюдении требует drain/replay, а не reload.
+18. Доставлять UI updates после обновления доменного кеша и вне directory lock. Каждая публикация имеет монотонное поколение в рамках storage lifetime; command result и watcher update проходят единую generation-aware доставку. Пакет более старого поколения не может перезаписать уже применённый новый, включая второй Update из TaskItemViewModel после возврата команды. ChangedTasks каскада брать из финального подтверждённого snapshot, а не из объектов, изменённых до последнего readback. Reconciliation/reload применяет diff к VM без доменного Delete/Save в ответ на наблюдение файлов: recovery не должен запускать каскадную запись. Соответствующее изменение внешнего delete описано в §7 явно.
+19. При corrupt/temporarily unreadable файле не запускать удаление/успешный status; допустимо оставить последнюю отображённую VM до исправления, но она не источник write validation. Ошибка — через существующий result/notification.
+20. Меню, пиктограмма, клавиатура/мышь, фильтры и no-op/denied hydration не меняются. Старый план spinner/flyout/attach redesign исключён.
+
+Граница согласованности: учитываются доставленные watcher события и результаты собственных записей. События внешнего редактора, доставленные после checkpoint, применяются следующим обновлением; FileSystemWatcher не даёт атомарный snapshot/CAS с произвольным процессом.
+
+Storyboard: старый статус → выбор → проверки в памяти → запись изменённых файлов → новый подтверждённый статус. Геометрия UI не меняется; отдельный макет не нужен.
+
+### 6.3 User-Observable Scenarios
+| Сценарий | Результат | Evidence |
+|---|---|---|
+| Выбор в большом загруженном source | значок/история обновлены без массового IO | file-backed UI + counters + desktop timing |
+| External blocker до команды | новый запрет учитывается до debounce | raw event + command regression |
+| Save, затем внешний edit | внешнее состояние видно/учтено | watcher integration |
+| Delete/rename/Id change | нет фиктивного старого Id и каскадной записи от наблюдения | storage/UI tests |
+| Corrupt/duplicate | write denied с diagnostics; после repair работает | safety tests |
+| Save/partial failure | нет неподтверждённого UI успеха; кеш согласован readback | fault injection/UI |
+| Overflow/reopen/source switch | reload либо ошибка; старые события не меняют новый source | lifecycle/race tests |
+| Git commit/push/pull pause | raw изменения не теряются; resume не вызывает full scan | SetEnable/ForceUpdateFile integration |
+
+### 6.4 State / Interaction Matrix
+| State | Read/command | Events/UI |
+|---|---|---|
+| Cold | существующий disk path | кеш не считается полным |
+| Loading | нет Ready до полного snapshot | buffer + initial hydration + replay |
+| Ready | snapshot; dirty drain до write | точечное применение |
+| NeedsReload | coalesced reload; failure запрещает write | продолжить регистрацию событий |
+| Disposed | новые операции отклонены | не обновлять другой source |
+
+### 6.5 Decision Ledger
+| Решение | Владелец | Статус |
+|---|---|---|
+| Использовать существующий кеш | пользователь: замечание + «Делай» | направление принято |
+| Один domain owner, не VM graph | реализация | зафиксировано |
+| Cold CLI/server прежние; targeted local readback | реализация | зафиксировано |
+| Формальный переход в EXEC | central QUEST/пользователь | подтверждено 2026-09-01 |
+
+### 6.6 Runtime / Config / Data Contract Matrix
+| Контракт | Изменение |
+|---|---|
+| JSON/settings/migration version | нет |
+| Local с активным watcher | live cache после init |
+| Local без watcher | cold path, stale cache не Ready |
+| CLI diagnostics/server | прежний disk/remote verification |
+| Lifetime | кеш/очередь одного storage |
+| Directory lock | сохранён, callback его не захватывает |
+
+## 7. Бизнес-правила / Алгоритмы
+TaskStatusTransitionPolicy/TaskAvailabilityService не менять. Сохранить запреты, completion criteria, unarchive normalization, один history entry на реальный переход, no-op без записи и authoritative hydration. Load errors, duplicates и broken references по-прежнему запрещают graph write. Наблюдение внешнего удаления меняет проекцию, но больше не вызывает TaskTreeManager.DeleteTask(..., false), который сейчас записывает связанные задачи. Это необходимое уточнение sync-контракта: внешняя неполная правка связей остаётся диагностикой, а не запускает скрытый ремонт/перезапись файлов. Явная пользовательская команда удаления по-прежнему выполняет прежний доменный алгоритм.
+
+## 8. Точки интеграции и триггеры
+Init/reinit активирует cache; raw create/change/delete/rename делает paths dirty; error/disable инвалидирует полноту; status/unarchive/criterion получает snapshot через storage. Любой Save/Remove, включая обычное редактирование, обновляет тот же кеш. UI delivery не выполняется под mutation lock.
+
+## 9. Изменения модели данных / состояния
+Только внутренние lifecycle states/dirty generations/diagnostics. Никаких сериализуемых флагов TaskItem/Settings. При выделении helper заменить прежнего owner, не хранить вторую независимо обновляемую коллекцию.
+
+## 10. Миграция / Rollout / Rollback
+Миграция не нужна; после запуска кеш строится из файлов. Проверять на временной копии без Git backup. Откат сборки сохраняет читаемый JSON. Commit/push/release не разрешены этим task.
+
+## 11. Тестирование и критерии приёмки
+- AC1: warm status/unarchive через настоящий FileStorage сохраняет файл/историю и UI; счётчики полного enumeration/read после warm-up равны 0.
+- AC2: raw dirty до debounce, create/change/delete/rename/Id change/own-write→external-edit корректны и изолированы по source.
+- AC3: corruption/duplicate/reference safety и repair сохранены; mutable alias/failed Save не портят подтверждённый snapshot. Full/targeted admissions совпадают для ignored/zero-length файлов и rename через границу фильтра.
+- AC4: partial failure/readback/no-op/denied/OutcomeUnknown сохраняют результатный контракт; readback лишь attempted/changed files.
+- AC5: init race/pause/resume/overflow/concurrent refresh/dispose проходят без stale success/deadlock и без обратных записей от UI reconciliation. Обычная Git backup pause/resume не увеличивает full-scan counter; raw события stash/rename, включая после ForceUpdateFile, учитываются. Собственный echo не перетирает pending editor data. При отложенной доставке command result новое watcher поколение не откатывается старым result ни в UnifiedTaskStorage, ни в TaskItemViewModel.
+- AC6: cold CLI/server/unknown JSON fields совместимы.
+- AC7: warm median из 5 одиночных переходов на той же большой копии <2 с, full IO counters = 0. Измерять selection → confirmed VM, отдельно запись/hydration. Это локальная цель, не SLA всех устройств. Если не достигнута, измерить и устранить относящийся к пути bottleneck.
+- AC8: relevant UI tests добавлены/обновлены и запущены; полный Main/Headless перед завершением либо конкретный environment blocker и next-best evidence. Baseline green не доказывает fix.
+
+### Acceptance-to-Test Matrix
+| AC | Coverage | Контрпример |
+|---|---|---|
+| 1 | MainControlTaskStatusIconUiTests с FileStorage + IO counters | InMemory green скрывает три scan |
+| 2 | FileStorageTaskStatusTests/FileDbWatcher integration | debounce/TTL теряет внешний edit |
+| 3 | FileTaskStorageTests/TaskGraphCommandServiceTests | stale delete/duplicate/alias, empty/ignored/rename admission |
+| 4 | UnifiedTaskStorageStatusCommandTests + faulting file writer | failed write выглядит успешным |
+| 5 | Init/source lifecycle и UI projection tests; Git watcher pause integration | event во время batch, поздний callback, reload cascade, backup-triggered scan, own echo; deterministic overflow/reload/command lock race |
+| 6 | CLI status/validate и remote command regression | live cache без подписки |
+| 7 | реальный desktop на полной копии + timers/counters | timing одной задачи выдаётся за результат |
+| 8 | full Main/Headless, pointer/keyboard flow | прямой MenuItem.Click заменяет пользовательский ввод |
+
+Команды, после добавления тестов:
+~~~powershell
+dotnet run --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug -p:UseSharedCompilation=false -- --treenode-filter '/*/*/FileStorageTaskStatusTests/*' --maximum-parallel-tests 1 --output Detailed
+dotnet run --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug --no-build -- --treenode-filter '/*/*/MainControlTaskStatusIconUiTests/TaskStatusPicker*' --maximum-parallel-tests 1 --output Detailed
+dotnet run --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Debug --no-build -- --treenode-filter '/*/*/UnifiedTaskStorageStatusCommandTests/*' --maximum-parallel-tests 1 --output Detailed
+git diff --check
+~~~
+Остальные затронутые классы и full Main/Headless — по актуальному repo workflow. Regression сначала падает на baseline по IO/sync assertion. Desktop screenshots и before/after recording — через существующий UI harness; при невозможности записи фиксировать конкретный технический blocker и screenshots/logs. Не публиковать названия реальных задач.
+
+## 12. Риски и edge cases
+Raw pending event не равен applied event; нужен generation checkpoint. Mutable snapshots, duplicate files, rename/atomic replace, Init replay, UI writeback, lock inversion и continuous events покрываются §6.2 и тестами. Полный reload после overflow допустим, но не обычная ветка статуса. Граница late external events описана явно, CAS не обещан.
+
+### Expected User Review Objections
+| Возражение | Ответ и проверка |
+|---|---|
+| «Почему опять все файлы?» | zero full IO counters; big-copy timing |
+| «Завели ещё один кеш?» | один storage owner; diff/state-owner review |
+| «Внешние изменения?» | raw events/checkpoints/recovery; race tests |
+| «Кеш покажет failed Save как успех?» | isolation/readback/fault injection |
+| «Трогаете меню или чужой checkout?» | scope и diff review |
+| «Проверяли одну задачу?» | file-backed UI + big-copy desktop |
+
+### Rework Prevention Checklist
+Scenarios/decisions/acceptance/objections заполнены. Продуктовых блокеров нет. Старый parallel-reader/spinner план исключён. Требуется formal phase gate и review обновлённого плана.
+
+## 13. План выполнения
+1. Утвердить spec по central QUEST. Выполнено 2026-09-01.
+2. Добавить падающий file-backed UI/storage regression.
+3. Реализовать одного domain owner, diagnostics/snapshot isolation.
+4. Подключить raw events/checkpoints/lifecycle/recovery/targeted readback.
+5. Запустить safety/races/CLI/server/UI tests.
+6. Выполнить desktop measurement/full tests/post-EXEC review.
+7. Отчитаться о локальном результате без claims о Git delivery/release.
+
+## 14. Открытые вопросы
+Продуктовых blockers нет. After-performance/tests/recording — будущие проверки EXEC, не подтверждённые результаты.
+
+## 15. Соответствие профилю
+UI-facing bugfix требует UI coverage/run, real desktop walkthrough и inspected screenshots. Проверять status control в списке/текущей задаче, pointer/keyboard, фильтры/source switching; layout не меняется. TUnit использует --treenode-filter. Performance измеряется после warm-up отдельно от startup/migrations/full-suite duration.
+
+## 16. Таблица изменений файлов
+| Область | План |
+|---|---|
+| FileTaskStorage.cs / internal helper | один кеш, snapshots/diagnostics/targeted refresh |
+| FileStorage.cs | live mode, watcher queue/replay |
+| FileDbWatcher.cs / watcher interface | один native watcher, raw lease отдельно от UI pause; paths/rename/invalidation без global own-write TTL |
+| UnifiedTaskStorage.cs / TaskStorageBuilder.cs / TaskItemViewModel.cs при необходимости | lifecycle, generation-aware hydration и projection без writeback; меню/layout не менять |
+| TaskGraphDiagnostics.cs / command service при необходимости | local targeted verification capability; remote не менять |
+| Clone helper при необходимости | глубокая копия без data format changes |
+| File/storage/command/UI/lifecycle tests | zero scans, safety, races |
+| Эта spec | журнал/evidence/review |
+GetAll в TaskTreeManager при live режиме не должен идти на диск; алгоритм по возможности остаётся прежним.
+
+## 17. Таблица соответствий (было -> стало)
+| Было | Стало |
+|---|---|
+| ReadGraph/GetAll обходят кеш | согласованный live snapshot |
+| Полный post-read | readback затронутых + анализ памяти |
+| Forced null оставляет stale entry | eviction/diagnostic в общем owner |
+| Debounce/TTL определяют свежесть | raw queue задаёт dirty state |
+| Init пропускает события | snapshot + replay |
+| Overflow только toast | invalidate + coalesced reload |
+
+## 18. Альтернативы и компромиссы
+Parallel scans отклонены пользователем: O(N) IO остаётся. VM graph содержит unsaved edits. Bare _tasks.Values теряет полноту/diagnostics. Новый cache service рядом со старым дублирует owner. Full scan не даёт CAS с внешним редактором. Выбран существующий domain cache с live lifecycle; CPU validation всего графа и память для snapshots пока сохраняются и измеряются.
+
+## 19. Результат quality gate и review
+
+### SPEC Linter Result
+| Пункт | Статус | Основание |
+|---|---|---|
+| A1 | PASS | цель §1 |
+| A2 | PASS | AS-IS + runtime baseline |
+| A3 | PASS | причина трёх чтений |
+| A4 | PASS | zero full IO + safety |
+| A5 | PASS | Non-Goals |
+| B6 | PASS | один owner |
+| B7 | PASS | lifecycle/integration |
+| B8 | PASS | policy неизменна |
+| B9 | PASS | failure/recovery |
+| B10 | PASS | counters/warm timings |
+| C11 | PASS | без data change |
+| C12 | PASS | без migration, restart rebuild |
+| C13 | PASS | CLI/server/rollback |
+| D14 | PASS | AC1–AC8 |
+| D15 | PASS | acceptance mapping |
+| D16 | PASS | commands/full tests |
+| E17 | PASS | этапы §13 |
+| E18 | PASS | product blockers нет |
+| E19 | PASS | multi-module scope указан |
+| F20 | PASS | UI/desktop/perf |
+Итог: ГОТОВО. Повторно проверены пункты 1–20, секции 0–20, acceptance mapping и отсутствие trailing whitespace; post-SPEC review завершён ниже.
+
+### SPEC Rubric Result
+| Критерий | Балл | Основание |
+|---|---:|---|
+| Цель/границы | 5 | local warm status |
+| Текущее состояние | 5 | source/tests/timings |
+| Целевой дизайн | 5 | owner/queue/lock/readback |
+| Безопасность | 5 | isolation/recovery/JSON |
+| Тестируемость | 5 | counters/races/UI |
+| Автономность | 5 | decisions/planned steps |
+Итого 30/30 по полноте плана, не оценка реализации.
+
+### Role-Based Review Result
+- Domain: rules/history/no-op сохраняются.
+- UX: прежнее меню, confirmed update; spinner не нужен для этого fix.
+- Tester: file-backed UI/counters/races/failure и full dataset.
+- Architect: один owner/generation barrier/targeted readback/cold compatibility.
+- Delivery/security: local copies, без production/Git delivery.
+
+### Post-SPEC Review
+- Статус PASS для спецификации; реализация не начата.
+- Scope/Evidence: FileTaskStorage/FileStorage/FileDbWatcher/IDatabaseWatcher, UnifiedTaskStorage lifecycle/updating, TaskStorageBuilder, diagnostics/command cloning, status tests, central owner-documents.
+- Contract pass: старые parallel scans/pending UI исключены, целостность live cache включена.
+- Adversarial pass: отдельный reviewer /root/review_status_spec прочитал новую spec и исходники. Выявлены UI ordering, reload lock ownership, file-admission parity; исправления внесены. Его runtime danger-full-access/approval never: это отдельный adversarial fallback, не технически изолированное независимое review.
+- Role-Based pass: domain — unchanged status rules и явное уточнение projection-only external delete; UX — прежний control без stale rollback; tester — IO/race/failure/UI coverage; architect — один owner и lock protocol; delivery/security — только local copies и spec, без публикации.
+- Fix and re-review: reviewer повторно прочитал §6.2 п2/3/11/15/18, §7, AC3/AC5 и таблицу файлов; вернул PASS/«Нет находок». Проверены также raw lease/Git pause/ForceUpdateFile, attempted paths и Ready vs write safety. Основной агент повторил mapping, all 20 linter items и структурную/whitespace проверку.
+- Depth checklist: scope drift — parallel IO/spinner/чужой checkout исключены; acceptance — AC1–AC8 измеримы; scenarios/decisions/objections сопоставлены; validation — есть baseline, новые тесты/after timing ещё не заявляются; regression — generation ordering, mutable cache, corruption, duplicates, early/late events, reload deadlock перечислены; comments/docs — меняется только текущая spec; hidden contract — external delete projection-only назван явно в §7; manual challenge — старый result после нового watcher update теперь покрыт обязательной проверкой.
+- Evidence inspected: перечисленные исходники плюс BackupViaGitService SetEnable/ForceUpdateFile/stash apply, TaskItemViewModel.ExecuteStatusOperationAsync, текущая spec и неизменённое состояние tracked files. Baseline commands/results и local-only artifacts сохранены в §2/§11.
+- No-findings justification: actionable замечания имеют конкретные изменения и regression checks; повторный проход не нашёл открытых design gaps в рассмотренной области. Это не подтверждает runtime performance или корректность ещё не написанного кода.
+- Stop decision: PASS — можно запрашивать точный переход central QUEST; продуктовых вопросов нет. Исходники/тесты не менять до формального approval.
+- Residual risks: reviewer runtime без read-only sandbox, реализация/after-evidence отсутствуют.
+
+| Severity | Area | Finding | Required action | Status |
+|---|---|---|---|---|
+| HIGH | UI ordering | watcher N+1 мог откатиться отложенным command N, включая второй VM.Update | общий generation guard, final cascade snapshot, race test | fixed in spec, re-reviewed |
+| MEDIUM | reload lock | shared refresh мог ждать удерживаемый командой lock | reload owner внутри critical section, deterministic race | fixed in spec, re-reviewed |
+| MEDIUM | file admission | targeted/full расходились на ignored/empty/rename | единый predicate и тесты границы | fixed in spec, re-reviewed |
+| — | итог | Нет находок после исправлений в проверенной области | EXEC после phase gate | PASS |
+
+### Post-EXEC Review
+- Статус PASS. Отдельный reviewer повторно проверил текущий diff после исправления всех найденных гонок; открытых BLOCKER/HIGH/MEDIUM/LOW замечаний нет. Изоляция reviewer была adversarial fallback: runtime unrestricted, файлов он не менял.
+- Обычная локальная статусная команда читает согласованный live graph из `FileTaskStorage`; `GetAll`/`ReadGraphAsync` не перечисляют каталог в Ready-состоянии. Источники без raw watcher остаются в прежнем cold-режиме.
+- Raw watcher регистрирует путь и поколение до debounce. Delete/zero-length/corrupt/rename, invalidation/reload, pause/resume и dispose обновляют либо инвалидируют того же владельца графа. Инициализация имеет checkpoint до и после VM hydration.
+- Запись публикуется только после disk IO. При частичном/неопределённом результате перечитываются все attempted IDs, а итоговый command result содержит подтверждённый snapshot и revision. Mutable `TaskItem` изолированы глубокой копией.
+- Unified хранит source-lifetime revision/tombstone по ID: watcher remove `N+1` блокирует поздний command hydrate `N`, а watcher create/update `N+1` блокирует старые remove/reconcile `N`.
+- Дополнительный пользовательский сценарий выявил потерю несохранённых editor-полей: немедленный Complete мог обогнать throttled save, а последующая Unified hydration перезаписывала `Model` подтверждённым состоянием с диска. Теперь статусная операция сначала сохраняет immutable editor snapshot, после ответа объединяет только editor-owned поля с авторитетным статусом/историей и при закрытии ожидает все допущенные producers и выполняет финальный drain. Ошибка финального сохранения остаётся видимой lifecycle seal, но не превращает уже подтверждённую смену статуса в ложную ошибку.
+- Точный file-backed regression создаёт задачу, сразу задаёт название, дату начала и ежедневное повторение, затем Complete: исходная задача сохраняет поля, а следующая Prepared-задача создаётся. Тот же поток покрыт через Headless status picker; отдельно проверены criterion edits, edit во время реальной `FileStorage → Unified → ViewModel` hydration, retry и lifecycle seal.
+- Сборка `Unlimotion.Test` прошла. Targeted: Unified 14/14, FileStorage status 22/22, TaskItemViewModel status 24/24, status picker UI 7/7, TaskGraph command 38/38, FileTaskStorage 7/7, BackupViaGit 53/53, TaskSourceManager 36/36, card layout UI 20/20, completion-criterion throttle 1/1. Полный Headless: 38/38 за 2:10.083.
+- Актуальный полный Main после исправления найденных cleanup/seal и test-fake проблем: 932/932, 0 failed, 0 skipped за 22:18.500. Более ранний проход 919/920 с несвязанным localization-flake и его чистый повтор 1/1 сохранены как историческое evidence, но не описывают итоговый код.
+- Реальный desktop на копии 2844 задач: pointer Prepared→InProgress записан на диск за 289 ms, новый icon наблюдался через 1258 ms вместе с screenshot capture. Это один подтверждённый проход, не требуемая AC7 median из пяти; performance evidence остаётся ограниченным.
+- `git diff --check` чист по содержимому, присутствуют только предупреждения о будущей LF→CRLF нормализации. Commit/push/release не выполнялись.
+
+## Approval
+Получено: «Спеку подтверждаю» — 2026-09-01. EXEC разрешён в утверждённых границах.
+
+## 20. Журнал действий агента
+| Фаза | Блок | Уверенность | Недостающие данные | Следующее действие | Передача человеку | Фактическое решение | Обоснование | Артефакты |
+|---|---|---:|---|---|---|---|---|---|
+| SPEC | Диагноз | 0.99 | after evidence | спроектировать fix | после review | main/daily-feed; 1.27 OK | tiny tests скрывают latency | source diff, 6 UI tests |
+| SPEC | CLI/desktop baseline | 0.99 | точное confirmed время | spec | нет | нет | CLI 41.864 с; UI 51.243–71.236 с | temp copies/screenshots |
+| SPEC | Первый дизайн | 0.8 | замечание пользователя | пересмотреть | approval | full scans отвергнуты | parallel IO сохраняет root cause | старый draft отозван |
+| SPEC | Коррекция | 0.99 | coherence contract | source inspection | пока нет | кеш+подписка, затем «Делай» | направление принято; exact phase gate остаётся | storage/watcher sources |
+| SPEC | Новый дизайн | 0.96 | adversarial review | reviewer/recheck | после review | повторно approval ещё не запрошено | один owner, generations, targeted readback | эта spec |
+| SPEC | Git pause и own echo | 0.98 | review нового контракта | adversarial check | нет | нет | BackupViaGitService временно выключает watcher; raw lease предотвращает повторные scans, fingerprint защищает от собственного echo | BackupViaGitService 692–886, spec §6.2 |
+| SPEC | Review: UI ordering | 0.98 | повторный reviewer pass | re-review | нет | нет | старый command result не должен откатывать новое watcher состояние; confirmed cascade берётся из final snapshot | spec §6.2/AC5, reviewer finding |
+| SPEC | Review: reload lock и file admission | 0.98 | итоговый re-review | повторить gates | нет | нет | reload owner выбирается внутри lock; full/targeted фильтрация едина | spec §6.2/AC3/AC5, reviewer findings |
+| SPEC | Полный post-SPEC loop завершён | 0.98 | formal phase approval | EXEC после фразы | да, central QUEST | финальный ответ запрашивает «Спеку подтверждаю» | reviewer re-review PASS; 21 секция/20 linter items/0 trailing whitespace; tracked source без изменений | spec, reviewer results, git status |
+| EXEC | Переход в реализацию | 0.99 | падающий regression и implementation evidence | создать ветку и тест | нет | пользователь: «Спеку подтверждаю» | exact QUEST gate выполнен; scope cache/watcher/UI ordering | branch fix/status-transition-cache, эта spec |
+| EXEC | Live graph и warm regression | 0.97 | full-suite/review | watcher/lifecycle tests | нет | нет | Unified.Init публикует storage-owned snapshot; warm status имеет 0 новых directory enumerations | FileTaskStorage, UnifiedTaskStorage, FileStorageTaskStatusTests: 9/9 |
+| EXEC | Raw watcher и ordering | 0.95 | reviewer/race coverage | full tests/review | нет | нет | raw path регистрируется до debounce; invalidation даёт один reload; revisions защищают Unified и второй VM.Update | watcher/storage/result/VM files; targeted 89 tests green |
+| EXEC | Большая копия desktop | 0.97 | 5-run median без capture overhead | full tests/review | нет | нет | 2844 задачи, pointer click Prepared→InProgress: disk 289 ms, новый icon наблюдался через 1258 ms; control screenshot capture adds variable latency | temp copy, computer-use screenshots, own PID 49608 |
+| EXEC | Generation tombstones | 0.99 | нет | targeted/full tests | нет | нет | source-lifetime CAS не позволяет старому command/reconcile перезаписать более новое watcher событие | UnifiedTaskStorage, 2 deterministic race tests |
+| EXEC | Немедленный Complete после редактирования | 0.99 | нет | file-backed/UI regression | нет | пользовательский сценарий воспроизведён | статус обгонял throttled save, а hydration стирала editor-поля; immutable snapshot и pre/post-command drain сохраняют поля и создают повтор | TaskItemViewModel, FileStorageTaskStatusTests, status picker UI |
+| EXEC | Lifecycle seal | 0.99 | нет | full tests/review | нет | нет | seal закрывает admission, ждёт producers, сохраняет стабильную throttled revision и сообщает persistent flush failure; подтверждённый status result остаётся независимым | TaskItemViewModel status tests, layout UI tests |
+| EXEC | Полные проверки | 0.99 | AC7 median 5 не измерена | post-EXEC review | нет | нет | affected suites, Headless 38/38 и актуальный Main 932/932 зелёные | TUnit reports, 2026-09-01 |
+| EXEC | Post-EXEC review | 0.99 | AC7 median 5 не измерена | финальный локальный отчёт | нет | нет | reviewer PASS без открытых findings; runtime adversarial fallback, файлов не менял | review_status_spec, текущий diff |

--- a/src/Unlimotion.FileStorage/FileTaskStorage.cs
+++ b/src/Unlimotion.FileStorage/FileTaskStorage.cs
@@ -9,7 +9,7 @@ using Unlimotion.TaskTree;
 
 namespace Unlimotion.Storage;
 
-public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraphWriteLock
+public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraphWriteLock, ITaskGraphWriteScopeStorage
 {
     private static readonly AsyncLocal<HashSet<string>?> HeldDirectoryLocks = new();
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> DirectorySemaphores =
@@ -17,6 +17,11 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
     private readonly ConcurrentDictionary<string, TaskItem> _tasks = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, string> _taskFilePaths = new(StringComparer.Ordinal);
     private readonly FileTaskStorageOptions _options;
+    private readonly object _liveGraphSync = new();
+    private TaskGraphReadResult? _liveGraph;
+    private long _liveGraphRevision;
+    private volatile bool _liveGraphNeedsReload;
+    private readonly AsyncLocal<FileTaskGraphWriteScope?> _activeWriteScope = new();
 
     public FileTaskStorage(FileTaskStorageOptions options)
     {
@@ -67,9 +72,20 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
 
     public async Task<TaskItem?> Load(string itemId, bool forced)
     {
+        var liveGraphEnabled = false;
+        if (!forced && TryGetLiveTask(itemId, out var liveTask, out liveGraphEnabled))
+        {
+            return liveTask;
+        }
+
+        if (!forced && liveGraphEnabled)
+        {
+            return null;
+        }
+
         if (!forced && _tasks.TryGetValue(itemId, out var cached))
         {
-            return cached;
+            return TaskItemSnapshot.Clone(cached);
         }
 
         if (!TryResolveTaskFilePath(itemId, out var filePath))
@@ -77,8 +93,12 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
             return null;
         }
 
-        if (!File.Exists(filePath))
+        if (!File.Exists(filePath) || new FileInfo(filePath).Length == 0)
         {
+            RemoveCachedTaskMappedToFile(filePath, exceptTaskId: null);
+            _tasks.TryRemove(itemId, out _);
+            _taskFilePaths.TryRemove(itemId, out _);
+            PublishLiveFileChange(filePath, task: null, error: null);
             return null;
         }
 
@@ -87,23 +107,44 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
         {
             task = await Task.Run(() => DeserializeTask(filePath));
         }
-        catch
+        catch (Exception ex)
         {
+            RemoveCachedTaskMappedToFile(filePath, exceptTaskId: null);
+            _tasks.TryRemove(itemId, out _);
+            _taskFilePaths.TryRemove(itemId, out _);
+            PublishLiveFileChange(filePath, task: null, error: ex.Message);
             return null;
         }
 
         if (task == null || !TryValidateTaskId(task.Id, out _))
         {
+            RemoveCachedTaskMappedToFile(filePath, exceptTaskId: null);
+            _tasks.TryRemove(itemId, out _);
+            _taskFilePaths.TryRemove(itemId, out _);
+            PublishLiveFileChange(filePath, task: null, error: "File does not contain a task with a valid non-empty Id.");
             return null;
         }
 
-        _tasks.AddOrUpdate(task.Id, task, (_, _) => task);
+        var stored = TaskItemSnapshot.Clone(task);
+        RemoveCachedTaskMappedToFile(filePath, exceptTaskId: stored.Id);
+        _tasks.AddOrUpdate(stored.Id, stored, (_, _) => stored);
         _taskFilePaths.AddOrUpdate(task.Id, filePath, (_, _) => filePath);
-        return task;
+        PublishLiveFileChange(filePath, stored, error: null);
+        return TaskItemSnapshot.Clone(stored);
     }
 
     public async IAsyncEnumerable<TaskItem> GetAll()
     {
+        if (TryGetLiveGraph(out var liveGraph))
+        {
+            foreach (var task in liveGraph.Tasks)
+            {
+                yield return TaskItemSnapshot.Clone(task);
+            }
+
+            yield break;
+        }
+
         foreach (var file in EnumerateTaskFiles())
         {
             TaskItem? task = null;
@@ -121,9 +162,10 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
                 continue;
             }
 
-            _tasks.AddOrUpdate(task.Id, task, (_, _) => task);
+            var stored = TaskItemSnapshot.Clone(task);
+            _tasks.AddOrUpdate(stored.Id, stored, (_, _) => stored);
             _taskFilePaths.AddOrUpdate(task.Id, file, (_, _) => file);
-            yield return task;
+            yield return TaskItemSnapshot.Clone(stored);
         }
     }
 
@@ -170,7 +212,8 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
                 }
 
                 files.Add(file);
-                _tasks.AddOrUpdate(task.Id, task, (_, _) => task);
+                var stored = TaskItemSnapshot.Clone(task);
+                _tasks.AddOrUpdate(task.Id, stored, (_, _) => stored);
                 _taskFilePaths.AddOrUpdate(task.Id, file, (_, _) => file);
             }
             catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
@@ -191,10 +234,49 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
         return new FileTaskStorageDirectoryReadResult(tasks, filesByTaskId, loadErrors, duplicates);
     }
 
-    public async Task<TaskGraphReadResult> ReadGraphAsync()
+    public virtual async Task<TaskGraphReadResult> ReadGraphAsync()
     {
+        if (TryGetLiveGraph(out var liveGraph))
+        {
+            return CloneGraph(liveGraph);
+        }
+
         var result = await ReadDirectoryAsync();
-        return new TaskGraphReadResult(
+        return ToGraphResult(result);
+    }
+
+    public async Task EnableLiveGraphAsync()
+    {
+        await WithDirectoryLockAsync(async () =>
+        {
+            _tasks.Clear();
+            _taskFilePaths.Clear();
+            var result = await ReadDirectoryAsync();
+            PublishLiveGraph(ToGraphResult(result));
+            _liveGraphNeedsReload = false;
+        });
+    }
+
+    public long LiveGraphRevision => Interlocked.Read(ref _liveGraphRevision);
+
+    public void InvalidateLiveGraph() => _liveGraphNeedsReload = true;
+
+    protected async Task EnsureLiveGraphReadyWithinWriteLockAsync()
+    {
+        if (!_liveGraphNeedsReload)
+        {
+            return;
+        }
+
+        _tasks.Clear();
+        _taskFilePaths.Clear();
+        var result = await ReadDirectoryAsync();
+        PublishLiveGraph(ToGraphResult(result));
+        _liveGraphNeedsReload = false;
+    }
+
+    private static TaskGraphReadResult ToGraphResult(FileTaskStorageDirectoryReadResult result) =>
+        new(
             result.Tasks,
             result.FilesByTaskId,
             result.LoadErrors
@@ -203,10 +285,27 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
             result.DuplicateIdIssues
                 .Select(static issue => new TaskGraphDuplicateIdIssue(issue.TaskId, issue.Files))
                 .ToArray());
+
+    public virtual Task<T> WithWriteLockAsync<T>(Func<Task<T>> operation) =>
+        WithDirectoryLockAsync(operation);
+
+    public ITaskGraphWriteScope BeginWriteScope()
+    {
+        var scope = new FileTaskGraphWriteScope(this, _activeWriteScope.Value);
+        _activeWriteScope.Value = scope;
+        return scope;
     }
 
-    public Task<T> WithWriteLockAsync<T>(Func<Task<T>> operation) =>
-        WithDirectoryLockAsync(operation);
+    public async Task<TaskGraphReadResult> RefreshAttemptedWritesAsync(ITaskGraphWriteScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        foreach (var taskId in scope.AttemptedTaskIds.Distinct(StringComparer.Ordinal))
+        {
+            await Load(taskId, forced: true);
+        }
+
+        return await ReadGraphAsync();
+    }
 
     public Task<T> WithDirectoryLockAsync<T>(Func<Task<T>> operation) =>
         WithDirectoryLockAsync(operation, CancellationToken.None);
@@ -281,26 +380,31 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
 
     private async Task<TaskItem> SaveCore(TaskItem taskItem)
     {
-        var item = taskItem with { };
+        var item = TaskItemSnapshot.Clone(taskItem);
         var id = string.IsNullOrWhiteSpace(item.Id) ? Guid.NewGuid().ToString() : item.Id;
         ValidateTaskId(id);
         item.Id = id;
         item.EnsureStatusHistory(item.UserId ?? "local-user");
+        _activeWriteScope.Value?.Record(item.Id);
 
         var filePath = ResolveTaskFilePath(item.Id);
         OnBeforeWrite(item.Id, filePath);
         var json = JsonConvert.SerializeObject(item, Formatting.Indented, CreateSerializerSettings());
         await AtomicWriteAllTextAsync(filePath, json + Environment.NewLine);
+        OnAfterWritePersisted(item.Id, filePath);
 
         taskItem.Id = item.Id;
-        _tasks.AddOrUpdate(taskItem.Id, item, (_, _) => item);
+        var stored = TaskItemSnapshot.Clone(item);
+        _tasks.AddOrUpdate(taskItem.Id, stored, (_, _) => stored);
         _taskFilePaths.AddOrUpdate(taskItem.Id, filePath, (_, _) => filePath);
-        return item;
+        PublishLiveFileChange(filePath, stored, error: null);
+        return TaskItemSnapshot.Clone(stored);
     }
 
     private Task<bool> RemoveCore(string itemId)
     {
         ValidateTaskId(itemId);
+        _activeWriteScope.Value?.Record(itemId);
         var filePath = ResolveTaskFilePath(itemId);
         OnBeforeRemove(itemId, filePath);
         _tasks.TryRemove(itemId, out _);
@@ -310,6 +414,8 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
         {
             File.Delete(filePath);
         }
+
+        PublishLiveFileChange(filePath, task: null, error: null);
 
         return Task.FromResult(true);
     }
@@ -321,7 +427,7 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
         return JsonRepairingReader.DeserializeWithRepair<TaskItem>(fullPath, serializer, saveRepairedSidecar: false);
     }
 
-    private IEnumerable<string> EnumerateTaskFiles()
+    protected virtual IEnumerable<string> EnumerateTaskFiles()
     {
         var directoryInfo = new DirectoryInfo(Path);
         return directoryInfo
@@ -332,7 +438,7 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
             .ToArray();
     }
 
-    private static bool IsTaskFile(string fileName)
+    protected static bool IsTaskFile(string fileName)
     {
         if (fileName.StartsWith(".", StringComparison.Ordinal))
         {
@@ -400,6 +506,10 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
     {
     }
 
+    protected virtual void OnAfterWritePersisted(string taskId, string filePath)
+    {
+    }
+
     protected bool TryGetTaskIdBySourceFileName(string fileName, out string taskId)
     {
         foreach (var pair in _taskFilePaths)
@@ -416,6 +526,185 @@ public class FileTaskStorage : IStorage, ITaskGraphDiagnosticStorage, ITaskGraph
 
         taskId = string.Empty;
         return false;
+    }
+
+    private bool TryGetLiveTask(string taskId, out TaskItem? task, out bool liveGraphEnabled)
+    {
+        lock (_liveGraphSync)
+        {
+            liveGraphEnabled = _liveGraph != null;
+            if (_liveGraph?.TasksById.TryGetValue(taskId, out var cached) == true)
+            {
+                task = TaskItemSnapshot.Clone(cached);
+                return true;
+            }
+        }
+
+        task = null;
+        return false;
+    }
+
+    private bool TryGetLiveGraph(out TaskGraphReadResult graph)
+    {
+        lock (_liveGraphSync)
+        {
+            if (_liveGraph == null)
+            {
+                graph = null!;
+                return false;
+            }
+
+            graph = _liveGraph;
+            return true;
+        }
+    }
+
+    private void PublishLiveGraph(TaskGraphReadResult graph)
+    {
+        lock (_liveGraphSync)
+        {
+            var revision = Interlocked.Increment(ref _liveGraphRevision);
+            _liveGraph = CloneGraph(graph) with { Revision = revision };
+        }
+    }
+
+    private void PublishLiveFileChange(string filePath, TaskItem? task, string? error)
+    {
+        lock (_liveGraphSync)
+        {
+            if (_liveGraph == null)
+            {
+                return;
+            }
+
+            // A graph with duplicate IDs needs its complete per-file ordering to select the canonical source.
+            // It is already write-unsafe, so keep its diagnostics intact until an explicit reload.
+            if (_liveGraph.DuplicateIdIssues.Count > 0)
+            {
+                _liveGraphNeedsReload = true;
+                return;
+            }
+
+            var previousTask = _liveGraph.FilesByTaskId
+                .Where(pair => string.Equals(pair.Value, filePath, StringComparison.OrdinalIgnoreCase))
+                .Select(pair => _liveGraph.TasksById.GetValueOrDefault(pair.Key))
+                .FirstOrDefault(existing => existing != null);
+            var previousError = _liveGraph.LoadErrors.FirstOrDefault(existing =>
+                string.Equals(existing.File, filePath, StringComparison.OrdinalIgnoreCase));
+            if (task != null && previousTask != null && previousError == null &&
+                JsonConvert.SerializeObject(previousTask, CreateSerializerSettings()) ==
+                JsonConvert.SerializeObject(task, CreateSerializerSettings()))
+            {
+                return;
+            }
+
+            var previousIds = _liveGraph.FilesByTaskId
+                .Where(pair => string.Equals(pair.Value, filePath, StringComparison.OrdinalIgnoreCase))
+                .Select(static pair => pair.Key)
+                .ToHashSet(StringComparer.Ordinal);
+            var tasks = _liveGraph.Tasks
+                .Where(existing => !previousIds.Contains(existing.Id))
+                .Select(TaskItemSnapshot.Clone)
+                .ToList();
+            var files = _liveGraph.FilesByTaskId
+                .Where(pair => !previousIds.Contains(pair.Key))
+                .ToDictionary(static pair => pair.Key, static pair => pair.Value, StringComparer.Ordinal);
+            var errors = _liveGraph.LoadErrors
+                .Where(existing => !string.Equals(existing.File, filePath, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var duplicates = new List<TaskGraphDuplicateIdIssue>();
+
+            if (task != null)
+            {
+                var stored = TaskItemSnapshot.Clone(task);
+                if (files.TryGetValue(stored.Id, out var otherFile) &&
+                    !string.Equals(otherFile, filePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    duplicates.Add(new TaskGraphDuplicateIdIssue(stored.Id, [otherFile, filePath]));
+                }
+
+                tasks.Add(stored);
+                files[stored.Id] = filePath;
+            }
+            else if (!string.IsNullOrWhiteSpace(error))
+            {
+                errors.Add(new TaskGraphLoadError(filePath, error));
+            }
+
+            var revision = Interlocked.Increment(ref _liveGraphRevision);
+            _liveGraph = new TaskGraphReadResult(tasks, files, errors, duplicates) { Revision = revision };
+        }
+    }
+
+    private void RemoveCachedTaskMappedToFile(string filePath, string? exceptTaskId)
+    {
+        foreach (var pair in _taskFilePaths)
+        {
+            if (string.Equals(pair.Value, filePath, StringComparison.OrdinalIgnoreCase) &&
+                (exceptTaskId == null || !string.Equals(pair.Key, exceptTaskId, StringComparison.Ordinal)))
+            {
+                _taskFilePaths.TryRemove(pair.Key, out _);
+                _tasks.TryRemove(pair.Key, out _);
+            }
+        }
+    }
+
+    private static TaskGraphReadResult CloneGraph(TaskGraphReadResult graph) => new(
+        graph.Tasks.Select(TaskItemSnapshot.Clone).ToArray(),
+        new Dictionary<string, string>(graph.FilesByTaskId, StringComparer.Ordinal),
+        graph.LoadErrors.Select(static error => new TaskGraphLoadError(error.File, error.Message)).ToArray(),
+        graph.DuplicateIdIssues
+            .Select(static issue => new TaskGraphDuplicateIdIssue(issue.TaskId, issue.Files.ToArray()))
+            .ToArray())
+    {
+        Revision = graph.Revision
+    };
+
+    private sealed class FileTaskGraphWriteScope : ITaskGraphWriteScope
+    {
+        private readonly FileTaskStorage _owner;
+        private readonly FileTaskGraphWriteScope? _previous;
+        private readonly HashSet<string> _attemptedTaskIds = new(StringComparer.Ordinal);
+        private bool _disposed;
+
+        public FileTaskGraphWriteScope(FileTaskStorage owner, FileTaskGraphWriteScope? previous)
+        {
+            _owner = owner;
+            _previous = previous;
+        }
+
+        public IReadOnlyList<string> AttemptedTaskIds
+        {
+            get
+            {
+                lock (_attemptedTaskIds)
+                {
+                    return _attemptedTaskIds.ToArray();
+                }
+            }
+        }
+
+        public void Record(string taskId)
+        {
+            lock (_attemptedTaskIds)
+            {
+                _attemptedTaskIds.Add(taskId);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            if (ReferenceEquals(_owner._activeWriteScope.Value, this))
+            {
+                _owner._activeWriteScope.Value = _previous;
+            }
+        }
     }
 
     private async Task<FileStream> AcquireDirectoryLockAsync(

--- a/src/Unlimotion.TaskTreeManager/TaskGraphCommandService.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskGraphCommandService.cs
@@ -6,6 +6,8 @@ namespace Unlimotion.TaskTree;
 public sealed class TaskGraphCommandService
 {
     private readonly IStorage _storage;
+    private long _lastReadRevision;
+    private ITaskGraphWriteScope? _activeWriteScope;
 
     public TaskGraphCommandService(IStorage storage)
     {
@@ -145,7 +147,7 @@ public sealed class TaskGraphCommandService
         }
         catch (Exception ex)
         {
-            return CreateOutcomeUnknownResult(
+            return await CreateOutcomeUnknownResultAsync(
                 ex,
                 task.Id,
                 requestedStatus,
@@ -156,7 +158,7 @@ public sealed class TaskGraphCommandService
 
         if (afterRead.Result != null)
         {
-            return CreateOutcomeUnknownResult(
+            return await CreateOutcomeUnknownResultAsync(
                 new InvalidOperationException(afterRead.Result.DeniedReason?.Message ?? "Post-write graph read failed."),
                 task.Id,
                 requestedStatus,
@@ -180,7 +182,7 @@ public sealed class TaskGraphCommandService
 
         var after = new TaskAvailabilityService(afterGraph.Tasks).Analyze(afterTask);
         return TaskOperationResult.Succeeded(
-            changedTasks,
+            BuildConfirmedChanges(changedTasks, afterGraph),
             before,
             after,
             validation,
@@ -269,7 +271,7 @@ public sealed class TaskGraphCommandService
         }
         catch (Exception ex)
         {
-            return CreateOutcomeUnknownResult(
+            return await CreateOutcomeUnknownResultAsync(
                 ex,
                 task.Id,
                 requestedStatus: null,
@@ -280,7 +282,7 @@ public sealed class TaskGraphCommandService
 
         if (afterRead.Result != null)
         {
-            return CreateOutcomeUnknownResult(
+            return await CreateOutcomeUnknownResultAsync(
                 new InvalidOperationException(afterRead.Result.DeniedReason?.Message ?? "Post-write graph read failed."),
                 task.Id,
                 requestedStatus: null,
@@ -317,7 +319,7 @@ public sealed class TaskGraphCommandService
         }
 
         var after = new TaskAvailabilityService(afterGraph.Tasks).Analyze(afterTask);
-        return TaskOperationResult.Succeeded(changedTasks, before, after, validation);
+        return TaskOperationResult.Succeeded(BuildConfirmedChanges(changedTasks, afterGraph), before, after, validation);
     }
 
     private async Task<TaskOperationReadResult> ReadGraphForWriteAsync()
@@ -332,7 +334,9 @@ public sealed class TaskGraphCommandService
 
         try
         {
-            return new TaskOperationReadResult(await diagnosticStorage.ReadGraphAsync(), null);
+            var graph = await diagnosticStorage.ReadGraphAsync();
+            _lastReadRevision = graph.Revision;
+            return new TaskOperationReadResult(graph, null);
         }
         catch (Exception ex)
         {
@@ -345,14 +349,18 @@ public sealed class TaskGraphCommandService
 
     private async Task<TaskOperationResult> ExecuteWriteAsync(Func<Task<TaskOperationResult>> operation)
     {
+        using var writeScope = (_storage as ITaskGraphWriteScopeStorage)?.BeginWriteScope();
+        _activeWriteScope = writeScope;
         try
         {
             if (_storage is ITaskGraphWriteLock writeLock)
             {
-                return await writeLock.WithWriteLockAsync(operation);
+                var result = await writeLock.WithWriteLockAsync(operation);
+                return result with { StorageRevision = _lastReadRevision };
             }
 
-            return await operation();
+            var unlockedResult = await operation();
+            return unlockedResult with { StorageRevision = _lastReadRevision };
         }
         catch (Exception ex)
         {
@@ -363,6 +371,10 @@ public sealed class TaskGraphCommandService
                 criterionId: null,
                 before: null,
                 validation: null);
+        }
+        finally
+        {
+            _activeWriteScope = null;
         }
     }
 
@@ -383,14 +395,15 @@ public sealed class TaskGraphCommandService
             before,
             validation: validation);
 
-    private static TaskOperationResult CreateOutcomeUnknownResult(
+    private async Task<TaskOperationResult> CreateOutcomeUnknownResultAsync(
         Exception ex,
         string? taskId,
         DomainTaskStatus? requestedStatus,
         string? criterionId,
         TaskAvailabilityAnalysis? before,
-        TaskGraphValidationReport? validation) =>
-        TaskOperationResult.Denied(
+        TaskGraphValidationReport? validation)
+    {
+        var result = TaskOperationResult.Denied(
             TaskOperationDeniedReason.Create(
                 TaskOperationDeniedKind.OutcomeUnknown,
                 $"Task graph write may have been persisted, but the final outcome could not be verified: {ex.Message}",
@@ -399,6 +412,41 @@ public sealed class TaskGraphCommandService
                 criterionId),
             before,
             validation: validation);
+
+        var attemptedTaskIds = _activeWriteScope?.AttemptedTaskIds ?? Array.Empty<string>();
+        if (attemptedTaskIds.Count == 0 || _storage is not ITaskGraphDiagnosticStorage diagnosticStorage)
+        {
+            return result;
+        }
+
+        try
+        {
+            var confirmedGraph = _storage is ITaskGraphWriteScopeStorage scopedStorage && _activeWriteScope != null
+                ? await scopedStorage.RefreshAttemptedWritesAsync(_activeWriteScope)
+                : await diagnosticStorage.ReadGraphAsync();
+            _lastReadRevision = confirmedGraph.Revision;
+            var confirmedTasks = attemptedTaskIds
+                .Select(id => confirmedGraph.TasksById.GetValueOrDefault(id))
+                .Where(static task => task != null)
+                .Select(static task => TaskItemSnapshot.Clone(task!))
+                .ToArray();
+            var authoritativeTask = taskId != null
+                ? confirmedGraph.TasksById.GetValueOrDefault(taskId)
+                : null;
+            return result with
+            {
+                ChangedTasks = confirmedTasks,
+                AuthoritativeTask = authoritativeTask == null
+                    ? null
+                    : TaskItemSnapshot.Clone(authoritativeTask),
+                StorageRevision = confirmedGraph.Revision
+            };
+        }
+        catch
+        {
+            return result;
+        }
+    }
 
     private TaskTreeManager CreateManager(string? author) => new(_storage)
     {
@@ -413,56 +461,16 @@ public sealed class TaskGraphCommandService
             ? manager.UpdateTaskWithinExistingMutationLockAsync(change)
             : manager.UpdateTask(change);
 
-    private static TaskItem CloneForUpdate(TaskItem task) => task with
-    {
-        StatusHistory = task.StatusHistory?.Select(CloneStatusHistoryEntry).ToList() ?? new List<TaskStatusHistoryEntry>(),
-        CompletionCriteria = task.CompletionCriteria?.Select(CloneCriterion).ToList() ?? new List<TaskCompletionCriterion>(),
-        ContainsTasks = task.ContainsTasks?.ToList() ?? new List<string>(),
-        ParentTasks = task.ParentTasks?.ToList() ?? new List<string>(),
-        BlocksTasks = task.BlocksTasks?.ToList() ?? new List<string>(),
-        BlockedByTasks = task.BlockedByTasks?.ToList() ?? new List<string>(),
-        Repeater = CloneRepeater(task.Repeater),
-        ExtensionData = task.ExtensionData?.ToDictionary(
-            static pair => pair.Key,
-            static pair => pair.Value == null ? null! : pair.Value.DeepClone())
-    };
+    private static TaskItem CloneForUpdate(TaskItem task) => TaskItemSnapshot.Clone(task);
 
-    private static TaskCompletionCriterion CloneCriterion(TaskCompletionCriterion criterion) => new()
-    {
-        Id = criterion.Id,
-        Text = criterion.Text,
-        IsSatisfied = criterion.IsSatisfied,
-        ExtensionData = criterion.ExtensionData?.ToDictionary(
-            static pair => pair.Key,
-            static pair => pair.Value == null ? null! : pair.Value.DeepClone())
-    };
-
-    private static TaskStatusHistoryEntry CloneStatusHistoryEntry(TaskStatusHistoryEntry entry) =>
-        entry == null
-            ? null!
-            : new TaskStatusHistoryEntry
-            {
-                Status = entry.Status,
-                ChangedAt = entry.ChangedAt,
-                Author = entry.Author,
-                ExtensionData = entry.ExtensionData?.ToDictionary(
-                    static pair => pair.Key,
-                    static pair => pair.Value == null ? null! : pair.Value.DeepClone())
-            };
-
-    private static RepeaterPattern? CloneRepeater(RepeaterPattern? repeater) =>
-        repeater == null
-            ? null
-            : new RepeaterPattern
-            {
-                Type = repeater.Type,
-                Period = repeater.Period,
-                AfterComplete = repeater.AfterComplete,
-                Pattern = repeater.Pattern?.ToList()!,
-                ExtensionData = repeater.ExtensionData?.ToDictionary(
-                    static pair => pair.Key,
-                    static pair => pair.Value == null ? null! : pair.Value.DeepClone())
-            };
+    private static IReadOnlyList<TaskItem> BuildConfirmedChanges(
+        IReadOnlyList<TaskItem> changedTasks,
+        TaskGraphReadResult confirmedGraph) => changedTasks
+        .Where(static task => !string.IsNullOrWhiteSpace(task.Id))
+        .Select(task => confirmedGraph.TasksById.GetValueOrDefault(task.Id))
+        .Where(static task => task != null)
+        .Select(static task => TaskItemSnapshot.Clone(task!))
+        .ToArray();
 
     private sealed record TaskOperationReadResult(TaskGraphReadResult? Graph, TaskOperationResult? Result);
 }

--- a/src/Unlimotion.TaskTreeManager/TaskGraphDiagnostics.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskGraphDiagnostics.cs
@@ -12,12 +12,25 @@ public interface ITaskGraphWriteLock
     Task<T> WithWriteLockAsync<T>(Func<Task<T>> operation);
 }
 
+public interface ITaskGraphWriteScopeStorage
+{
+    ITaskGraphWriteScope BeginWriteScope();
+    Task<TaskGraphReadResult> RefreshAttemptedWritesAsync(ITaskGraphWriteScope scope);
+}
+
+public interface ITaskGraphWriteScope : IDisposable
+{
+    IReadOnlyList<string> AttemptedTaskIds { get; }
+}
+
 public sealed record TaskGraphReadResult(
     IReadOnlyList<TaskItem> Tasks,
     IReadOnlyDictionary<string, string> FilesByTaskId,
     IReadOnlyList<TaskGraphLoadError> LoadErrors,
     IReadOnlyList<TaskGraphDuplicateIdIssue> DuplicateIdIssues)
 {
+    public long Revision { get; init; }
+
     public IReadOnlyDictionary<string, TaskItem> TasksById { get; } = Tasks
         .Where(static task => !string.IsNullOrWhiteSpace(task.Id))
         .GroupBy(static task => task.Id, StringComparer.Ordinal)

--- a/src/Unlimotion.TaskTreeManager/TaskItemSnapshot.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskItemSnapshot.cs
@@ -1,0 +1,60 @@
+using Unlimotion.Domain;
+
+namespace Unlimotion.TaskTree;
+
+public static class TaskItemSnapshot
+{
+    public static TaskItem Clone(TaskItem task) => task with
+    {
+        StatusHistory = task.StatusHistory?.Select(CloneStatusHistoryEntry).ToList() ?? [],
+        CompletionCriteria = task.CompletionCriteria?.Select(CloneCriterion).ToList() ?? [],
+        ContainsTasks = task.ContainsTasks?.ToList() ?? [],
+        ParentTasks = task.ParentTasks?.ToList() ?? [],
+        BlocksTasks = task.BlocksTasks?.ToList() ?? [],
+        BlockedByTasks = task.BlockedByTasks?.ToList() ?? [],
+        Repeater = CloneRepeater(task.Repeater),
+        ExtensionData = task.ExtensionData?.ToDictionary(
+            static pair => pair.Key,
+            static pair => pair.Value == null ? null! : pair.Value.DeepClone())
+    };
+
+    private static TaskCompletionCriterion CloneCriterion(TaskCompletionCriterion criterion) =>
+        criterion == null
+            ? null!
+            : new TaskCompletionCriterion
+            {
+                Id = criterion.Id,
+                Text = criterion.Text,
+                IsSatisfied = criterion.IsSatisfied,
+                ExtensionData = criterion.ExtensionData?.ToDictionary(
+                    static pair => pair.Key,
+                    static pair => pair.Value == null ? null! : pair.Value.DeepClone())
+            };
+
+    private static TaskStatusHistoryEntry CloneStatusHistoryEntry(TaskStatusHistoryEntry entry) =>
+        entry == null
+            ? null!
+            : new TaskStatusHistoryEntry
+            {
+                Status = entry.Status,
+                ChangedAt = entry.ChangedAt,
+                Author = entry.Author,
+                ExtensionData = entry.ExtensionData?.ToDictionary(
+                    static pair => pair.Key,
+                    static pair => pair.Value == null ? null! : pair.Value.DeepClone())
+            };
+
+    private static RepeaterPattern? CloneRepeater(RepeaterPattern? repeater) =>
+        repeater == null
+            ? null
+            : new RepeaterPattern
+            {
+                Type = repeater.Type,
+                Period = repeater.Period,
+                AfterComplete = repeater.AfterComplete,
+                Pattern = repeater.Pattern?.ToList()!,
+                ExtensionData = repeater.ExtensionData?.ToDictionary(
+                    static pair => pair.Key,
+                    static pair => pair.Value == null ? null! : pair.Value.DeepClone())
+            };
+}

--- a/src/Unlimotion.TaskTreeManager/TaskOperationResult.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskOperationResult.cs
@@ -12,6 +12,7 @@ public sealed record TaskOperationResult
     public TaskAvailabilityAnalysis? Before { get; init; }
     public TaskAvailabilityAnalysis? After { get; init; }
     public TaskGraphValidationReport? Validation { get; init; }
+    public long StorageRevision { get; init; }
 
     public static TaskOperationResult Succeeded(
         IReadOnlyList<TaskItem> changedTasks,

--- a/src/Unlimotion.TaskTreeManager/TaskStorageUpdateEventArgs.cs
+++ b/src/Unlimotion.TaskTreeManager/TaskStorageUpdateEventArgs.cs
@@ -4,4 +4,5 @@ public class TaskStorageUpdateEventArgs : EventArgs
 {
     public string Id { get; set; } = string.Empty;
     public UpdateType Type { get; set; }
+    public long StorageRevision { get; set; }
 }

--- a/src/Unlimotion.Test/FileStorageTaskStatusTests.cs
+++ b/src/Unlimotion.Test/FileStorageTaskStatusTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Unlimotion.Domain;
@@ -14,6 +15,611 @@ namespace Unlimotion.Test;
 
 public class FileStorageTaskStatusTests
 {
+    [Test]
+    public async Task ImmediateCriterionSatisfaction_IsFlushedBeforeCompletion()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new CountingFileStorage(tempDir, new RecordingDatabaseWatcher());
+            var source = new TaskItem
+            {
+                Id = "immediate-criterion-completion",
+                Title = "Criterion task",
+                Status = DomainTaskStatus.Prepared,
+                IsCanBeCompleted = true,
+                CompletionCriteria =
+                [
+                    new TaskCompletionCriterion
+                    {
+                        Text = "Verify result",
+                        IsSatisfied = false
+                    }
+                ]
+            };
+            await storage.Save(source);
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            var viewModel = unified.Tasks.Lookup(source.Id).Value;
+            viewModel.IsInitializedProvider = () => true;
+
+            viewModel.CompletionCriteria.Single().IsSatisfied = true;
+            var result = await viewModel.TryTransitionToStatusAsync(
+                DomainTaskStatus.Completed,
+                "tester");
+            var persisted = await storage.Load(source.Id, forced: true);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.Success).IsTrue();
+                await Assert.That(persisted?.Status).IsEqualTo(DomainTaskStatus.Completed);
+                await Assert.That(persisted?.CompletionCriteria.Single().IsSatisfied).IsTrue();
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task ImmediateRepeatingCompletion_FlushesEditorFieldsAndCreatesNextOccurrence()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new CountingFileStorage(tempDir, new RecordingDatabaseWatcher());
+            var source = new TaskItem
+            {
+                Id = "immediate-repeating-completion",
+                Status = DomainTaskStatus.Prepared,
+                IsCanBeCompleted = true
+            };
+            await storage.Save(source);
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            var viewModel = unified.Tasks.Lookup(source.Id).Value;
+            viewModel.IsInitializedProvider = () => true;
+            var plannedBegin = DateTime.Now.AddDays(-1);
+
+            viewModel.Title = "Daily review";
+            viewModel.PlannedBeginDateTime = plannedBegin;
+            viewModel.Repeater = new RepeaterPatternViewModel
+            {
+                Type = RepeaterType.Daily,
+                Period = 1
+            };
+
+            var result = await viewModel.TryTransitionToStatusAsync(
+                DomainTaskStatus.Completed,
+                "tester");
+            var graph = await storage.ReadGraphAsync();
+            var persistedSource = graph.TasksById[source.Id];
+            var next = graph.Tasks.Single(task => task.Id != source.Id);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.Success).IsTrue();
+                await Assert.That(persistedSource.Title).IsEqualTo("Daily review");
+                await Assert.That(persistedSource.PlannedBeginDateTime?.LocalDateTime).IsEqualTo(plannedBegin);
+                await Assert.That(persistedSource.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+                await Assert.That(next.Title).IsEqualTo("Daily review");
+                await Assert.That(next.Status).IsEqualTo(DomainTaskStatus.Prepared);
+                await Assert.That(next.PlannedBeginDateTime?.LocalDateTime).IsEqualTo(plannedBegin.AddDays(1));
+                await Assert.That(next.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+                await Assert.That(unified.Tasks.Lookup(next.Id).HasValue).IsTrue();
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task EditDuringFileBackedStatusCommand_SurvivesUnifiedCacheHydration()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new BlockingCompletedWriteFileStorage(tempDir, new RecordingDatabaseWatcher());
+            var source = new TaskItem
+            {
+                Id = "file-backed-editor-race",
+                Title = "Original title",
+                Status = DomainTaskStatus.Prepared,
+                IsCanBeCompleted = true
+            };
+            await storage.Save(source);
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            var viewModel = unified.Tasks.Lookup(source.Id).Value;
+            viewModel.IsInitializedProvider = () => true;
+            viewModel.Title = "Before command";
+            storage.BlockCompletedWrite = true;
+
+            var transition = viewModel.TryTransitionToStatusAsync(
+                DomainTaskStatus.Completed,
+                "tester");
+            await storage.CompletedWriteEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            viewModel.Title = "Edited while command is pending";
+
+            storage.ReleaseCompletedWrite.TrySetResult();
+            var result = await transition.WaitAsync(TimeSpan.FromSeconds(5));
+            var persisted = await storage.Load(source.Id, forced: true);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.Success).IsTrue();
+                await Assert.That(viewModel.Status).IsEqualTo(DomainTaskStatus.Completed);
+                await Assert.That(viewModel.Title).IsEqualTo("Edited while command is pending");
+                await Assert.That(persisted?.Status).IsEqualTo(DomainTaskStatus.Completed);
+                await Assert.That(persisted?.Title).IsEqualTo("Edited while command is pending");
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task WarmStatusCommand_UsesLoadedGraphWithoutEnumeratingTaskDirectory()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new CountingFileStorage(tempDir, new RecordingDatabaseWatcher());
+            for (var index = 0; index < 32; index++)
+            {
+                await storage.Save(new TaskItem
+                {
+                    Id = $"cached-status-{index:D2}",
+                    UserId = "owner",
+                    Title = $"Cached status {index}",
+                    Status = DomainTaskStatus.NotReady,
+                    IsCanBeCompleted = true
+                });
+            }
+
+            using var repository = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await repository.Init();
+            var enumerationsAfterWarmUp = storage.DirectoryEnumerationCount;
+
+            var result = await repository.TrySetStatusAsync("cached-status-00", DomainTaskStatus.Prepared, "tester");
+            var persisted = await storage.Load("cached-status-00", forced: true);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.Success).IsTrue();
+                await Assert.That(result.AuthoritativeTask?.Status).IsEqualTo(DomainTaskStatus.Prepared);
+                await Assert.That(persisted?.Status).IsEqualTo(DomainTaskStatus.Prepared);
+                await Assert.That(persisted?.StatusHistory.Last().Author).IsEqualTo("tester");
+                await Assert.That(storage.DirectoryEnumerationCount).IsEqualTo(enumerationsAfterWarmUp);
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task WatcherlessStorage_RemainsColdAndReadsExternalEditForNextCommand()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new CountingFileStorage(tempDir);
+            var task = new TaskItem
+            {
+                Id = "watcherless-cold-task",
+                Title = "Before external edit",
+                Status = DomainTaskStatus.NotReady
+            };
+            await storage.Save(task);
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            var enumerationsAfterInit = storage.DirectoryEnumerationCount;
+
+            task.Title = "After external edit";
+            await File.WriteAllTextAsync(
+                Path.Combine(tempDir, task.Id),
+                JsonConvert.SerializeObject(task));
+            var result = await unified.TrySetStatusAsync(task.Id, DomainTaskStatus.NotReady);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.AuthoritativeTask?.Title).IsEqualTo("After external edit");
+                await Assert.That(storage.DirectoryEnumerationCount).IsGreaterThan(enumerationsAfterInit);
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task InitFinalCheckpoint_RemovesDeletedTaskButPreservesUnrelatedCorruptProjection()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var watcher = new RecordingDatabaseWatcher();
+            var storage = new TestFileStorage(tempDir, watcher);
+            var deleted = new TaskItem { Id = "init-deleted", Title = "Deleted", Status = DomainTaskStatus.NotReady };
+            var corrupt = new TaskItem { Id = "init-corrupt", Title = "Last valid projection", Status = DomainTaskStatus.NotReady };
+            await storage.Save(deleted);
+            await storage.Save(corrupt);
+            watcher.OnEnabled = () =>
+            {
+                File.Delete(Path.Combine(tempDir, deleted.Id));
+                File.WriteAllText(Path.Combine(tempDir, corrupt.Id), "{ corrupt json");
+                watcher.EmitRaw(deleted.Id, UpdateType.Removed);
+                watcher.EmitRaw(corrupt.Id, UpdateType.Saved);
+            };
+
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            var graph = await storage.ReadGraphAsync();
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(unified.Tasks.Lookup(deleted.Id).HasValue).IsFalse();
+                await Assert.That(unified.Tasks.Lookup(corrupt.Id).HasValue).IsTrue();
+                await Assert.That(unified.Tasks.Lookup(corrupt.Id).Value.Title).IsEqualTo("Last valid projection");
+                await Assert.That(graph.LoadErrors.Select(static error => Path.GetFileName(error.File)))
+                    .Contains(corrupt.Id);
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task LiveGraph_LoadReturnsIsolatedTaskSnapshot()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new FileStorage(tempDir, watcher: false);
+            await storage.Save(new TaskItem
+            {
+                Id = "isolated-live-task",
+                Title = "Persisted",
+                Status = DomainTaskStatus.NotReady
+            });
+            await storage.EnableLiveGraphAsync();
+
+            var loaded = await storage.Load("isolated-live-task");
+            loaded!.Status = DomainTaskStatus.Completed;
+            loaded.StatusHistory.Add(new TaskStatusHistoryEntry
+            {
+                Status = DomainTaskStatus.Completed,
+                ChangedAt = DateTimeOffset.UtcNow,
+                Author = "mutator"
+            });
+
+            var graph = await storage.ReadGraphAsync();
+            var cached = graph.TasksById["isolated-live-task"];
+            await Assert.That(cached.Status).IsEqualTo(DomainTaskStatus.NotReady);
+            await Assert.That(cached.StatusHistory.Any(entry => entry?.Author == "mutator")).IsFalse();
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task StatusCommand_AppliesRawWatcherChangeBeforeDebouncedUiUpdate()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var watcher = new RecordingDatabaseWatcher();
+            var storage = new TestFileStorage(tempDir, watcher);
+            var task = new TaskItem
+            {
+                Id = "raw-watcher-task",
+                Title = "Before external edit",
+                Status = DomainTaskStatus.NotReady
+            };
+            await storage.Save(task);
+            await storage.EnableLiveGraphAsync();
+
+            task.Title = "After external edit";
+            await File.WriteAllTextAsync(
+                Path.Combine(tempDir, task.Id),
+                JsonConvert.SerializeObject(task));
+            watcher.EmitRaw(task.Id, UpdateType.Saved);
+
+            var result = await new TaskGraphCommandService(storage)
+                .TrySetStatusAsync(task.Id, DomainTaskStatus.NotReady, "tester");
+
+            await Assert.That(result.Success).IsTrue();
+            await Assert.That(result.AuthoritativeTask?.Title).IsEqualTo("After external edit");
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task WatcherInvalidation_PerformsOneReloadBeforeNextCommand()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var watcher = new RecordingDatabaseWatcher();
+            var storage = new CountingFileStorage(tempDir, watcher);
+            await storage.Save(new TaskItem
+            {
+                Id = "reload-once-task",
+                Title = "Reload once",
+                Status = DomainTaskStatus.NotReady
+            });
+            await storage.EnableLiveGraphAsync();
+            var initialEnumerations = storage.DirectoryEnumerationCount;
+            watcher.Invalidate();
+
+            var service = new TaskGraphCommandService(storage);
+            var first = await service.TrySetStatusAsync("reload-once-task", DomainTaskStatus.NotReady);
+            var afterRecovery = storage.DirectoryEnumerationCount;
+            var second = await service.TrySetStatusAsync("reload-once-task", DomainTaskStatus.NotReady);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(first.Success).IsTrue();
+                await Assert.That(second.Success).IsTrue();
+                await Assert.That(afterRecovery).IsEqualTo(initialEnumerations + 1);
+                await Assert.That(storage.DirectoryEnumerationCount).IsEqualTo(afterRecovery);
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task TruncatedFile_IsAppliedBeforeWarmStatusCommandAndIsNotOverwritten()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var watcher = new RecordingDatabaseWatcher();
+            var storage = new TestFileStorage(tempDir, watcher);
+            const string taskId = "truncated-before-command";
+            await storage.Save(new TaskItem
+            {
+                Id = taskId,
+                Title = "Must not be restored",
+                Status = DomainTaskStatus.NotReady
+            });
+            await storage.EnableLiveGraphAsync();
+            var filePath = Path.Combine(tempDir, taskId);
+            await File.WriteAllTextAsync(filePath, string.Empty);
+            watcher.EmitRaw(taskId, UpdateType.Saved);
+
+            var result = await new TaskGraphCommandService(storage)
+                .TrySetStatusAsync(taskId, DomainTaskStatus.Prepared, "tester");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.Success).IsFalse();
+                await Assert.That(result.DeniedReason?.Kind).IsEqualTo(TaskOperationDeniedKind.TaskNotFound);
+                await Assert.That(new FileInfo(filePath).Length).IsEqualTo(0);
+                await Assert.That(await storage.Load(taskId)).IsNull();
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task LiveGraphMiss_DoesNotFallBackToStaleLegacyCacheAfterDeleteOrCorruption()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var watcher = new RecordingDatabaseWatcher();
+            var storage = new TestFileStorage(tempDir, watcher);
+            const string taskId = "authoritative-live-miss";
+            var task = new TaskItem { Id = taskId, Title = "Original", Status = DomainTaskStatus.NotReady };
+            await storage.Save(task);
+            await storage.EnableLiveGraphAsync();
+            var filePath = Path.Combine(tempDir, taskId);
+
+            File.Delete(filePath);
+            watcher.EmitRaw(taskId, UpdateType.Removed);
+            await storage.SynchronizePendingFileChangesAsync();
+            await Assert.That(await storage.Load(taskId)).IsNull();
+
+            await storage.Save(task);
+            await File.WriteAllTextAsync(filePath, "{ corrupt json");
+            watcher.EmitRaw(taskId, UpdateType.Saved);
+            var graph = await storage.SynchronizePendingFileChangesAsync();
+            var result = await new TaskGraphCommandService(storage)
+                .TrySetStatusAsync(taskId, DomainTaskStatus.Prepared);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(await storage.Load(taskId)).IsNull();
+                await Assert.That(graph.LoadErrors).HasCount().EqualTo(1);
+                await Assert.That(result.DeniedReason?.Kind).IsEqualTo(TaskOperationDeniedKind.ValidationFailed);
+                await Assert.That(await File.ReadAllTextAsync(filePath)).IsEqualTo("{ corrupt json");
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task DebouncedEventType_IsDerivedFromCurrentPhysicalState()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new TestFileStorage(tempDir);
+            const string taskId = "event-reorder";
+            var task = new TaskItem { Id = taskId, Title = "Initial", Status = DomainTaskStatus.NotReady };
+            await storage.Save(task);
+            await storage.EnableLiveGraphAsync();
+            var observed = new List<UpdateType>();
+            storage.Updating += (_, args) => observed.Add(args.Type);
+
+            task.Title = "Recreated";
+            await File.WriteAllTextAsync(Path.Combine(tempDir, taskId), JsonConvert.SerializeObject(task));
+            await storage.TriggerUpdatingAsync(taskId, UpdateType.Removed);
+            File.Delete(Path.Combine(tempDir, taskId));
+            await storage.TriggerUpdatingAsync(taskId, UpdateType.Saved);
+
+            await Assert.That(observed).IsEquivalentTo([UpdateType.Saved, UpdateType.Removed]);
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task LegacyNullNestedValues_AreClonedWithoutAliasingOrStartupFailure()
+    {
+        var task = new TaskItem
+        {
+            Id = "legacy-null-nested",
+            CompletionCriteria = [null!],
+            StatusHistory = [null!],
+            Repeater = new RepeaterPattern { Type = RepeaterType.Daily, Pattern = null! }
+        };
+
+        var clone = TaskItemSnapshot.Clone(task);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(clone.CompletionCriteria).HasCount().EqualTo(1);
+            await Assert.That(clone.CompletionCriteria[0]).IsNull();
+            await Assert.That(clone.StatusHistory[0]).IsNull();
+            await Assert.That(clone.Repeater?.Pattern).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task Dispose_StopsOwnedWatcherLifetime()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var watcher = new RecordingDatabaseWatcher();
+            var storage = new TestFileStorage(tempDir, watcher);
+
+            storage.Dispose();
+
+            await Assert.That(watcher.IsDisposed).IsTrue();
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task NewRawGenerationDuringRefresh_RemainsPendingForNextCommand()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var watcher = new RecordingDatabaseWatcher();
+            var storage = new TestFileStorage(tempDir, watcher);
+            const string taskId = "generation-during-refresh";
+            var task = new TaskItem { Id = taskId, Title = "Initial", Status = DomainTaskStatus.NotReady };
+            await storage.Save(task);
+            await storage.EnableLiveGraphAsync();
+
+            var lockEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var heldLock = storage.WithDirectoryLockAsync(async () =>
+            {
+                lockEntered.SetResult();
+                await releaseLock.Task;
+            });
+            await lockEntered.Task;
+
+            task.Title = "First external edit";
+            await File.WriteAllTextAsync(Path.Combine(tempDir, taskId), JsonConvert.SerializeObject(task));
+            watcher.EmitRaw(taskId, UpdateType.Saved);
+            var refresh = storage.TriggerUpdatingAsync(taskId);
+            await Task.Delay(50);
+            task.Title = "Second external edit";
+            await File.WriteAllTextAsync(Path.Combine(tempDir, taskId), JsonConvert.SerializeObject(task));
+            watcher.EmitRaw(taskId, UpdateType.Saved);
+            releaseLock.SetResult();
+            await Task.WhenAll(heldLock, refresh);
+
+            var result = await new TaskGraphCommandService(storage)
+                .TrySetStatusAsync(taskId, DomainTaskStatus.NotReady);
+
+            await Assert.That(result.AuthoritativeTask?.Title).IsEqualTo("Second external edit");
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
+    [Test]
+    public async Task PartialRepeaterFailure_ReconcilesEveryAttemptedTaskFromLiveGraph()
+    {
+        var tempDir = CreateTempDirectory();
+        try
+        {
+            var storage = new FailingWriteFileStorage(tempDir, new RecordingDatabaseWatcher());
+            var source = new TaskItem
+            {
+                Id = "partial-repeater-source",
+                UserId = "owner",
+                Title = "Repeating source",
+                Status = DomainTaskStatus.Prepared,
+                IsCanBeCompleted = true,
+                PlannedBeginDateTime = DateTimeOffset.UtcNow.AddDays(-1),
+                Repeater = new RepeaterPattern { Type = RepeaterType.Daily, Period = 1, Pattern = [] }
+            };
+            await storage.Save(source);
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            var enumerationsAfterInit = storage.DirectoryEnumerationCount;
+            storage.FailWhenWriting(source.Id);
+
+            var result = await unified.TrySetStatusAsync(source.Id, DomainTaskStatus.Completed, "tester");
+            var graph = await storage.ReadGraphAsync();
+            var clone = graph.Tasks.Single(task => task.Id != source.Id && task.Title == source.Title);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.DeniedReason?.Kind).IsEqualTo(TaskOperationDeniedKind.OutcomeUnknown);
+                await Assert.That(result.StorageRevision).IsGreaterThan(0);
+                await Assert.That(result.StorageRevision).IsEqualTo(graph.Revision);
+                await Assert.That(storage.DirectoryEnumerationCount).IsEqualTo(enumerationsAfterInit);
+                await Assert.That(result.ChangedTasks.Select(static task => task.Id)).Contains(clone.Id);
+                await Assert.That(unified.Tasks.Lookup(clone.Id).HasValue).IsTrue();
+                await Assert.That(unified.Tasks.Lookup(source.Id).Value.Status).IsEqualTo(DomainTaskStatus.Completed);
+            }
+        }
+        finally
+        {
+            TryDeleteDirectory(tempDir);
+        }
+    }
+
     [Test]
     public async Task UnarchiveCommand_PreservesNullAndFutureHistoryAndAppendsOneNormalizedEntry()
     {
@@ -154,7 +760,7 @@ public class FileStorageTaskStatusTests
     }
 
     [Test]
-    public async Task OnUpdating_MalformedTaskFileDoesNotThrowAndRaisesUpdating()
+    public async Task OnUpdating_MalformedTaskFileDoesNotThrowOrDeleteExistingProjection()
     {
         var tempDir = CreateTempDirectory();
         try
@@ -173,8 +779,8 @@ public class FileStorageTaskStatusTests
 
             await storage.TriggerUpdatingAsync("malformed-task");
 
-            await Assert.That(raised).IsTrue();
-            await Assert.That(observedId).IsEqualTo("malformed-task");
+            await Assert.That(raised).IsFalse();
+            await Assert.That(observedId).IsNull();
             await Assert.That(await storage.Load("malformed-task", forced: true)).IsNull();
         }
         finally
@@ -291,23 +897,116 @@ public class FileStorageTaskStatusTests
         {
         }
 
-        public Task TriggerUpdatingAsync(string id) => OnUpdatingAsync(new TaskStorageUpdateEventArgs
+        public Task TriggerUpdatingAsync(string id, UpdateType type = UpdateType.Saved) => OnUpdatingAsync(new TaskStorageUpdateEventArgs
         {
             Id = id,
-            Type = UpdateType.Saved
+            Type = type
         });
     }
 
-    private sealed class RecordingDatabaseWatcher : IDatabaseWatcher
+    private sealed class CountingFileStorage : FileStorage
+    {
+        public CountingFileStorage(string path) : base(path, watcher: false)
+        {
+        }
+
+        public CountingFileStorage(string path, IDatabaseWatcher watcher) : base(path, watcher)
+        {
+        }
+
+        public int DirectoryEnumerationCount { get; private set; }
+
+        protected override IEnumerable<string> EnumerateTaskFiles()
+        {
+            DirectoryEnumerationCount++;
+            return base.EnumerateTaskFiles();
+        }
+    }
+
+    private sealed class FailingWriteFileStorage : FileStorage
+    {
+        private string? _failingTaskId;
+
+        public FailingWriteFileStorage(string path, IDatabaseWatcher watcher) : base(path, watcher)
+        {
+        }
+
+        public int DirectoryEnumerationCount { get; private set; }
+
+        public void FailWhenWriting(string taskId) => _failingTaskId = taskId;
+
+        protected override IEnumerable<string> EnumerateTaskFiles()
+        {
+            DirectoryEnumerationCount++;
+            return base.EnumerateTaskFiles();
+        }
+
+        protected override void OnAfterWritePersisted(string taskId, string filePath)
+        {
+            base.OnAfterWritePersisted(taskId, filePath);
+            if (string.Equals(taskId, _failingTaskId, StringComparison.Ordinal))
+            {
+                throw new IOException("simulated post-commit cache publication failure");
+            }
+        }
+    }
+
+    private sealed class BlockingCompletedWriteFileStorage : FileStorage
+    {
+        private int _hasBlockedCompletedWrite;
+
+        public BlockingCompletedWriteFileStorage(string path, IDatabaseWatcher watcher) : base(path, watcher)
+        {
+        }
+
+        public bool BlockCompletedWrite { get; set; }
+
+        public TaskCompletionSource CompletedWriteEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseCompletedWrite { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override void OnAfterWritePersisted(string taskId, string filePath)
+        {
+            base.OnAfterWritePersisted(taskId, filePath);
+            if (!BlockCompletedWrite || Volatile.Read(ref _hasBlockedCompletedWrite) != 0)
+            {
+                return;
+            }
+
+            var persisted = JsonConvert.DeserializeObject<TaskItem>(File.ReadAllText(filePath));
+            if (persisted?.Status != DomainTaskStatus.Completed ||
+                Interlocked.Exchange(ref _hasBlockedCompletedWrite, 1) != 0)
+            {
+                return;
+            }
+
+            CompletedWriteEntered.TrySetResult();
+            ReleaseCompletedWrite.Task.GetAwaiter().GetResult();
+        }
+    }
+
+    private sealed class RecordingDatabaseWatcher : IDatabaseWatcher, IRawDatabaseWatcher, IDisposable
     {
         public List<string> IgnoredTaskIds { get; } = [];
+        public bool IsDisposed { get; private set; }
+        public Action? OnEnabled { get; set; }
 
         public event EventHandler<DbUpdatedEventArgs>? OnUpdated;
+        public event EventHandler<DbUpdatedEventArgs>? OnRawUpdated;
+        public event EventHandler? OnInvalidated;
 
         public void AddIgnoredTask(string taskId) => IgnoredTaskIds.Add(taskId);
 
         public void SetEnable(bool enable)
         {
+            if (enable)
+            {
+                var callback = OnEnabled;
+                OnEnabled = null;
+                callback?.Invoke();
+            }
         }
 
         public void ForceUpdateFile(string filename, UpdateType type) => OnUpdated?.Invoke(this, new DbUpdatedEventArgs
@@ -315,5 +1014,15 @@ public class FileStorageTaskStatusTests
             Id = filename,
             Type = type
         });
+
+        public void EmitRaw(string filename, UpdateType type) => OnRawUpdated?.Invoke(this, new DbUpdatedEventArgs
+        {
+            Id = filename,
+            Type = type
+        });
+
+        public void Invalidate() => OnInvalidated?.Invoke(this, EventArgs.Empty);
+
+        public void Dispose() => IsDisposed = true;
     }
 }

--- a/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
+++ b/src/Unlimotion.Test/MainControlTaskStatusIconUiTests.cs
@@ -924,57 +924,171 @@ public class MainControlTaskStatusIconUiTests
     }
 
     [Test]
+    public async Task TaskStatusPicker_ImmediateRepeatingCompletion_PreservesEditorFieldsAndCreatesNextTask()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            var storage = new InMemoryStorage();
+            var repository = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            var storedTask = new TaskItem
+            {
+                Id = "status-picker-immediate-repeat",
+                Status = DomainTaskStatus.Prepared,
+                IsCanBeCompleted = true
+            };
+            storedTask.EnsureStatusHistory("owner");
+            await storage.Save(storedTask);
+            await repository.Init();
+            Window? window = null;
+
+            try
+            {
+                var task = repository.Tasks.Lookup(storedTask.Id).Value;
+                task.IsInitializedProvider = () => true;
+                var plannedBegin = DateTime.Now.AddDays(-1);
+                task.Title = "Daily review";
+                task.PlannedBeginDateTime = plannedBegin;
+                task.Repeater = new RepeaterPatternViewModel
+                {
+                    Type = RepeaterType.Daily,
+                    Period = 1
+                };
+                var statusPicker = new TaskStatusPicker
+                {
+                    Task = task,
+                    Width = 28,
+                    Height = 24
+                };
+
+                window = CreateWindow(statusPicker);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                var flyout = await OpenStatusFlyoutAsync(window, statusPicker);
+                var completedItem = flyout.Items
+                    .OfType<MenuItem>()
+                    .Single(item => string.Equals(
+                        AutomationProperties.GetAutomationId(item),
+                        "TaskStatusOptionCompleted",
+                        StringComparison.Ordinal));
+
+                InvokeMenuItemClick(completedItem);
+
+                var completed = await TestHelpers.WaitUntilAsync(() =>
+                {
+                    Dispatcher.UIThread.RunJobs();
+                    return task.Status == DomainTaskStatus.Completed && repository.Tasks.Count == 2;
+                }, TimeSpan.FromSeconds(2));
+                var next = repository.Tasks.Items.Single(item => item.Id != task.Id);
+
+                using (Assert.Multiple())
+                {
+                    await Assert.That(completed).IsTrue();
+                    await Assert.That(task.Title).IsEqualTo("Daily review");
+                    await Assert.That(task.PlannedBeginDateTime).IsEqualTo(plannedBegin);
+                    await Assert.That(task.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+                    await Assert.That(next.Title).IsEqualTo("Daily review");
+                    await Assert.That(next.Status).IsEqualTo(DomainTaskStatus.Prepared);
+                    await Assert.That(next.PlannedBeginDateTime).IsEqualTo(plannedBegin.AddDays(1));
+                    await Assert.That(next.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+                }
+            }
+            finally
+            {
+                window?.Close();
+                repository.Dispose();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
     public async Task TaskStatusPickerFlyout_EnablesCompletedOptionAfterCriterionIsSatisfied()
     {
         await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
         await session.DispatchAsync(async () =>
         {
-            var task = new TaskItemViewModel(
-                new TaskItem
+            var storage = new InMemoryStorage();
+            var repository = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            var storedTask = new TaskItem
+            {
+                Id = "status-picker-criteria-task",
+                Title = "Status picker criteria task",
+                Status = DomainTaskStatus.Prepared,
+                IsCanBeCompleted = true,
+                CompletionCriteria =
+                [
+                    new TaskCompletionCriterion
+                    {
+                        Text = "Проверить результат",
+                        IsSatisfied = false
+                    }
+                ]
+            };
+            storedTask.EnsureStatusHistory("owner");
+            await storage.Save(storedTask);
+            await repository.Init();
+            var task = repository.Tasks.Lookup(storedTask.Id).Value;
+            task.IsInitializedProvider = () => true;
+            var statusPicker = new TaskStatusPicker
+            {
+                Task = task,
+                Width = 28,
+                Height = 24
+            };
+            Window? window = null;
+
+            try
+            {
+                window = CreateWindow(statusPicker);
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+                var flyout = await OpenStatusFlyoutAsync(window, statusPicker);
+                var completedItem = flyout.Items
+                    .OfType<MenuItem>()
+                    .SingleOrDefault(item =>
+                        string.Equals(
+                            AutomationProperties.GetAutomationId(item),
+                            "TaskStatusOptionCompleted",
+                            StringComparison.Ordinal));
+
+                await Assert.That(completedItem).IsNotNull();
+                await Assert.That(completedItem!.IsEnabled).IsFalse();
+                await Assert.That(AutomationProperties.GetHelpText(completedItem)).IsNotEmpty();
+                flyout.Hide();
+
+                task.CompletionCriteria.Single().IsSatisfied = true;
+                Dispatcher.UIThread.RunJobs();
+
+                await Assert.That(task.StatusOptions.Single(option => option.Status == DomainTaskStatus.Completed).IsEnabled)
+                    .IsTrue();
+                flyout = await OpenStatusFlyoutAsync(window, statusPicker);
+                completedItem = flyout.Items
+                    .OfType<MenuItem>()
+                    .Single(item =>
+                        string.Equals(
+                            AutomationProperties.GetAutomationId(item),
+                            "TaskStatusOptionCompleted",
+                            StringComparison.Ordinal));
+                await Assert.That(completedItem.IsEnabled).IsTrue();
+                await Assert.That(AutomationProperties.GetHelpText(completedItem)).IsEmpty();
+
+                InvokeMenuItemClick(completedItem);
+                var completed = await TestHelpers.WaitUntilAsync(() =>
                 {
-                    Id = "status-picker-criteria-task",
-                    Title = "Status picker criteria task",
-                    Status = DomainTaskStatus.Prepared,
-                    IsCanBeCompleted = true,
-                    CompletionCriteria =
-                    [
-                        new TaskCompletionCriterion
-                        {
-                            Text = "Проверить результат",
-                            IsSatisfied = false
-                        }
-                    ]
-                },
-                new UnifiedTaskStorage(new TaskTreeManager(new InMemoryStorage())),
-                () => false);
-            var flyout = BuildStatusFlyout(task);
-            var completedItem = flyout.Items
-                .OfType<MenuItem>()
-                .SingleOrDefault(item =>
-                    string.Equals(
-                        AutomationProperties.GetAutomationId(item),
-                        "TaskStatusOptionCompleted",
-                        StringComparison.Ordinal));
+                    Dispatcher.UIThread.RunJobs();
+                    return task.Status == DomainTaskStatus.Completed;
+                }, TimeSpan.FromSeconds(2));
+                var persisted = await storage.Load(task.Id);
 
-            await Assert.That(completedItem).IsNotNull();
-            await Assert.That(completedItem!.IsEnabled).IsFalse();
-            await Assert.That(AutomationProperties.GetHelpText(completedItem)).IsNotEmpty();
-
-            task.CompletionCriteria.Single().IsSatisfied = true;
-            Dispatcher.UIThread.RunJobs();
-
-            await Assert.That(task.StatusOptions.Single(option => option.Status == DomainTaskStatus.Completed).IsEnabled)
-                .IsTrue();
-            flyout = BuildStatusFlyout(task);
-            completedItem = flyout.Items
-                .OfType<MenuItem>()
-                .Single(item =>
-                    string.Equals(
-                        AutomationProperties.GetAutomationId(item),
-                        "TaskStatusOptionCompleted",
-                        StringComparison.Ordinal));
-            await Assert.That(completedItem.IsEnabled).IsTrue();
-            await Assert.That(AutomationProperties.GetHelpText(completedItem)).IsEmpty();
+                await Assert.That(completed).IsTrue();
+                await Assert.That(persisted?.Status).IsEqualTo(DomainTaskStatus.Completed);
+                await Assert.That(persisted?.CompletionCriteria.Single().IsSatisfied).IsTrue();
+            }
+            finally
+            {
+                window?.Close();
+                repository.Dispose();
+            }
         }, CancellationToken.None);
     }
 
@@ -1360,8 +1474,11 @@ public class MainControlTaskStatusIconUiTests
             return Task.FromResult(change);
         }
 
-        public Task<TaskItemViewModel> Update(TaskItem change) =>
-            throw new NotSupportedException();
+        public Task<TaskItemViewModel> Update(TaskItem change)
+        {
+            UpdateAccessChecks.Add(Dispatcher.UIThread.CheckAccess());
+            return Task.FromResult<TaskItemViewModel>(null!);
+        }
 
         public Task<TaskOperationResult> TrySetStatusAsync(
             string taskId,

--- a/src/Unlimotion.Test/TaskItemViewModelStatusCommandTests.cs
+++ b/src/Unlimotion.Test/TaskItemViewModelStatusCommandTests.cs
@@ -99,6 +99,278 @@ public sealed class TaskItemViewModelStatusCommandTests
     }
 
     [Test]
+    public async Task DelayedStatusResult_DoesNotOverwriteNewerStorageGeneration()
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("generation-order", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        storage.StatusHandler = async (taskId, requestedStatus, author) =>
+        {
+            started.TrySetResult();
+            await release.Task;
+            return storage.CreateSuccess(taskId, requestedStatus, author) with { StorageRevision = 10 };
+        };
+        using var viewModel = new TaskItemViewModel(task, storage, () => false);
+
+        var transition = viewModel.TryTransitionToStatusAsync(DomainTaskStatus.InProgress, "tester");
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var newer = TaskItemSnapshot.Clone(task);
+        newer.Status = DomainTaskStatus.Completed;
+        viewModel.Update(newer, storageRevision: 11);
+
+        release.TrySetResult();
+        var result = await transition.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Success).IsTrue();
+            await Assert.That(result.AuthoritativeTask?.Status).IsEqualTo(DomainTaskStatus.InProgress);
+            await Assert.That(viewModel.Status).IsEqualTo(DomainTaskStatus.Completed);
+        }
+    }
+
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task EditDuringStatusCommand_IsMergedAndDrainedBeforeCompletion(bool sealDuringCommand)
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("editor-race", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        storage.StatusHandler = async (taskId, requestedStatus, author) =>
+        {
+            started.TrySetResult();
+            await release.Task;
+            return storage.CreateSuccess(taskId, requestedStatus, author);
+        };
+        using var viewModel = new TaskItemViewModel(task, storage, () => true);
+        viewModel.Title = "Before command";
+
+        var transition = viewModel.TryTransitionToStatusAsync(DomainTaskStatus.Completed, "tester");
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Title = "Edited while command is pending";
+        viewModel.Repeater = new RepeaterPatternViewModel
+        {
+            Type = RepeaterType.Daily,
+            Period = 1
+        };
+        var sealedSaves = sealDuringCommand ? viewModel.SealPendingSaves() : Task.CompletedTask;
+
+        release.TrySetResult();
+        var result = await transition.WaitAsync(TimeSpan.FromSeconds(5));
+        await sealedSaves.WaitAsync(TimeSpan.FromSeconds(5));
+        var persisted = storage.Snapshot(task.Id);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Success).IsTrue();
+            await Assert.That(viewModel.Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(viewModel.Title).IsEqualTo("Edited while command is pending");
+            await Assert.That(viewModel.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+            await Assert.That(persisted.Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(persisted.Title).IsEqualTo("Edited while command is pending");
+            await Assert.That(persisted.Repeater?.Type).IsEqualTo(RepeaterType.Daily);
+        }
+    }
+
+    [Test]
+    public async Task EditorFlushFailureBeforeStatusCommand_ReturnsControlledFailureAndRemainsRetryable()
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("editor-preflush-failure", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        storage.UpdateHandler = _ => Task.FromException(new InvalidOperationException("controlled editor save failure"));
+        using var viewModel = new TaskItemViewModel(task, storage, () => true);
+        viewModel.Title = "Unsaved title";
+
+        var result = await viewModel.TryTransitionToStatusAsync(
+            DomainTaskStatus.Completed,
+            "tester").WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Success).IsFalse();
+            await Assert.That(result.DeniedReason?.Kind).IsEqualTo(TaskOperationDeniedKind.StorageFailed);
+            await Assert.That(storage.StatusCalls).IsEmpty();
+            await Assert.That(storage.Snapshot(task.Id).Title).IsEqualTo(task.Title);
+        }
+
+        storage.UpdateHandler = null;
+        await viewModel.SaveItemCommand.Execute().ToTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(storage.Snapshot(task.Id).Title).IsEqualTo("Unsaved title");
+
+        viewModel.Description = "New edit after successful retry";
+        await viewModel.SealPendingSaves().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(storage.Snapshot(task.Id).Description)
+            .IsEqualTo("New edit after successful retry");
+    }
+
+    [Test]
+    public async Task SealPendingSaves_FlushesThrottledEditorRevisionBeforeTeardown()
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("sealed-throttled-editor", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        using var viewModel = new TaskItemViewModel(task, storage, () => true);
+        viewModel.Title = "Saved by lifecycle seal";
+
+        await viewModel.SealPendingSaves().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(storage.Snapshot(task.Id).Title)
+            .IsEqualTo("Saved by lifecycle seal");
+    }
+
+    [Test]
+    public async Task SealPendingSaves_WhenFinalEditorFlushFails_FaultsTeardown()
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("sealed-throttled-editor-failure", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        storage.UpdateHandler = _ => Task.FromException(new InvalidOperationException("controlled seal save failure"));
+        using var viewModel = new TaskItemViewModel(task, storage, () => true);
+        viewModel.Title = "Cannot be discarded";
+
+        var sealedSaves = viewModel.SealPendingSaves();
+
+        await Assert.That(async () =>
+                await sealedSaves.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task EditorFlushFailureAfterSuccessfulStatusCommand_PreservesConfirmedResultAndRemainsRetryable()
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("editor-postflush-failure", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        storage.StatusHandler = async (taskId, requestedStatus, author) =>
+        {
+            started.TrySetResult();
+            await release.Task;
+            return storage.CreateSuccess(taskId, requestedStatus, author);
+        };
+        using var viewModel = new TaskItemViewModel(task, storage, () => true);
+        viewModel.Title = "Before command";
+
+        var transition = viewModel.TryTransitionToStatusAsync(DomainTaskStatus.Completed, "tester");
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Title = "Edited while command is pending";
+        storage.UpdateHandler = _ => Task.FromException(new InvalidOperationException("controlled final editor save failure"));
+
+        release.TrySetResult();
+        var result = await transition.WaitAsync(TimeSpan.FromSeconds(5));
+        var persistedBeforeRetry = storage.Snapshot(task.Id);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Success).IsTrue();
+            await Assert.That(result.AuthoritativeTask?.Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(viewModel.Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(viewModel.Title).IsEqualTo("Edited while command is pending");
+            await Assert.That(persistedBeforeRetry.Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(persistedBeforeRetry.Title).IsEqualTo("Before command");
+        }
+
+        storage.UpdateHandler = null;
+        await viewModel.SaveItemCommand.Execute().ToTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await viewModel.SealPendingSaves().WaitAsync(TimeSpan.FromSeconds(5));
+        var persistedAfterRetry = storage.Snapshot(task.Id);
+        using (Assert.Multiple())
+        {
+            await Assert.That(persistedAfterRetry.Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(persistedAfterRetry.Title).IsEqualTo("Edited while command is pending");
+        }
+    }
+
+    [Test]
+    public async Task EditorFlushFailureAfterSuccessfulStatusCommand_FaultsConcurrentLifecycleSeal()
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("editor-postflush-seal-failure", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        storage.StatusHandler = async (taskId, requestedStatus, author) =>
+        {
+            started.TrySetResult();
+            await release.Task;
+            return storage.CreateSuccess(taskId, requestedStatus, author);
+        };
+        using var viewModel = new TaskItemViewModel(task, storage, () => true);
+        viewModel.Title = "Before command";
+
+        var transition = viewModel.TryTransitionToStatusAsync(DomainTaskStatus.Completed, "tester");
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Title = "Unsaved edit during sealed command";
+        storage.UpdateHandler = _ => Task.FromException(new InvalidOperationException("controlled sealed editor save failure"));
+        var sealedSaves = viewModel.SealPendingSaves();
+
+        release.TrySetResult();
+        var result = await transition.WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Success).IsTrue();
+            await Assert.That(viewModel.Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(viewModel.Title).IsEqualTo("Unsaved edit during sealed command");
+            await Assert.That(storage.Snapshot(task.Id).Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(storage.Snapshot(task.Id).Title).IsEqualTo("Before command");
+        }
+
+        await Assert.That(async () =>
+                await sealedSaves.WaitAsync(TimeSpan.FromSeconds(5)))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task RetryThatPersistsFailedRevisionBeforeProducerCompletion_AllowsLifecycleSeal()
+    {
+        using var storage = new ScriptedTaskStorage();
+        var task = CreateTask("editor-retry-before-producer-completion", DomainTaskStatus.Prepared);
+        storage.Seed(task);
+        var statusStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseStatus = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        storage.StatusHandler = async (taskId, requestedStatus, author) =>
+        {
+            statusStarted.TrySetResult();
+            await releaseStatus.Task;
+            return storage.CreateSuccess(taskId, requestedStatus, author);
+        };
+        var notifications = new BlockingErrorNotificationManager();
+        using var viewModel = new TaskItemViewModel(task, storage, () => true)
+        {
+            NotificationManager = notifications
+        };
+        viewModel.Title = "Before command";
+
+        var transition = viewModel.TryTransitionToStatusAsync(DomainTaskStatus.Completed, "tester");
+        await statusStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        viewModel.Title = "Retry saves this edit";
+        storage.UpdateHandler = _ => Task.FromException(new InvalidOperationException("controlled final editor save failure"));
+        releaseStatus.TrySetResult();
+        await notifications.ErrorToastEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        storage.UpdateHandler = null;
+        await viewModel.SaveItemCommand.Execute().ToTask().WaitAsync(TimeSpan.FromSeconds(5));
+        notifications.ReleaseErrorToast.TrySetResult();
+        var result = await transition.WaitAsync(TimeSpan.FromSeconds(5));
+        await viewModel.SealPendingSaves().WaitAsync(TimeSpan.FromSeconds(5));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Success).IsTrue();
+            await Assert.That(storage.Snapshot(task.Id).Status).IsEqualTo(DomainTaskStatus.Completed);
+            await Assert.That(storage.Snapshot(task.Id).Title).IsEqualTo("Retry saves this edit");
+        }
+    }
+
+    [Test]
     public async Task PendingArchiveConfirmation_IsCancelledAndDrainedByLifecycleSeal()
     {
         using var storage = new ScriptedTaskStorage();
@@ -814,6 +1086,8 @@ public sealed class TaskItemViewModelStatusCommandTests
 
         public Func<string, DomainTaskStatus, string?, Task<TaskOperationResult>>? StatusHandler { get; set; }
 
+        public Func<TaskItem, Task>? UpdateHandler { get; set; }
+
         public event EventHandler<EventArgs>? Initiated;
 
         public void Seed(params TaskItem[] tasks)
@@ -903,11 +1177,18 @@ public sealed class TaskItemViewModelStatusCommandTests
         public Task<bool> Delete(TaskItemViewModel change, TaskItemViewModel parent) =>
             throw new NotSupportedException();
 
-        public Task<TaskItemViewModel> Update(TaskItemViewModel change) =>
-            throw new NotSupportedException();
+        public Task<TaskItemViewModel> Update(TaskItemViewModel change) => Update(change.Model);
 
-        public Task<TaskItemViewModel> Update(TaskItem change) =>
-            throw new NotSupportedException();
+        public async Task<TaskItemViewModel> Update(TaskItem change)
+        {
+            if (UpdateHandler is not null)
+            {
+                await UpdateHandler(Clone(change));
+            }
+
+            _tasks[change.Id] = Clone(change);
+            return null!;
+        }
 
         public Task<TaskItemViewModel> Clone(
             TaskItemViewModel change,
@@ -964,6 +1245,31 @@ public sealed class TaskItemViewModelStatusCommandTests
             BlocksTasks = task.BlocksTasks?.ToList() ?? [],
             BlockedByTasks = task.BlockedByTasks?.ToList() ?? []
         };
+    }
+
+    private sealed class BlockingErrorNotificationManager : INotificationManagerWrapper
+    {
+        public TaskCompletionSource ErrorToastEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseErrorToast { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Ask(string header, string message, Action yesAction, Action? noAction = null) =>
+            noAction?.Invoke();
+
+        public Task<bool> ConfirmTaskOutlinePasteAsync(TaskOutlinePastePreview preview) =>
+            Task.FromResult(false);
+
+        public void ErrorToast(string message)
+        {
+            ErrorToastEntered.TrySetResult();
+            ReleaseErrorToast.Task.GetAwaiter().GetResult();
+        }
+
+        public void SuccessToast(string message)
+        {
+        }
     }
 
     private sealed class FakeSystemCultureProvider(string cultureName) : ILocalizationSystemCultureProvider

--- a/src/Unlimotion.Test/UnifiedTaskStorageStatusCommandTests.cs
+++ b/src/Unlimotion.Test/UnifiedTaskStorageStatusCommandTests.cs
@@ -11,6 +11,8 @@ using DomainTaskStatus = Unlimotion.Domain.TaskStatus;
 
 namespace Unlimotion.Test;
 
+[NotInParallel("AvaloniaHeadless")]
+[ParallelLimiter<SharedUiStateParallelLimit>]
 public sealed class UnifiedTaskStorageStatusCommandTests
 {
     [Test]
@@ -260,6 +262,63 @@ public sealed class UnifiedTaskStorageStatusCommandTests
             await Assert.That(results.All(static result => result.Success)).IsTrue();
             await Assert.That(unified.Tasks.Lookup("task").Value.Status).IsEqualTo(DomainTaskStatus.InProgress);
         }
+    }
+
+    [Test]
+    public async Task NewerWatcherDeleteTombstone_PreventsDelayedCommandFromRecreatingTask()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            var storage = new GenerationOrderingStorage(CreateTask("generation-delete", DomainTaskStatus.Prepared));
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            storage.BlockPostWriteRead = true;
+
+            var command = unified.TrySetStatusAsync(
+                "generation-delete",
+                DomainTaskStatus.InProgress,
+                "tester");
+            await storage.PostWriteReadEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            storage.PublishRemoved(storageRevision: 11);
+            await WaitUntilAsync(
+                () => !unified.Tasks.Lookup("generation-delete").HasValue,
+                TimeSpan.FromSeconds(5));
+
+            storage.ReleasePostWriteRead.TrySetResult();
+            var result = await command.WaitAsync(TimeSpan.FromSeconds(5));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.Success).IsTrue();
+                await Assert.That(result.StorageRevision).IsEqualTo(10);
+                await Assert.That(unified.Tasks.Lookup("generation-delete").HasValue).IsFalse();
+            }
+        }, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task OlderRemovalAfterNewerWatcherCreate_DoesNotDeleteTask()
+    {
+        await using var session = SafeHeadlessUnitTestSession.StartNew(typeof(App));
+        await session.DispatchAsync(async () =>
+        {
+            var storage = new GenerationOrderingStorage(CreateTask("generation-create", DomainTaskStatus.Prepared));
+            using var unified = new UnifiedTaskStorage(new TaskTreeManager(storage));
+            await unified.Init();
+            var newer = CreateTask("generation-create", DomainTaskStatus.Completed);
+
+            storage.PublishSaved(newer, storageRevision: 11);
+            await WaitUntilAsync(
+                () => unified.Tasks.Lookup(newer.Id).HasValue &&
+                      unified.Tasks.Lookup(newer.Id).Value.Status == DomainTaskStatus.Completed,
+                TimeSpan.FromSeconds(5));
+            storage.PublishRemoved(storageRevision: 10);
+            await Task.Delay(50);
+
+            await Assert.That(unified.Tasks.Lookup(newer.Id).HasValue).IsTrue();
+            await Assert.That(unified.Tasks.Lookup(newer.Id).Value.Status).IsEqualTo(DomainTaskStatus.Completed);
+        }, CancellationToken.None);
     }
 
     [Test]
@@ -554,6 +613,93 @@ public sealed class UnifiedTaskStorageStatusCommandTests
             }
 
             return CreateGraph(persisted);
+        }
+    }
+
+    private sealed class GenerationOrderingStorage : IStorage, ITaskGraphDiagnosticStorage
+    {
+        private TaskItem? persisted;
+        private int graphReadCount;
+
+        public GenerationOrderingStorage(TaskItem task) => persisted = CloneTask(task);
+
+        public bool BlockPostWriteRead { get; set; }
+        public TaskCompletionSource PostWriteReadEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleasePostWriteRead { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public event EventHandler<TaskStorageUpdateEventArgs>? Updating;
+        public event Action<Exception?>? OnConnectionError
+        {
+            add { }
+            remove { }
+        }
+
+        public Task<TaskItem> Save(TaskItem item)
+        {
+            persisted = CloneTask(item);
+            return Task.FromResult(CloneTask(item));
+        }
+
+        public Task<bool> Remove(string itemId)
+        {
+            persisted = null;
+            return Task.FromResult(true);
+        }
+
+        public Task<TaskItem?> Load(string itemId) =>
+            Task.FromResult(persisted == null ? null : CloneTask(persisted));
+
+        public async IAsyncEnumerable<TaskItem> GetAll()
+        {
+            if (persisted != null)
+            {
+                yield return CloneTask(persisted);
+            }
+
+            await Task.CompletedTask;
+        }
+
+        public Task BulkInsert(IEnumerable<TaskItem> taskItems) => Task.CompletedTask;
+        public Task<bool> Connect() => Task.FromResult(true);
+        public Task Disconnect() => Task.CompletedTask;
+
+        public async Task<TaskGraphReadResult> ReadGraphAsync()
+        {
+            var snapshot = persisted == null ? null : CloneTask(persisted);
+            if (BlockPostWriteRead && Interlocked.Increment(ref graphReadCount) == 2)
+            {
+                PostWriteReadEntered.TrySetResult();
+                await ReleasePostWriteRead.Task;
+            }
+
+            return snapshot == null
+                ? new TaskGraphReadResult([], new Dictionary<string, string>(), [], []) { Revision = 10 }
+                : CreateGraph(snapshot) with { Revision = 10 };
+        }
+
+        public void PublishRemoved(long storageRevision)
+        {
+            var taskId = persisted?.Id ?? "generation-delete";
+            persisted = null;
+            Updating?.Invoke(this, new TaskStorageUpdateEventArgs
+            {
+                Id = taskId,
+                Type = UpdateType.Removed,
+                StorageRevision = storageRevision
+            });
+        }
+
+        public void PublishSaved(TaskItem task, long storageRevision)
+        {
+            persisted = CloneTask(task);
+            Updating?.Invoke(this, new TaskStorageUpdateEventArgs
+            {
+                Id = task.Id,
+                Type = UpdateType.Saved,
+                StorageRevision = storageRevision
+            });
         }
     }
 

--- a/src/Unlimotion.ViewModel/FileDbWatcher.cs
+++ b/src/Unlimotion.ViewModel/FileDbWatcher.cs
@@ -8,18 +8,19 @@ using Unlimotion.TaskTree;
 
 namespace Unlimotion.ViewModel
 {
-    public class FileDbWatcher : IDatabaseWatcher
+    public class FileDbWatcher : IDatabaseWatcher, IRawDatabaseWatcher, IDisposable
     {
         private const string GitFolderName = ".git";
         private const string GitLockPostfix = ".lock";
         private const string GitOrigPostfix = ".orig";
-        private readonly MemoryCache ignoredTasks = MemoryCache.Default;
         private readonly FileSystemWatcher? watcher;
-        private readonly object itLock = new();
         public event EventHandler<DbUpdatedEventArgs>? OnUpdated;
+        public event EventHandler<DbUpdatedEventArgs>? OnRawUpdated;
+        public event EventHandler? OnInvalidated;
         private readonly MemoryCache cache = new("EventThrottlerCache");
         private readonly TimeSpan throttlePeriod = TimeSpan.FromSeconds(1);
         private bool isEnable;
+        private bool isDisposed;
     private readonly INotificationManagerWrapper? _notificationManager;
     private readonly object itLockEnable = new();
 
@@ -27,21 +28,23 @@ namespace Unlimotion.ViewModel
         {
             lock (itLockEnable)
             {
+                if (isDisposed)
+                    return;
                 isEnable = enable;
-                if (watcher != null)
-                {
-                    watcher.EnableRaisingEvents = enable;
-                }
             }
         }
 
         public void ForceUpdateFile(string filename, UpdateType type)
         {
-            OnUpdated?.Invoke(this, new DbUpdatedEventArgs
+            if (isDisposed)
+                return;
+            var args = new DbUpdatedEventArgs
             {
                 Id = filename,
                 Type = type
-            });
+            };
+            OnRawUpdated?.Invoke(this, args);
+            OnUpdated?.Invoke(this, args);
         }
 
         public FileDbWatcher(string path, INotificationManagerWrapper? notificationManager = null)
@@ -63,6 +66,19 @@ namespace Unlimotion.ViewModel
             watcher.Changed += throttle;
             watcher.Created += throttle;
             watcher.Deleted += throttle;
+            watcher.Renamed += (sender, args) =>
+            {
+                RegisterRawUpdate(args.OldName, UpdateType.Removed);
+                RegisterRawUpdate(args.Name, UpdateType.Saved);
+                throttle(sender, new FileSystemEventArgs(
+                    WatcherChangeTypes.Deleted,
+                    Path.GetDirectoryName(args.OldFullPath) ?? string.Empty,
+                    args.OldName ?? string.Empty));
+                throttle(sender, new FileSystemEventArgs(
+                    WatcherChangeTypes.Created,
+                    Path.GetDirectoryName(args.FullPath) ?? string.Empty,
+                    args.Name ?? string.Empty));
+            };
 
             //todo Добавить логер и логировать ошибки
             watcher.Error += OnError;
@@ -73,16 +89,17 @@ namespace Unlimotion.ViewModel
 
         public void AddIgnoredTask(string taskId)
         {
-            lock (itLock)
-            {
-                ignoredTasks.Add(taskId, itLock,  new CacheItemPolicy { SlidingExpiration = TimeSpan.FromSeconds(60) });
-                Debug.WriteLine($"{DateTimeOffset.Now}: ${taskId} is added to ignored");
-            }
+            // Own writes are deduplicated by the storage's confirmed content snapshot.
+            // Do not suppress by file name: an external edit can follow immediately.
+            Debug.WriteLine($"{DateTimeOffset.Now}: ${taskId} was written by this storage");
         }
 
         private void OnError(object sender, ErrorEventArgs e)
         {
+            if (isDisposed)
+                return;
             Debug.WriteLine("Error in FileWatcher");
+            OnInvalidated?.Invoke(this, EventArgs.Empty);
             _notificationManager?.ErrorToast(L10n.Format("FileWatcherError", e.GetException().Message));
 
         }
@@ -92,14 +109,18 @@ namespace Unlimotion.ViewModel
         {
             return (s, e) =>
             {
-                if (!isEnable)
-                    return;
-
                 var fullPath = e.FullPath;
                 
                 if (fullPath.Contains(GitFolderName) ||
                     fullPath.EndsWith(GitOrigPostfix) ||
                     IsStorageServiceArtifact(e.Name))
+                    return;
+
+                RegisterRawUpdate(
+                    e.Name,
+                    e.ChangeType == WatcherChangeTypes.Deleted ? UpdateType.Removed : UpdateType.Saved);
+
+                if (!isEnable)
                     return;
                 
                 if (fullPath.EndsWith(GitLockPostfix)) 
@@ -116,15 +137,6 @@ namespace Unlimotion.ViewModel
         {
             if (!isEnable)
                 return;
-
-            lock (itLock)
-            {
-                var fileInfo = new FileInfo(e.FullPath);
-                if (ignoredTasks.Contains(fileInfo.Name))
-                {
-                    return;
-                }
-            }
 
             switch (e.ChangeType)
             {
@@ -147,6 +159,20 @@ namespace Unlimotion.ViewModel
             Debug.WriteLine($"{DateTimeOffset.Now}: {e.FullPath} {e.ChangeType}.");
         }
 
+        private void RegisterRawUpdate(string? fileName, UpdateType type)
+        {
+            if (isDisposed || string.IsNullOrWhiteSpace(fileName) || IsStorageServiceArtifact(fileName))
+            {
+                return;
+            }
+
+            OnRawUpdated?.Invoke(this, new DbUpdatedEventArgs
+            {
+                Id = fileName,
+                Type = type
+            });
+        }
+
         private static bool IsStorageServiceArtifact(string? fileName) =>
             string.IsNullOrWhiteSpace(fileName) ||
             fileName.Equals(".unlimotion.lock", StringComparison.OrdinalIgnoreCase) ||
@@ -165,6 +191,26 @@ namespace Unlimotion.ViewModel
                     Task.Run(handler);
                 }
             };
+        }
+
+        public void Dispose()
+        {
+            lock (itLockEnable)
+            {
+                if (isDisposed)
+                    return;
+
+                isDisposed = true;
+                isEnable = false;
+            }
+
+            if (watcher != null)
+            {
+                watcher.EnableRaisingEvents = false;
+                watcher.Dispose();
+            }
+
+            cache.Dispose();
         }
     }
 }

--- a/src/Unlimotion.ViewModel/IDatabaseWatcher.cs
+++ b/src/Unlimotion.ViewModel/IDatabaseWatcher.cs
@@ -9,3 +9,9 @@ public interface IDatabaseWatcher
     public void SetEnable(bool enable);
     public void ForceUpdateFile(string filename, UpdateType type);
 }
+
+public interface IRawDatabaseWatcher
+{
+    public event EventHandler<DbUpdatedEventArgs> OnRawUpdated;
+    public event EventHandler OnInvalidated;
+}

--- a/src/Unlimotion.ViewModel/TaskItemViewModel.cs
+++ b/src/Unlimotion.ViewModel/TaskItemViewModel.cs
@@ -71,7 +71,13 @@ namespace Unlimotion.ViewModel
         private readonly HashSet<Task> _pendingSaves = [];
         private readonly HashSet<Task> _pendingWriteProducers = [];
         private readonly CancellationTokenSource _writeProducerLifetime = new();
+        private readonly object _editorStateLock = new();
         private bool _acceptingSaves = true;
+        private long _appliedStorageRevision;
+        private long _editableRevision;
+        private long _persistedEditableRevision;
+        private TaskItem? _latestEditorSnapshot;
+        private int _statusOperationCount;
         private Task? _sealedPendingSavesTask;
         private bool _isUpdatingFromModel;
         public bool IsHighlighted { get; set; }
@@ -83,7 +89,22 @@ namespace Unlimotion.ViewModel
         public static IScheduler? InProgressElapsedRefreshScheduler { get; set; }
         public TimeSpan PropertyChangedThrottleTimeSpanDefault { get; set; } = DefaultThrottleTime;
         private bool IsInitialized => IsInitializedProvider?.Invoke() ?? true;
-        private bool CanAutosave => IsInitialized && !_isUpdatingFromModel;
+        private bool CanTrackEditableChange => IsInitialized && !_isUpdatingFromModel;
+
+        private bool CanAutosave =>
+            CanTrackEditableChange &&
+            Volatile.Read(ref _statusOperationCount) == 0;
+
+        private bool HasPendingEditableChanges
+        {
+            get
+            {
+                lock (_editorStateLock)
+                {
+                    return _editableRevision > _persistedEditableRevision;
+                }
+            }
+        }
 
         private void Init(ITaskStorage taskStorage)
         {
@@ -93,7 +114,13 @@ namespace Unlimotion.ViewModel
             SetDurationCommands = new SetDurationCommands(this);
             SaveItemCommand = ReactiveCommand.CreateFromTask(async () =>
             {
-                 await taskStorage.Update(this);
+                var pendingEditor = CapturePendingEditorState();
+                var revision = pendingEditor?.Revision ?? GetEditableRevision();
+                var snapshot = pendingEditor is { } editor
+                    ? MergeAuthoritativeStateWithEditorFields(Model, editor.Snapshot)
+                    : TaskItemSnapshot.Clone(Model);
+                await taskStorage.Update(snapshot);
+                MarkEditableRevisionPersisted(revision);
             });
             var saveExceptionSubscription = SaveItemCommand.ThrownExceptions
                 .Subscribe(new ObservableExceptionHandler(NotificationManager));
@@ -218,8 +245,10 @@ namespace Unlimotion.ViewModel
                                 return false;
                         }
                     })
-                    .Where(_ => CanAutosave)
-                    .Throttle(PropertyChangedThrottleTimeSpanDefault);
+                    .Where(_ => CanTrackEditableChange)
+                    .Do(_ => MarkEditableChanged())
+                    .Throttle(PropertyChangedThrottleTimeSpanDefault)
+                    .Where(_ => CanAutosave);
 
                 propertyChanged
                     .Subscribe(_ => ExecuteSaveCommand())
@@ -312,8 +341,10 @@ namespace Unlimotion.ViewModel
 
             var saveSubscription = repeaterChanges
                 .Where(changed => IsRepeaterPatternPersistenceProperty(changed.EventArgs.PropertyName))
-                .Where(_ => CanAutosave)
+                .Where(_ => CanTrackEditableChange)
+                .Do(_ => MarkEditableChanged())
                 .Throttle(TimeSpan.FromSeconds(2))
+                .Where(_ => CanAutosave)
                 .Subscribe(_ => ExecuteSaveCommand());
 
             _repeaterPropertyChangedSubscription.Disposable = new CompositeDisposable(markerSubscription, saveSubscription);
@@ -1058,6 +1089,39 @@ namespace Unlimotion.ViewModel
             RefreshStatusOptions();
         }
 
+        public bool Update(TaskItem taskItem, long storageRevision)
+        {
+            if (!TryAcceptStorageRevision(storageRevision))
+            {
+                return false;
+            }
+
+            Update(taskItem);
+            return true;
+        }
+
+        public bool TryAcceptStorageRevision(long storageRevision)
+        {
+            if (storageRevision <= 0)
+            {
+                return true;
+            }
+
+            while (true)
+            {
+                var current = Interlocked.Read(ref _appliedStorageRevision);
+                if (storageRevision < current)
+                {
+                    return false;
+                }
+
+                if (Interlocked.CompareExchange(ref _appliedStorageRevision, storageRevision, current) == current)
+                {
+                    return true;
+                }
+            }
+        }
+
         public static void SynchronizeCollections(ObservableCollection<string> observableCollection, List<string> list)
         {
             if (observableCollection == null)
@@ -1123,6 +1187,11 @@ namespace Unlimotion.ViewModel
 
         private void OnCompletionCriteriaChanged()
         {
+            if (CanTrackEditableChange)
+            {
+                MarkEditableChanged();
+            }
+
             RegisterCompletionCriteriaPropertyChangedSubscription();
             RefreshStatusOptions();
             SaveCompletionCriteriaIfNeeded();
@@ -1143,6 +1212,9 @@ namespace Unlimotion.ViewModel
                                      change.EventArgs.PropertyName == nameof(TaskCompletionCriterion.IsSatisfied))
                     .Publish();
 
+                subscriptions.Add(criterionChanges
+                    .Where(_ => CanTrackEditableChange)
+                    .Subscribe(_ => MarkEditableChanged()));
                 subscriptions.Add(criterionChanges
                     .ObserveOn(RxSchedulers.MainThreadScheduler)
                     .Subscribe(_ => RefreshStatusOptions()));
@@ -1189,14 +1261,33 @@ namespace Unlimotion.ViewModel
             lock (_pendingSavesLock)
             {
                 _acceptingSaves = false;
+                var pendingWrites = _pendingSaves.Concat(_pendingWriteProducers).ToArray();
                 sealedSnapshot = _sealedPendingSavesTask ??=
-                    _pendingSaves.Count == 0 && _pendingWriteProducers.Count == 0
-                    ? Task.CompletedTask
-                    : Task.WhenAll(_pendingSaves.Concat(_pendingWriteProducers).ToArray());
+                    SealPendingSavesCoreAsync(pendingWrites);
             }
 
             _writeProducerLifetime.Cancel();
             return sealedSnapshot;
+        }
+
+        private async Task SealPendingSavesCoreAsync(IReadOnlyCollection<Task> pendingWrites)
+        {
+            if (pendingWrites.Count > 0)
+            {
+                await Task.WhenAll(pendingWrites);
+            }
+
+            // Throttled edits may not have started a SaveItemCommand yet. Once the producer
+            // boundary is closed, persist that stable final revision before allowing teardown.
+            await DrainPendingEditorChangesAsync();
+
+            lock (_editorStateLock)
+            {
+                if (_editableRevision > _persistedEditableRevision)
+                {
+                    throw new InvalidOperationException("The task still has unsaved editor changes.");
+                }
+            }
         }
 
         public Task WaitForPendingSavesAsync()
@@ -1280,6 +1371,8 @@ namespace Unlimotion.ViewModel
             Func<Task<TaskOperationResult>> execute,
             DomainTaskStatus? requestedStatus)
         {
+            var editorWriteCompletion = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
             Task<TaskOperationResult> transitionTask;
             lock (_pendingSavesLock)
             {
@@ -1293,47 +1386,246 @@ namespace Unlimotion.ViewModel
                             requestedStatus)));
                 }
 
-                transitionTask = ExecuteStatusOperationAsync(execute, requestedStatus);
+                _pendingWriteProducers.Add(editorWriteCompletion.Task);
+                var pendingSaves = _pendingSaves.ToArray();
+                transitionTask = ExecuteStatusOperationAsync(
+                    execute,
+                    requestedStatus,
+                    pendingSaves,
+                    editorWriteCompletion);
                 _pendingSaves.Add(transitionTask);
             }
 
+            _ = ObserveWriteProducerFailureAsync(editorWriteCompletion.Task);
             _ = ObserveSaveCompletionAsync(transitionTask);
             return transitionTask;
         }
 
         private async Task<TaskOperationResult> ExecuteStatusOperationAsync(
             Func<Task<TaskOperationResult>> execute,
-            DomainTaskStatus? requestedStatus)
+            DomainTaskStatus? requestedStatus,
+            IReadOnlyList<Task> pendingSaves,
+            TaskCompletionSource editorWriteCompletion)
         {
-            TaskOperationResult result;
+            Interlocked.Increment(ref _statusOperationCount);
+            var editorDrainFailed = false;
+            Exception? editorDrainException = null;
+            long editorDrainRevision = 0;
             try
             {
-                result = await execute();
+                TaskOperationResult? result = null;
+                try
+                {
+                    if (pendingSaves.Count > 0)
+                    {
+                        await Task.WhenAll(pendingSaves);
+                    }
+
+                    await DrainPendingEditorChangesAsync();
+                }
+                catch (Exception exception)
+                {
+                    editorDrainFailed = true;
+                    editorDrainException = exception;
+                    editorDrainRevision = GetEditableRevision();
+                    result = TaskOperationResult.Denied(
+                        TaskOperationDeniedReason.Create(
+                            TaskOperationDeniedKind.StorageFailed,
+                            exception.Message,
+                            Id,
+                            requestedStatus));
+                }
+
+                if (result is null)
+                {
+                    try
+                    {
+                        result = await execute();
+                    }
+                    catch (Exception exception)
+                    {
+                        result = TaskOperationResult.Denied(
+                            TaskOperationDeniedReason.Create(
+                                TaskOperationDeniedKind.StorageFailed,
+                                exception.Message,
+                                Id,
+                                requestedStatus));
+                    }
+
+                    if (result.AuthoritativeTask is { } authoritativeTask &&
+                        string.Equals(authoritativeTask.Id, Id, StringComparison.Ordinal))
+                    {
+                        var pendingEditor = CapturePendingEditorState();
+                        var taskToApply = pendingEditor is { } editor
+                            ? MergeAuthoritativeStateWithEditorFields(authoritativeTask, editor.Snapshot)
+                            : authoritativeTask;
+                        Update(taskToApply, result.StorageRevision);
+                    }
+
+                    try
+                    {
+                        await DrainPendingEditorChangesAsync();
+                    }
+                    catch (Exception exception)
+                    {
+                        // The status result has already been confirmed by storage. Keep that result
+                        // and leave the editor revision dirty so an explicit later save can retry it.
+                        editorDrainFailed = true;
+                        editorDrainException = exception;
+                        editorDrainRevision = GetEditableRevision();
+                    }
+                }
+
+                if (!result.Success)
+                {
+                    NotificationManager?.ErrorToast(GetStatusOperationFailureMessage(result));
+                }
+                else if (editorDrainFailed)
+                {
+                    NotificationManager?.ErrorToast(L10n.Get("TaskStatusSaveFailed"));
+                }
+
+                RefreshStatusOptions();
+                OnPropertyChanged(nameof(StatusOption));
+                return result;
             }
-            catch (Exception exception)
+            finally
             {
-                result = TaskOperationResult.Denied(
-                    TaskOperationDeniedReason.Create(
-                        TaskOperationDeniedKind.StorageFailed,
-                        exception.Message,
-                        Id,
-                        requestedStatus));
+                CompleteEditorWriteProducer(
+                    editorWriteCompletion,
+                    editorDrainException,
+                    editorDrainRevision);
+                if (Interlocked.Decrement(ref _statusOperationCount) == 0 &&
+                    !editorDrainFailed &&
+                    HasPendingEditableChanges &&
+                    _acceptingSaves)
+                {
+                    ExecuteSaveCommand();
+                }
+            }
+        }
+
+        private async Task DrainPendingEditorChangesAsync()
+        {
+            while (CapturePendingEditorState() is { } pendingEditor)
+            {
+                var editorSnapshot = MergeAuthoritativeStateWithEditorFields(
+                    Model,
+                    pendingEditor.Snapshot);
+                await _taskStorage.Update(editorSnapshot);
+                MarkEditableRevisionPersisted(pendingEditor.Revision);
+            }
+        }
+
+        private void CompleteEditorWriteProducer(
+            TaskCompletionSource completion,
+            Exception? failure,
+            long failedRevision)
+        {
+            var unresolvedFailure = failure is not null &&
+                                    !IsEditableRevisionPersisted(failedRevision);
+            if (!unresolvedFailure)
+            {
+                completion.TrySetResult();
+            }
+            else
+            {
+                completion.TrySetException(failure!);
             }
 
-            if (result.AuthoritativeTask is { } authoritativeTask &&
-                string.Equals(authoritativeTask.Id, Id, StringComparison.Ordinal))
+            lock (_pendingSavesLock)
             {
-                Update(authoritativeTask);
+                _pendingWriteProducers.Remove(completion.Task);
             }
+        }
 
-            if (!result.Success)
+        private bool IsEditableRevisionPersisted(long revision)
+        {
+            lock (_editorStateLock)
             {
-                NotificationManager?.ErrorToast(GetStatusOperationFailureMessage(result));
+                return revision <= _persistedEditableRevision;
             }
+        }
 
-            RefreshStatusOptions();
-            OnPropertyChanged(nameof(StatusOption));
-            return result;
+        private static async Task ObserveWriteProducerFailureAsync(Task producer)
+        {
+            try
+            {
+                await producer;
+            }
+            catch
+            {
+                // SealPendingSaves still observes the original faulted task. This observer only
+                // prevents an abandoned producer from surfacing as an unobserved exception.
+            }
+        }
+
+        private static TaskItem MergeAuthoritativeStateWithEditorFields(
+            TaskItem authoritative,
+            TaskItem editor)
+        {
+            var merged = TaskItemSnapshot.Clone(authoritative);
+            var editorClone = TaskItemSnapshot.Clone(editor);
+            merged.Title = editorClone.Title;
+            merged.Description = editorClone.Description;
+            merged.PlannedBeginDateTime = editorClone.PlannedBeginDateTime;
+            merged.PlannedEndDateTime = editorClone.PlannedEndDateTime;
+            merged.PlannedDuration = editorClone.PlannedDuration;
+            merged.CompletionCriteria = editorClone.CompletionCriteria;
+            merged.Repeater = editorClone.Repeater;
+            merged.Importance = editorClone.Importance;
+            merged.Wanted = editorClone.Wanted;
+            return merged;
+        }
+
+        private void MarkEditableChanged()
+        {
+            lock (_pendingSavesLock)
+            {
+                if (!_acceptingSaves)
+                {
+                    return;
+                }
+
+                var snapshot = TaskItemSnapshot.Clone(Model);
+                lock (_editorStateLock)
+                {
+                    _editableRevision++;
+                    _latestEditorSnapshot = snapshot;
+                }
+            }
+        }
+
+        private (long Revision, TaskItem Snapshot)? CapturePendingEditorState()
+        {
+            lock (_editorStateLock)
+            {
+                if (_editableRevision <= _persistedEditableRevision || _latestEditorSnapshot is null)
+                {
+                    return null;
+                }
+
+                return (_editableRevision, TaskItemSnapshot.Clone(_latestEditorSnapshot));
+            }
+        }
+
+        private long GetEditableRevision()
+        {
+            lock (_editorStateLock)
+            {
+                return _editableRevision;
+            }
+        }
+
+        private void MarkEditableRevisionPersisted(long revision)
+        {
+            lock (_editorStateLock)
+            {
+                if (_persistedEditableRevision < revision)
+                {
+                    _persistedEditableRevision = revision;
+                }
+            }
         }
 
         private TaskStatusTransitionFacts CreateStatusTransitionFacts() => new(

--- a/src/Unlimotion/FileStorage.cs
+++ b/src/Unlimotion/FileStorage.cs
@@ -2,16 +2,25 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using Unlimotion.Services;
+using Unlimotion.Domain;
 using Unlimotion.TaskTree;
 using Unlimotion.ViewModel;
 using L10n = Unlimotion.ViewModel.Localization.Localization;
 
 namespace Unlimotion;
 
-public class FileStorage : global::Unlimotion.Storage.FileTaskStorage
+public class FileStorage : global::Unlimotion.Storage.FileTaskStorage, IDisposable
 {
     private readonly IDatabaseWatcher? _dbWatcher;
+    private readonly ConcurrentDictionary<string, PendingFileChange> _pendingFileChanges =
+        new(StringComparer.OrdinalIgnoreCase);
+    private long _nextPendingGeneration;
+    private bool _disposed;
 
     public FileStorage(string path, bool watcher = false, INotificationManagerWrapper? notificationManager = null)
         : base(new global::Unlimotion.Storage.FileTaskStorageOptions { Path = PreparePath(path) })
@@ -39,11 +48,37 @@ public class FileStorage : global::Unlimotion.Storage.FileTaskStorage
         var taskId = TryGetTaskIdBySourceFileName(e.Id, out var mappedTaskId)
             ? mappedTaskId
             : e.Id;
-        var loaded = await Load(taskId, forced: true);
+        RemovePendingFileChange(e.Id);
+        var refresh = await WithDirectoryLockAsync(async () =>
+        {
+            var revisionBefore = LiveGraphRevision;
+            var loaded = await Load(taskId, forced: true);
+            var sourcePath = System.IO.Path.Combine(Path, e.Id);
+            var physicallyAbsent = !File.Exists(sourcePath) || new FileInfo(sourcePath).Length == 0;
+            return new FileRefreshResult(
+                loaded,
+                physicallyAbsent,
+                revisionBefore,
+                LiveGraphRevision);
+        });
+
+        if (refresh.RevisionBefore > 0 && refresh.RevisionBefore == refresh.RevisionAfter)
+        {
+            return;
+        }
+
+        if (refresh.Task == null && !refresh.PhysicallyAbsent)
+        {
+            // Keep the existing projection for corrupt or temporarily unreadable content.
+            // The live graph records the diagnostic and blocks writes until the file is repaired.
+            return;
+        }
+
         RaiseUpdating(new TaskStorageUpdateEventArgs
         {
-            Id = loaded?.Id ?? taskId,
-            Type = e.Type
+            Id = refresh.Task?.Id ?? taskId,
+            Type = refresh.Task == null ? UpdateType.Removed : UpdateType.Saved,
+            StorageRevision = refresh.RevisionAfter
         });
     }
 
@@ -53,8 +88,39 @@ public class FileStorage : global::Unlimotion.Storage.FileTaskStorage
     protected override void OnBeforeRemove(string taskId, string filePath) =>
         _dbWatcher?.AddIgnoredTask(System.IO.Path.GetFileName(filePath));
 
+    public override Task<T> WithWriteLockAsync<T>(Func<Task<T>> operation) =>
+        WithDirectoryLockAsync(async () =>
+        {
+            await EnsureLiveGraphReadyWithinWriteLockAsync();
+            await DrainPendingFileChangesAsync();
+            return await operation();
+        });
+
+    public Task<TaskGraphReadResult> SynchronizePendingFileChangesAsync() =>
+        WithDirectoryLockAsync(async () =>
+        {
+            await EnsureLiveGraphReadyWithinWriteLockAsync();
+            await DrainPendingFileChangesAsync();
+            return await ReadGraphAsync();
+        });
+
     private void SubscribeToWatcher(IDatabaseWatcher watcher)
     {
+        if (watcher is IRawDatabaseWatcher rawWatcher)
+        {
+            rawWatcher.OnInvalidated += (_, _) => InvalidateLiveGraph();
+            rawWatcher.OnRawUpdated += (_, args) =>
+            {
+                if (IsTaskFile(args.Id))
+                {
+                    var change = new PendingFileChange(
+                        Interlocked.Increment(ref _nextPendingGeneration),
+                        args.Type);
+                    _pendingFileChanges.AddOrUpdate(args.Id, change, (_, _) => change);
+                }
+            };
+        }
+
         watcher.OnUpdated += async (_, args) =>
         {
             try
@@ -71,6 +137,68 @@ public class FileStorage : global::Unlimotion.Storage.FileTaskStorage
             }
         };
     }
+
+    private async Task DrainPendingFileChangesAsync()
+    {
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            var pending = _pendingFileChanges.ToArray();
+            if (pending.Length == 0)
+            {
+                return;
+            }
+
+            foreach (var entry in pending)
+            {
+                if (!RemovePendingFileChange(entry))
+                {
+                    continue;
+                }
+
+                var fileName = entry.Key;
+                var taskId = TryGetTaskIdBySourceFileName(fileName, out var mappedTaskId)
+                    ? mappedTaskId
+                    : fileName;
+                await Load(taskId, forced: true);
+            }
+        }
+
+        if (!_pendingFileChanges.IsEmpty)
+        {
+            throw new IOException("Task files keep changing while preparing a graph command.");
+        }
+    }
+
+    private void RemovePendingFileChange(string fileName)
+    {
+        if (_pendingFileChanges.TryGetValue(fileName, out var pending))
+        {
+            RemovePendingFileChange(new KeyValuePair<string, PendingFileChange>(fileName, pending));
+        }
+    }
+
+    private bool RemovePendingFileChange(KeyValuePair<string, PendingFileChange> entry) =>
+        ((ICollection<KeyValuePair<string, PendingFileChange>>)_pendingFileChanges).Remove(entry);
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        (_dbWatcher as IDisposable)?.Dispose();
+        _pendingFileChanges.Clear();
+    }
+
+    private sealed record PendingFileChange(long Generation, UpdateType Type);
+
+    private sealed record FileRefreshResult(
+        TaskItem? Task,
+        bool PhysicallyAbsent,
+        long RevisionBefore,
+        long RevisionAfter);
 
     private static string PreparePath(string path)
     {

--- a/src/Unlimotion/UnifiedTaskStorage.cs
+++ b/src/Unlimotion/UnifiedTaskStorage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -26,6 +27,8 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
     private readonly TaskItemViewModelContext? taskContext;
     private readonly SemaphoreSlim statusCommandGate = new(1, 1);
     private readonly CancellationTokenSource cacheLifetime = new();
+    private readonly ConcurrentDictionary<string, long> appliedStorageRevisions =
+        new(StringComparer.Ordinal);
     private SynchronizationContext? cacheSynchronizationContext;
     private volatile bool disposed;
 
@@ -53,17 +56,23 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
         StatusModelMigrationWasApplied = false;
         Tasks.Edit(operations => operations.Clear());
         TaskTreeManager.Storage.Updating -= TaskStorageOnUpdating;
+        if (TaskTreeManager.Storage is FileStorage initializingFileStorage &&
+            initializingFileStorage.Watcher is IRawDatabaseWatcher)
+        {
+            initializingFileStorage.Watcher?.SetEnable(false);
+        }
 
         var initialTaskViews = await BuildInitialTaskViewsAsync();
         var shouldYieldBetweenBatches = SynchronizationContext.Current != null;
         await AddInitialTasksToCacheAsync(initialTaskViews, shouldYieldBetweenBatches);
 
-        if (TaskTreeManager.Storage is FileStorage initFileStorage)
+        TaskTreeManager.Storage.Updating += TaskStorageOnUpdating;
+        if (TaskTreeManager.Storage is FileStorage initFileStorage &&
+            initFileStorage.Watcher is IRawDatabaseWatcher)
         {
             initFileStorage.Watcher?.SetEnable(true);
+            await ReconcileFileStorageSnapshotAsync(initFileStorage);
         }
-
-        TaskTreeManager.Storage.Updating += TaskStorageOnUpdating;
 
         OnInited();
     }
@@ -79,7 +88,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
         cacheLifetime.Cancel();
         if (TaskTreeManager.Storage is FileStorage fileStorage)
         {
-            fileStorage.Watcher?.SetEnable(false);
+            fileStorage.Dispose();
         }
 
         TaskTreeManager.Storage.Updating -= TaskStorageOnUpdating;
@@ -101,6 +110,11 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
                 var forceReverseLinksRecheck = ShouldForceReverseLinkRecheck(fileStorage);
                 var reverseLinksResult = await MigrateReverseLinks(TaskTreeManager, forceReverseLinksRecheck);
                 await MigrateIsCanBeCompleted(TaskTreeManager, forceRecheck: reverseLinksResult.AnyChanges);
+                if (fileStorage.Watcher is IRawDatabaseWatcher)
+                {
+                    await fileStorage.EnableLiveGraphAsync();
+                    await fileStorage.SynchronizePendingFileChangesAsync();
+                }
             }
 
             var initialTasks = new List<TaskItem>();
@@ -117,6 +131,47 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
             new TaskRelationsIndex().Rebuild(initialTaskViews);
             return initialTaskViews;
         });
+    }
+
+    private async Task ReconcileFileStorageSnapshotAsync(FileStorage fileStorage)
+    {
+        var previousGraph = await fileStorage.ReadGraphAsync();
+        var graph = await fileStorage.SynchronizePendingFileChangesAsync();
+        await RunOnCacheSynchronizationContextAsync(() =>
+        {
+            var taskIds = graph.TasksById.Keys.ToHashSet(StringComparer.Ordinal);
+            var changed = false;
+            foreach (var task in graph.TasksById.Values)
+            {
+                changed |= HydrateCache(task, create: true, graph.Revision);
+            }
+
+            // A load error means the physical file still exists but cannot be projected safely.
+            // Preserve its last visible VM; write commands remain blocked by the graph diagnostic.
+            var errorFiles = graph.LoadErrors
+                .Select(static error => error.File)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var idsWithUnreadableSources = previousGraph.FilesByTaskId
+                .Where(pair => errorFiles.Contains(pair.Value))
+                .Select(static pair => pair.Key)
+                .ToHashSet(StringComparer.Ordinal);
+            var removedIds = Tasks.Keys
+                .Where(id => !taskIds.Contains(id) && !idsWithUnreadableSources.Contains(id))
+                .ToArray();
+            var acceptedRemovedIds = removedIds
+                .Where(id => TryAcceptStorageRevision(id, graph.Revision))
+                .ToArray();
+            if (acceptedRemovedIds.Length > 0)
+            {
+                RemoveTasksFromCache(acceptedRemovedIds);
+                changed = true;
+            }
+
+            if (changed)
+            {
+                RefreshRelations();
+            }
+        }).ConfigureAwait(false);
     }
 
     private async Task AddInitialTasksToCacheAsync(
@@ -337,6 +392,24 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
 
         if (result.DeniedReason?.Kind == TaskOperationDeniedKind.OutcomeUnknown)
         {
+            if (result.ChangedTasks.Count > 0)
+            {
+                await RunOnCacheSynchronizationContextAsync(() =>
+                {
+                    var hydrated = false;
+                    foreach (var task in result.ChangedTasks)
+                    {
+                        hydrated |= HydrateCache(task, create: true, result.StorageRevision);
+                    }
+
+                    if (hydrated)
+                    {
+                        RefreshRelations();
+                    }
+                }).ConfigureAwait(false);
+                return;
+            }
+
             TaskItem? reloadedTask = null;
             try
             {
@@ -352,7 +425,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
             {
                 await RunOnCacheSynchronizationContextAsync(() =>
                 {
-                    if (HydrateCache(reloadedTask, create: false))
+                    if (HydrateCache(reloadedTask, create: false, result.StorageRevision))
                     {
                         RefreshRelations();
                     }
@@ -387,7 +460,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
             var hydrated = false;
             foreach (var (task, create) in tasksToHydrate.Values)
             {
-                hydrated |= HydrateCache(task, create);
+                hydrated |= HydrateCache(task, create, result.StorageRevision);
             }
 
             if (hydrated)
@@ -1088,7 +1161,7 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
                 var taskItem = await TaskTreeManager.Storage.Load(e.Id);
                 if (taskItem?.Id != null)
                 {
-                    UpdateCache(taskItem, true);
+                    HydrateCache(taskItem, create: true, e.StorageRevision);
                     RefreshRelations();
                 }
                 break;
@@ -1096,8 +1169,14 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
                 // Handle file storage ID mapping
                 var taskId = isFileStorage ? new FileInfo(e.Id).Name : e.Id;
                 var deletedItem = Tasks.Lookup(taskId);
-                if (deletedItem.HasValue)
-                    await Delete(deletedItem.Value, false);
+                if (TryAcceptStorageRevision(taskId, e.StorageRevision))
+                {
+                    if (deletedItem.HasValue)
+                    {
+                        RemoveTasksFromCache([taskId]);
+                        RefreshRelations();
+                    }
+                }
                 break;
             default:
                 throw new ArgumentOutOfRangeException();
@@ -1124,23 +1203,59 @@ public class UnifiedTaskStorage : ITaskStorage, IDisposable
         HydrateCache(task, create);
     }
 
-    private bool HydrateCache(TaskItem task, bool create)
+    private bool HydrateCache(TaskItem task, bool create, long storageRevision = 0)
     {
+        if (!TryAcceptStorageRevision(task.Id, storageRevision))
+        {
+            return false;
+        }
+
         var vm = Tasks.Lookup(task.Id);
 
         if (vm.HasValue)
         {
-            vm.Value.Update(task);
-            return true;
+            return vm.Value.Update(task, storageRevision);
         }
         else if (create)
         {
             vm = CreateTaskViewModel(task);
+            vm.Value.TryAcceptStorageRevision(storageRevision);
             Tasks.AddOrUpdate(vm.Value);
             return true;
         }
 
         return false;
+    }
+
+    private bool TryAcceptStorageRevision(string taskId, long storageRevision)
+    {
+        if (storageRevision <= 0)
+        {
+            return true;
+        }
+
+        while (true)
+        {
+            if (!appliedStorageRevisions.TryGetValue(taskId, out var current))
+            {
+                if (appliedStorageRevisions.TryAdd(taskId, storageRevision))
+                {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (storageRevision < current)
+            {
+                return false;
+            }
+
+            if (appliedStorageRevisions.TryUpdate(taskId, storageRevision, current))
+            {
+                return true;
+            }
+        }
     }
 
     private TaskItemViewModel CreateTaskViewModel(

--- a/tests/Unlimotion.UiTests.Headless/Tests/HeadlessSessionStorageLifecycleTests.cs
+++ b/tests/Unlimotion.UiTests.Headless/Tests/HeadlessSessionStorageLifecycleTests.cs
@@ -11,11 +11,10 @@ namespace Unlimotion.UiTests.Headless.Tests;
 public sealed class HeadlessSessionStorageLifecycleTests
 {
     private const int DelayedWatcherCycleCount = 8;
-    private static readonly TimeSpan EventDeliveryTimeout = TimeSpan.FromSeconds(2);
     private static readonly TimeSpan ThrottleBoundary = TimeSpan.FromMilliseconds(1_500);
 
     [Test]
-    public async Task DelayedWatcherEvent_AfterDispose_DoesNotCrashHost()
+    public async Task DelayedWatcherEvent_AfterDispose_IsIgnoredAndDoesNotCrashHost()
     {
         var currentTaskId = UnlimotionAppLaunchHost.GetCurrentTaskId(
             UnlimotionAutomationScenario.ReadmeDemo,
@@ -57,7 +56,8 @@ public sealed class HeadlessSessionStorageLifecycleTests
 
                 await Task.Delay(TimeSpan.FromMilliseconds(25));
                 state.Watcher.ForceUpdateFile(currentTaskId, UpdateType.Removed);
-                await updateObserved.Task.WaitAsync(EventDeliveryTimeout);
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                await Assert.That(updateObserved.Task.IsCompleted).IsFalse();
             }
             finally
             {


### PR DESCRIPTION
## Summary

На текущем `main` смена статуса могла ждать полного перечитывания файлов всех задач. Кроме того, немедленное завершение могло обогнать throttled-сохранение полей редактора: последующая Unified hydration заменяла живую модель устаревшими данными с диска, из-за чего пропадали название, дата начала и повторение, а следующая задача не создавалась.

PR переводит статусные команды на live graph, принадлежащий storage, и сохраняет editor-owned поля на всём жизненном цикле смены статуса.

## Changes

- `FileTaskStorage` хранит согласованный граф задач и обновляет его по raw watcher events, targeted reload, успешным записям, revisions и tombstones.
- Unified storage учитывает source-lifetime revisions, поэтому устаревший результат команды не перезаписывает более новое watcher-состояние.
- Immutable editor snapshots сохраняются до и после статусной команды, а также при lifecycle sealing.
- После hydration авторитетные status/history объединяются с актуальными полями редактора.
- При завершении сразу после ввода названия, даты начала и повторения создаётся следующая повторяющаяся задача.
- Добавлены diagnostics и детерминированные race/lifecycle/file-backed/ViewModel/status-picker regression tests.
- Добавлена утверждённая спека с Post-EXEC evidence.

## Validation

- Сборка `Unlimotion.Test`: прошла.
- Полный Main: **932/932**, 0 failed, 0 skipped (22m 18.500s).
- Полный Headless: **38/38** (2m 10.083s).
- Targeted suites:
  - FileStorage status: 22/22
  - TaskItemViewModel status: 24/24
  - TaskStatusPicker UI: 7/7
  - Unified status: 14/14
  - Task card layout UI: 20/20
  - Completion-criterion throttle: 1/1
- Реальный file-backed regression подтверждает: немедленный Complete сохраняет название, дату начала и daily repeater и создаёт следующую Prepared-задачу.
- `git diff --check`: чисто; только предупреждения о будущей LF-to-CRLF нормализации working tree.
- Независимый Post-EXEC review: PASS, открытых findings нет.

UI video не записывалось, потому что PR не меняет layout или визуальный interaction flow, а исправляет persistence и ordering за существующим status picker. Next-best evidence: детерминированный Headless picker flow, реальный file-backed recurrence regression и local-only desktop walkthrough, описанный в спеке.

## Risks / Rollback

Основной риск — конкуренция watcher updates, статусных команд, throttled editor saves и disposal. Границы покрыты revision/tombstone guards и детерминированными race/lifecycle tests. Для отката достаточно revert коммита `4f16bb3`.

## Links

- Spec: `specs/2026-08-31-status-transition-latency.md`
