### PR TITLE
feat(cli): publish tool to NuGet

### DIFF
--- a/.github/workflows/nuget-cli.yml
+++ b/.github/workflows/nuget-cli.yml
@@ -1,0 +1,189 @@
+name: Publish Unlimotion CLI to NuGet
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nuget-cli-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  DOTNET_NOLOGO: "1"
+  NUGET_SOURCE: https://api.nuget.org/v3/index.json
+
+jobs:
+  publish:
+    if: ${{ !github.event.release.draft && !github.event.release.prerelease }}
+    name: Validate and publish CLI package
+    runs-on: windows-latest
+    timeout-minutes: 35
+
+    steps:
+    - name: Checkout release tag
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.release.tag_name }}
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Setup .NET 10 SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Validate release source and package version
+      id: release
+      shell: pwsh
+      run: |
+        $tag = '${{ github.event.release.tag_name }}'
+        if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+)$') {
+          throw "CLI publishing requires a stable vMAJOR.MINOR.PATCH release tag; received '$tag'."
+        }
+
+        $version = $Matches.version
+        [xml]$project = Get-Content -Raw 'src/Unlimotion.Cli/Unlimotion.Cli.csproj'
+        $projectVersion = [string]$project.Project.PropertyGroup.Version
+        if ($projectVersion -ne $version) {
+          throw "Release tag version '$version' does not match Unlimotion.Cli version '$projectVersion'."
+        }
+
+        git fetch origin main:refs/remotes/origin/main
+        git merge-base --is-ancestor HEAD origin/main
+        if ($LASTEXITCODE -ne 0) {
+          throw "Release tag '$tag' is not reachable from origin/main; refusing to publish a feature or detached commit."
+        }
+
+        "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Prepare local NuGet feed directory
+      shell: pwsh
+      run: New-Item -ItemType Directory -Force artifacts/nuget-local | Out-Null
+
+    - name: Run CLI regression tests
+      shell: pwsh
+      run: >-
+        dotnet run --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --
+        --treenode-filter "/*/*/TaskDirectoryResolverTests/*"
+        --maximum-parallel-tests 1 --output Detailed
+
+    - name: Run full regression suite
+      shell: pwsh
+      run: >-
+        dotnet run --project src/Unlimotion.Test/Unlimotion.Test.csproj -c Release --
+        --maximum-parallel-tests 1 --output Detailed
+
+    - name: Build CLI
+      shell: pwsh
+      run: dotnet build src/Unlimotion.Cli/Unlimotion.Cli.csproj -c Release --no-restore
+
+    - name: Pack CLI
+      id: pack
+      shell: pwsh
+      run: |
+        $output = Join-Path $env:RUNNER_TEMP 'unlimotion-cli-package'
+        New-Item -ItemType Directory -Force $output | Out-Null
+        dotnet pack src/Unlimotion.Cli/Unlimotion.Cli.csproj -c Release --no-build -o $output
+        $package = Join-Path $output "Unlimotion.Cli.${{ steps.release.outputs.version }}.nupkg"
+        if (-not (Test-Path -LiteralPath $package)) {
+          throw "Expected CLI package was not created: $package"
+        }
+
+        "package=$package" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+    - name: Inspect package contract
+      shell: pwsh
+      run: |
+        $package = '${{ steps.pack.outputs.package }}'
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $archive = [System.IO.Compression.ZipFile]::OpenRead($package)
+        try {
+          $names = @($archive.Entries | ForEach-Object FullName)
+          $expectedFiles = @(
+            'License.txt',
+            'README.md',
+            'tools/net10.0/any/DotnetToolSettings.xml',
+            'tools/net10.0/any/Unlimotion.Cli.dll',
+            'tools/net10.0/any/Unlimotion.Cli.runtimeconfig.json')
+          $missing = @($expectedFiles | Where-Object { $_ -notin $names })
+          if ($missing.Count -gt 0) {
+            throw "CLI package is missing required entries: $($missing -join ', ')"
+          }
+
+          $nuspec = $archive.Entries | Where-Object FullName -eq 'Unlimotion.Cli.nuspec'
+          if ($null -eq $nuspec) {
+            throw 'CLI package has no Unlimotion.Cli.nuspec.'
+          }
+
+          $reader = [System.IO.StreamReader]::new($nuspec.Open())
+          try {
+            [xml]$manifest = $reader.ReadToEnd()
+          }
+          finally {
+            $reader.Dispose()
+          }
+
+          $metadata = $manifest.package.metadata
+          if ($metadata.id -ne 'Unlimotion.Cli' -or $metadata.version -ne '${{ steps.release.outputs.version }}') {
+            throw "Unexpected package identity: $($metadata.id) $($metadata.version)"
+          }
+
+          if ($metadata.packageTypes.packageType.name -ne 'DotnetTool') {
+            throw 'CLI package is not marked as a DotnetTool.'
+          }
+        }
+        finally {
+          $archive.Dispose()
+        }
+
+    - name: Install and smoke local package
+      shell: pwsh
+      run: |
+        $toolPath = Join-Path $env:RUNNER_TEMP 'unlimotion-cli-local-tool'
+        $source = Split-Path -Parent '${{ steps.pack.outputs.package }}'
+        dotnet tool install --tool-path $toolPath --add-source $source Unlimotion.Cli --version '${{ steps.release.outputs.version }}'
+        & (Join-Path $toolPath 'unlimotion-cli.exe') --help
+
+    - name: Publish package to NuGet.org
+      shell: pwsh
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: |
+        if ([string]::IsNullOrWhiteSpace($env:NUGET_API_KEY)) {
+          throw 'NUGET_API_KEY is not configured; refusing to publish without a protected repository secret.'
+        }
+
+        dotnet nuget push '${{ steps.pack.outputs.package }}' --api-key $env:NUGET_API_KEY --source $env:NUGET_SOURCE --skip-duplicate
+
+    - name: Verify public package and smoke install
+      shell: pwsh
+      run: |
+        $version = '${{ steps.release.outputs.version }}'
+        $index = 'https://api.nuget.org/v3-flatcontainer/unlimotion.cli/index.json'
+        $found = $false
+        for ($attempt = 1; $attempt -le 12; $attempt++) {
+          try {
+            $versions = (Invoke-RestMethod -Uri $index -ErrorAction Stop).versions
+            if ($versions -contains $version) {
+              $found = $true
+              break
+            }
+          }
+          catch {
+            Write-Host "NuGet index is not available yet (attempt $attempt): $($_.Exception.Message)"
+          }
+
+          Start-Sleep -Seconds 10
+        }
+
+        if (-not $found) {
+          throw "NuGet.org did not expose Unlimotion.Cli $version within the verification window."
+        }
+
+        $toolPath = Join-Path $env:RUNNER_TEMP 'unlimotion-cli-public-tool'
+        dotnet tool install --tool-path $toolPath Unlimotion.Cli --version $version
+        & (Join-Path $toolPath 'unlimotion-cli.exe') --help

--- a/specs/2026-09-12-cli-default-task-storage.md
+++ b/specs/2026-09-12-cli-default-task-storage.md
@@ -1,0 +1,304 @@
+# CLI Unlimotion: каталог задач по активной desktop-настройке
+
+## 0. Метаданные
+- Тип (профиль): `delivery-task`; .NET desktop client + config/state behavior.
+- Владелец: Codex; код и интеграция остаются у основного агента.
+- Масштаб: medium; меняется публично наблюдаемое поведение CLI и чтение локальной конфигурации, но без миграции данных.
+- Целевое семейство / behavior baseline: `GPT-6 Astra`; задача не меняет model/prompt behavior.
+- Поверхность: Codex.
+- Effective runtime: текущая Codex-сессия; на контракт CLI не влияет.
+- Eval baseline / evidence: Не применимо — задача не про модель; evidence составляют TUnit-тесты и CLI contract checks.
+- Целевой релиз / ветка: после approval создать отдельный worktree на свежем `origin/main` и ветку `feat/cli-default-task-storage`; текущий checkout `main` отстаёт от `origin/main` на 11 коммитов.
+- Ограничения: до approval изменяется только этот файл. Не читать/не выводить `Login`, `Password`, URL, токены или Git-настройки из пользовательского `Settings.json`; не записывать настройки и не менять каталог задач для read-команд.
+- Связанные ссылки: `src/Unlimotion.Cli/Program.cs`, `src/Unlimotion.Cli/README.md`, `src/Unlimotion.Test/UnlimotionCliIntegrationTests.cs`, `src/Unlimotion/Services/TaskSourceSettingsAdapter.cs`.
+
+## 1. Overview / Цель
+Убрать обязательность `--tasks` для CLI Unlimotion. Если флаг отсутствует, CLI должен определить каталог активного локального task space так же, как установленное desktop-приложение: по compatibility-проекции `TaskStorage` в стандартном `Settings.json`.
+
+Outcome contract:
+
+- Success means: `unlimotion-cli unlocked --format json` без `--tasks` работает с папкой задач, указанной в активной локальной desktop-настройке; явный `--tasks` неизменно имеет приоритет.
+- Итоговый артефакт / output: обновлённые CLI, документация и regression tests в новом worktree.
+- Stop rules: не реализовывать до точной фразы «Спеку подтверждаю»; при неясности источника настроек или необходимости поддерживать server source остановиться и запросить решение, а не обращаться к учётным данным/сети.
+
+## 2. Текущее состояние (AS-IS)
+- `Program.Main` после разбора аргументов немедленно отклоняет пустой `CliOptions.TasksPath` с `Missing required --tasks <path> option.`
+- В release desktop-приложение хранит стандартный конфиг в `%USERPROFILE%\Documents\Unlimotion\Settings.json` (`Environment.SpecialFolder.Personal`, `Program.cs` desktop).
+- Desktop поддерживает несколько task spaces. `TaskSourceSettingsAdapter.SyncLegacy(...)` поддерживает `TaskStorage` как compatibility-проекцию активного source; для file source это его `Path`, для server source — `IsServerMode=true`.
+- CLI уже использует `FileTaskStorage` и предназначен для file task directory; у него нет зависимостей и полномочий для server storage.
+- `UnlimotionCliIntegrationTests` запускает упакованный CLI в дочернем процессе и уже покрывает статусы, критерии, ошибки и сохранность файлов, но не выбор default directory из desktop settings.
+
+## 3. Проблема
+Агент или пользователь, работающий с установленным Unlimotion, вынужден вручную искать и повторять путь активного каталога задач в каждом CLI-вызове, хотя desktop уже хранит это значение в своей standard settings compatibility-проекции.
+
+## 4. Цели дизайна
+- Сохранить `--tasks` как явный и приоритетный override.
+- Повторить именно active local task-space путь desktop-приложения через его `TaskStorage` compatibility projection, а не дублировать хрупкий парсер каталога `TaskSources`.
+- Читать минимальный набор несекретных полей конфигурации.
+- Сделать ошибки конфигурации различимыми, стабильными в JSON и безопасными для автоматизации.
+- Добавить детерминированные regression tests без чтения реального пользовательского профиля во время тестов.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не добавляем новый CLI-флаг для пути к settings и не меняем формат существующих команд, кроме того что `--tasks` становится необязательным.
+- Не поддерживаем active server task space, сетевую аутентификацию, URL, backup/Git sync или переключение task spaces.
+- Не создаём, не исправляем, не мигрируем и не сохраняем `Settings.json`.
+- Не меняем задачу пользователя, данные в task directory, формат task files или алгоритмы availability.
+- Не меняем desktop UI, UI automation selectors или visual flow; visual planning artifact и UI video evidence не применимы.
+
+## 6. Предлагаемое решение (TO-BE)
+
+### 6.1 Распределение ответственности
+
+| Компонент/файл | Ответственность |
+| --- | --- |
+| `src/Unlimotion.Cli/TaskDirectoryResolver.cs` (новый) | Вычислить стандартный путь `Documents\Unlimotion\Settings.json`, прочитать только `TaskStorage.Path` и `TaskStorage.IsServerMode`, вернуть file-directory path либо typed resolution error. Тестируемый overload принимает путь settings явно. |
+| `src/Unlimotion.Cli/Program.cs` | После parse и до `Directory.Exists` выбрать explicit `--tasks` либо resolver; сохранить общий pipeline `FileTaskStorage` для всех команд. |
+| `src/Unlimotion.Cli/README.md` | Показать `--tasks` как optional override, описать default source и невозможность server source. |
+| `src/Unlimotion.Test/UnlimotionCliIntegrationTests.cs` | Закрепить precedence `--tasks`, successful resolution и negative configuration cases. |
+
+### 6.2 Детальный дизайн
+1. После `CliOptions.Parse` и help path `Program.Main` вызывает единый resolver. Если `options.TasksPath` непустой, resolver возвращает его без попытки открыть desktop settings.
+2. Если `--tasks` отсутствует, resolver получает `%USERPROFILE%\Documents\Unlimotion\Settings.json`, читает JSON read-only через `System.Text.Json` и извлекает только:
+   - `TaskStorage.Path` — непустой строковый путь к file task directory;
+   - `TaskStorage.IsServerMode` — JSON boolean или стандартная строка `True`/`False`; по умолчанию `false` только если поле отсутствует.
+3. CLI использует `TaskStorage.Path` как authoritative compatibility-projection активного task space. Это согласуется с desktop, который при activate/switch сохраняет projection через `TaskSourceSettingsAdapter.SyncLegacy`; не требуется интерпретация `TaskSources` slots и их migration journal.
+4. Если config отсутствует, JSON некорректен, `TaskStorage`/`Path` отсутствует или пуст, либо `IsServerMode=true`, resolver выдаёт `CliException` с exit code `1` и стабильным kind: соответственно `settingsNotFound`, `settingsInvalid`, `settingsPathMissing` или `settingsUnsupported`. Текст объясняет, что следует указать `--tasks <path>`; не включает содержимое settings.
+5. После успешного resolution применяется прежняя проверка `Directory.Exists`; отсутствующий каталог остаётся `operationFailed`/exit `1`, но сообщение указывает resolved path. Затем все commands, включая write commands, используют тот же уже выбранный path и имеющийся directory lock/atomic storage behavior.
+6. Public CLI usage и README показывают `[--tasks <path>]`. JSON error envelope сохраняет существующую форму `{ success: false, error: { kind, message } }`.
+
+### 6.3 User-Observable Scenarios
+
+| Scenario | User action / trigger | Expected visible result / output | Evidence required | Covered by AC |
+| --- | --- | --- | --- | --- |
+| Default local source | Запускает `unlimotion-cli unlocked --format json` без `--tasks` | CLI читает `TaskStorage.Path` стандартного desktop settings и выводит результат для этой папки | automated resolver/CLI test with temporary settings fixture | AC-1 |
+| Explicit override | Передаёт `--tasks D:\\OtherTasks` при отсутствующих/некорректных settings | CLI работает с `D:\\OtherTasks`, не читая settings | automated regression test | AC-2 |
+| Unsupported desktop source | Активный source projected as `IsServerMode=true` | exit `1`, stable JSON kind `settingsUnsupported`, подсказка про `--tasks`; сеть и credentials не используются | automated negative test | AC-3 |
+| Broken/missing settings | Settings отсутствует, повреждён или не содержит path | exit `1`, stable configuration error; task directory не открывается | automated negative tests | AC-4 |
+
+### 6.4 State / Interaction Matrix
+
+| Current state | Trigger | Expected transition/result | Empty/error/disabled/concurrent case | Notes |
+| --- | --- | --- | --- | --- |
+| `--tasks` present | Any CLI command | Use supplied path | Missing directory preserves existing error | Highest priority, no settings read |
+| `--tasks` absent, local projection valid | Any CLI command | Read projected `TaskStorage.Path`, then use existing storage pipeline | Concurrent desktop config write may produce unreadable JSON | Return `settingsInvalid`; do not retry/mutate |
+| `--tasks` absent, server projection | Any CLI command | Refuse before storage creation | No network fallback | CLI stays file-only |
+| `--tasks` absent, config invalid/missing | Any CLI command | Refuse before storage creation | No default guessed path | User can supply explicit `--tasks` |
+
+### 6.5 Decision Ledger
+
+| Decision | Owner | Default / chosen option | Confidence | Risk if assumed | Needs user before EXEC |
+| --- | --- | --- | ---: | --- | --- |
+| Source of active local path | agent | `TaskStorage.Path` compatibility projection, not direct `TaskSources` parsing | 0.93 | Projection may be stale only if desktop failed before its own persistence; direct slot parsing is less compatible and wider scope | Нет |
+| Settings location | agent | `%USERPROFILE%\Documents\Unlimotion\Settings.json`, matching release desktop `Program.cs` | 0.98 | A portable/debug app with `--config` is intentionally out of scope; it can use `--tasks` | Нет |
+| Empty/missing path fallback | agent | Fail safely; do not guess/create `Tasks` | 0.90 | A first-run user must give `--tasks`; avoids reading/creating an unintended directory | Нет |
+| Server mode | agent | Refuse with typed error and explicit override hint | 0.99 | Server task source cannot be faithfully handled by `FileTaskStorage` | Нет |
+| Test seam | agent | Test resolver with an explicit temporary settings-file path; keep public CLI surface free of test-only settings arguments | 0.90 | Requires a small testable internal seam or friend-access arrangement | Нет |
+
+### 6.6 Runtime / Config / Data Contract Matrix
+
+| Contract area | Current source of truth | Expected change | Compatibility / migration | Verification |
+| --- | --- | --- | --- | --- |
+| Desktop config location | release `Unlimotion.Desktop/Program.cs` | CLI derives the same standard `Settings.json` path only when `--tasks` absent | No config schema migration | Fixture and resolver tests |
+| Active source projection | `TaskSourceSettingsAdapter.SyncLegacy` -> `TaskStorage` | CLI reads `Path` and `IsServerMode` only | Supports existing projection; ignores secrets and `TaskSources` internal slots | File/server fixture tests |
+| CLI options | `CliOptions` and `PrintUsage` | `--tasks` optional but still allowed for every current command | Existing explicit invocations behave identically | Override integration test and help/README checks |
+| Error protocol | `ErrorOutput` / `CliException` | Add typed configuration failures within existing envelope | No output-schema break | JSON negative tests |
+
+## 7. Бизнес-правила / Алгоритмы
+- `EffectiveTasksPath = explicit --tasks`, если значение задано и не состоит из whitespace.
+- Иначе `EffectiveTasksPath = TaskStorage.Path` из standard settings только при `IsServerMode != true` и непустом path.
+- Resolver не применяет relative path normalization, не создаёт директории и не изменяет settings; действующая проверка `Directory.Exists(EffectiveTasksPath)` определяет возможность продолжения.
+- `--tasks` не зависит от settings даже когда они отсутствуют, повреждены или обозначают server source.
+- Конфигурационные ошибки имеют exit code `1`; syntax/option errors остаются `2`.
+
+## 8. Точки интеграции и триггеры
+- Единственная интеграционная точка — `Program.Main` между parse/help и существующей проверкой каталога.
+- Все read/write command branches получают уже разрешённый `CliOptions.TasksPath` (или локальную effective path variable); command-specific logic не дублирует resolver.
+
+## 9. Изменения модели данных / состояния
+- Новых persisted model fields, task-file properties и desktop setting keys нет.
+- CLI читает существующие `TaskStorage.Path`/`IsServerMode` read-only.
+- Resolver state ephemeral; credentials, URL и токены не десериализуются и не логируются.
+
+## 10. Миграция / Rollout / Rollback
+- Миграция не требуется: explicit `--tasks` продолжает работать без изменений.
+- Rollout: после merge/package update пользователи могут постепенно убрать `--tasks` в local file source workflows.
+- Rollback: вернуть CLI package/commit к предыдущей версии; settings и task files не изменяются этой feature, поэтому data rollback отсутствует.
+
+## 11. Тестирование и критерии приёмки
+
+Acceptance Criteria:
+
+- AC-1: каждый существующий CLI command может работать без `--tasks`, когда standard settings содержит valid local `TaskStorage.Path`; selected directory передаётся в existing storage pipeline.
+- AC-2: explicit `--tasks` имеет приоритет и не требует доступного/валидного `Settings.json`.
+- AC-3: projected server source не провоцирует network/auth access и возвращает JSON envelope kind `settingsUnsupported`, exit `1`.
+- AC-4: missing, malformed и pathless desktop settings возвращают стабильные configuration errors, exit `1`, до открытия task directory.
+- AC-5: `--format json` сохраняет current error envelope; help и README правильно показывают optional `--tasks` и default behavior.
+- AC-6: targeted CLI tests, affected Release build и полный `Unlimotion.Test` проходят; unrelated current worktree changes не смешиваются с delivery worktree.
+
+Проверки после approval (до long full suite сначала preflight SDK/restore и состояние процесса; suites запускаются последовательно):
+
+```powershell
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release -- --treenode-filter "/*/*/UnlimotionCliIntegrationTests/*" --maximum-parallel-tests 1 --output Detailed
+dotnet build src/Unlimotion.Cli/Unlimotion.Cli.csproj -c Release
+dotnet test src/Unlimotion.Test/Unlimotion.Test.csproj -c Release -p:UseSharedCompilation=false -- --maximum-parallel-tests 1 --output Detailed
+git diff --check
+```
+
+Stop rules: при timeout не повторять тот же runner blindly; сначала собрать progress/root-cause evidence. Green targeted test не заменяет full suite. UI test/video evidence не применимы: изменение не затрагивает UI, navigation, layout или UI-facing state.
+
+### Acceptance-to-Test Matrix
+
+| Acceptance criterion | Automated test | Manual / visual / log check | Evidence artifact | If not tested, why |
+| --- | --- | --- | --- | --- |
+| AC-1 | Resolver fixture: valid local settings resolves expected path; CLI process invokes a read command with resolved path | Inspect targeted TUnit output | TUnit console/TRX | N/A |
+| AC-2 | CLI integration test: explicit temp directory succeeds while injected fixture settings is missing/invalid | Inspect no resolver attempt if observable | TUnit output | N/A |
+| AC-3 | Resolver/CLI test with `IsServerMode=true`, asserts exit 1 and `settingsUnsupported` JSON | Confirm no credential/network code paths are referenced in diff | TUnit + diff review | N/A |
+| AC-4 | Separate missing, invalid JSON and empty-path fixtures assert stable kinds/exit 1 | Inspect error messages do not include config contents | TUnit output | N/A |
+| AC-5 | Help and JSON-envelope regression tests; README diff review | `dotnet ... --help` smoke after build | CLI stdout | N/A |
+| AC-6 | Targeted class, CLI Release build, full `Unlimotion.Test` serial | `git diff --check`, post-EXEC review | commands above | N/A |
+
+## 12. Риски и edge cases
+- Desktop could be writing `Settings.json` concurrently; malformed/partial snapshot fails safely, with no retries or writes.
+- Active source may be a server; treating URL as a file path would be unsafe, so resolution refuses it.
+- The compatibility projection can be stale only outside normal desktop persistence; direct `TaskSources` parsing would duplicate migration/recovery behavior and increase drift risk, so it is intentionally excluded.
+- The new default affects write commands too. Existing lock/atomic write behavior stays intact, but user should use explicit `--tasks` when targeting a non-active task space.
+
+### Expected User Review Objections
+
+| Likely objection | Why likely | Mitigation in spec/code plan | Status |
+| --- | --- | --- | --- |
+| «CLI выбрал не тот task space» | В desktop несколько spaces | Use active source compatibility projection persisted by desktop, and retain explicit override | mitigated |
+| «CLI прочитал пароль или пошёл в сеть» | Settings can hold credentials and server configuration | Parse only `Path`/`IsServerMode`; server source refuses before storage/network | mitigated |
+| «После обновления автоматизация с --tasks сломалась» | Existing scripts use explicit path | Explicit option retains absolute priority and regression coverage | mitigated |
+| «Первый запуск создал не ту папку» | Default folder heuristics are risky | Missing/pathless settings fail; no directory/config creation | mitigated |
+
+### Rework Prevention Checklist
+- Does the spec name what the user will see or operate? Да: CLI without `--tasks`, JSON errors and optional usage.
+- Does every user-visible scenario have evidence? Да: section 6.3 and AC matrix.
+- Did the agent list decisions it assumed? Да: Decision Ledger.
+- Did the agent predict likely objections and mitigate them? Да: table above.
+- Did role-based review run for the relevant task type? Да: section 19.
+- Are acceptance criteria verifiers, not preparation steps? Да.
+- Does EXEC have a path to prove the scenarios before final? Да: staged TUnit/build/full-suite plan.
+
+## 13. План выполнения
+1. После approval проверить fresh `origin/main`, создать отдельный worktree/branch и подтвердить clean ownership boundary.
+2. Добавить testable read-only settings resolver, затем заменить mandatory-path guard единым effective-path flow.
+3. Сначала добавить and run regression tests for default, override and configuration failures; confirm expected red before resolver implementation where practical.
+4. Update CLI README/usage and run targeted tests, affected build, full test suite serially, then `git diff --check`.
+5. Выполнить post-EXEC review; создать commit/push/PR только по отдельному прямому поручению пользователя.
+
+## 14. Открытые вопросы
+Нет. Контракт намеренно ограничен active local source compatibility projection; portable/debug configurations могут использовать existing `--tasks`.
+
+## 15. Соответствие профилю
+- Применимые документы: `creator-vibe-lens` (full skill не применим: задача factual/exact), `model-behavior-baseline`, `quest-governance`, `quest-mode`, `collaboration-baseline`, `tool-execution-baseline`, `testing-baseline`, `testing-dotnet`, `session-insights-context`, `dotnet-desktop-client`, `spec-linter`, `spec-rubric`, `review-loops`; локальный `AGENTS.override.md` не добавляет UI test обязанностей, так как UI behavior не меняется.
+- Выполненные требования профиля: staged automated tests, `dotnet build` и `dotnet test` запланированы; UI thread, selectors, visual artifacts не затрагиваются.
+
+## 16. Таблица изменений файлов
+
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.Cli/TaskDirectoryResolver.cs` | Новый read-only resolver settings -> local path/errors | Изолировать config contract и сделать его тестируемым |
+| `src/Unlimotion.Cli/Program.cs` | Explicit-or-default path flow и typed configuration error propagation | Убрать mandatory `--tasks` |
+| `src/Unlimotion.Cli/README.md` | Optional flag/default/error documentation | Не оставлять устаревший CLI contract |
+| `src/Unlimotion.Test/TaskDirectoryResolverTests.cs` | Deterministic resolver fixtures | Защитить default, override и settings error contract без доступа к профилю пользователя |
+| `specs/2026-09-12-cli-default-task-storage.md` | Эта SPEC/audit log | QUEST traceability |
+
+## 17. Таблица соответствий (было -> стало)
+
+| Область | Было | Стало |
+| --- | --- | --- |
+| CLI without `--tasks` | Invalid arguments, exit 2 | Resolves active local desktop path or typed configuration failure, exit 1 |
+| Explicit `--tasks` | Required and used | Optional, still selected first and used unchanged |
+| Server active task space | No default behavior | Typed refusal; no network/auth fallback |
+| Settings/task data | Not read | Settings read-only; task data behavior unchanged |
+
+## 18. Альтернативы и компромиссы
+- Вариант: parsing `TaskSources` catalog directly.
+  - Плюсы: direct access to active-source descriptor.
+  - Минусы: duplicates desktop migration/journal/recovery semantics and requires wider shared dependencies.
+- Вариант: always guess `Documents\Unlimotion\Tasks`.
+  - Плюсы: simple.
+  - Минусы: ignores a configured/custom active path and may target wrong data.
+- Выбранное решение: `TaskStorage` compatibility projection.
+  - Плюсы: desktop already persists it for the active source; minimal JSON surface and no secret/server behavior.
+  - Минусы: depends on normal desktop projection persistence.
+  - Почему выбранное решение лучше в контексте этой задачи: it is the narrowest authoritative bridge between installed desktop settings and file-only CLI while preserving an explicit override.
+
+## 19. Результат quality gate и review
+
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Outcome, AS-IS, root cause, limits and non-goals are explicit. |
+| B. Качество дизайна | 6-10 | PASS | One resolver, one integration point, typed failures and no-write contract are defined. |
+| C. Безопасность изменений | 11-13 | PASS | Existing config only; no secret parsing, writes, migration or data rollback requirement. |
+| D. Проверяемость | 14-16 | PASS | Six ACs map to negative and positive automated checks, staged commands and stop rules. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Worktree, ownership, decisions and no open questions are recorded. |
+| F. Соответствие профилю | 20 | PASS | .NET/TUnit/build contract and UI non-applicability are explicit. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Observable default behavior and non-goals are concrete. |
+| 2. Понимание текущего состояния | 5 | Mandatory guard, desktop config path and projection behavior were inspected. |
+| 3. Конкретность целевого дизайна | 5 | Resolver inputs, precedence, error contract and integration point are fixed. |
+| 4. Безопасность (миграция, откат) | 5 | Read-only minimal fields, server refusal and no-migration rollback are specified. |
+| 5. Тестируемость | 5 | Positive, override and three error families are mapped to automated evidence. |
+| 6. Готовность к автономной реализации | 5 | No user-owned decisions remain; plan and changed files are bounded. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Role-Based Review Result
+
+| Role | Applicability | Review question | Verdict | Required spec changes |
+| --- | --- | --- | --- | --- |
+| Business analyst / domain workflow | applicable | Does active desktop task-space selection map to the requested CLI workflow? | PASS | Use the desktop compatibility projection instead of arbitrary folder fallback. |
+| UX / designer | not applicable | No UI, layout, visual state or copy surface changes. | Не применимо | None. |
+| Tester / validation | applicable | Are precedence, settings failures and envelope stability covered? | PASS | AC matrix includes happy path and negative cases. |
+| Developer / architect | applicable | Is the boundary compatible with existing desktop source management and file-only CLI? | PASS | Isolate resolver; do not parse catalog internals. |
+| Delivery / operations / security | applicable | Are local config, secrets, write behavior and rollback bounded? | PASS | Read two nonsecret fields only; no writes/network; fresh worktree planned. |
+
+### Post-SPEC Review
+- Статус / stop decision: PASS; spec is ready for user approval, but EXEC is blocked by the QUEST gate.
+- Scope/Evidence pass: inspected this spec; central `quest-governance`, `quest-mode`, `spec-linter`, `spec-rubric`, `review-loops`, testing/docs profiles; local `AGENTS.override.md`; current `Program.cs`, CLI README/project, existing CLI integration tests, release desktop `Program.cs`, `TaskSourceSettingsAdapter` and installed settings shape (field names only).
+- Contract pass: `--tasks` precedence, file-only boundary, no config/task write, config errors and full test requirement agree with the inspected implementation and non-goals.
+- Adversarial risk pass: considered stale/malformed concurrent settings, multiple spaces, server source, first-run no config, secret leakage, explicit override and accidental task-directory creation. Each has a concrete no-write/refuse/override outcome.
+- Findings:
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| MEDIUM | Active task-space selection | Direct `TaskSources` parsing would duplicate migration/recovery behavior and risk wrong source selection. | Use `TaskStorage` compatibility projection only. | Fixed in section 6.2 |
+| MEDIUM | First-run behavior | Guessing a default folder could create/read unintended data. | Fail pathless/missing settings and preserve explicit override. | Fixed in sections 6.2 and 7 |
+| LOW | Test isolation | Process integration cannot safely overwrite the user's real Documents config. | Require testable resolver fixture seam; no test-only CLI option. | Fixed in Decision Ledger and test matrix |
+- Fix and re-review: after incorporating those constraints, rechecked sections 6–12 and AC matrix; no remaining BLOCKER/HIGH/MEDIUM findings.
+- No-findings justification: scope, contracts, negative scenarios, test evidence, worktree boundary, docs and no-secret invariant were all inspected; the remaining projection-staleness risk is documented and mitigated by `--tasks`.
+- Manual-review challenge / остаточные риски / needs human: a desktop crash before it persists the active-source projection can leave the prior path. This is existing desktop state; CLI must not invent recovery. User can override with `--tasks`.
+
+### Post-EXEC Review
+- Статус / stop decision: PASS.
+- Scope/Evidence pass: reviewed approved SPEC, `git status`, relevant diff, resolver, Program, README, new TUnit tests, targeted expected-red/green evidence, Release CLI build and read-only installed-settings smoke; full sequential `Unlimotion.Test` completed successfully.
+- Contract pass: explicit `--tasks` remains priority; missing default resolves through standard desktop settings; local path, string/boolean server flag, server refusal, no credentials/network/settings writes and stable error envelope conform to AC.
+- Adversarial risk pass: real installed settings used string `IsServerMode="False"`; initial smoke rejected it, so resolver and regression fixture were corrected to accept both JSON booleans and parseable True/False strings. Re-run targeted tests and smoke passed.
+- Role-Based pass: workflow, tester, architecture and delivery/security roles PASS; UX remains not applicable because no UI behavior changed.
+- Findings/fixes: one MEDIUM compatibility finding (string boolean) fixed; no BLOCKER/HIGH/MEDIUM findings remain. No unrelated changes in the new worktree.
+- No-findings justification: every user-observable scenario has targeted or smoke evidence; full suite and Release build completed; only existing repository warnings and LF-to-CRLF notices remain.
+- Residual risk: a stale desktop compatibility projection can select the prior active space after a desktop persistence failure; explicit `--tasks` remains the safe override.
+
+## Approval
+Ожидается фраза: «Спеку подтверждаю».
+
+## 20. Журнал действий агента
+
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Inspect current CLI/default desktop config contract | 0.96 | None material | Draft expanded SPEC | Нет | Нет | User requests a behavior change; current CLI requires `--tasks`, desktop persists active source projection in `TaskStorage`. | `Program.cs`, desktop `Program.cs`, adapter, tests, README |
+| SPEC | Define safe default resolution and test plan | 0.93 | None material | Complete quality gates and request approval | Да | Yes: user asked to implement feature in a new worktree; approval phrase has not yet been supplied | Chose compatibility projection, explicit precedence and no-write failures to minimize drift/secrets risk. | This SPEC |
+| SPEC | Post-SPEC review | 0.94 | Exact future `origin/main` SHA (must refresh after approval) | Wait for exact approval | Да | Pending | All pre-approval gates PASS; QUEST prohibits code/worktree changes before approval. | This SPEC |
+| EXEC | Implement, validate and review default task-directory resolution | 0.97 | No material data missing | Report completed uncommitted worktree change | Нет | User approved SPEC | Real smoke exposed the desktop's string boolean representation; corrected within approved settings-format compatibility scope. | `TaskDirectoryResolver.cs`, `Program.cs`, `README.md`, `TaskDirectoryResolverTests.cs`, this SPEC |

--- a/specs/2026-09-12-official-nuget-cli-publishing.md
+++ b/specs/2026-09-12-official-nuget-cli-publishing.md
@@ -1,0 +1,339 @@
+# Официальная публикация Unlimotion CLI как .NET tool
+
+## 0. Метаданные
+- Тип (профиль): delivery-task; `testing-dotnet`, `dotnet-desktop-client`, `github-delivery-policy`, `tool-execution-baseline`, `session-insights-context`.
+- Владелец: Kibnet / Unlimotion.
+- Масштаб: medium, expanded SPEC: меняются package/release contracts и планируется внешняя публикация.
+- Целевое семейство / behavior baseline: не применимо — задача не меняет model/prompt behavior.
+- Поверхность: Codex; конечная поверхность — NuGet.org и стандартный .NET SDK.
+- Effective runtime: локальный .NET SDK из `global.json`; точную версию записать в EXEC evidence перед pack.
+- Eval baseline / evidence: не применимо — нет model-eval; evidence составят package inspection, clean tool install/smoke, CI и read-back NuGet.
+- Целевой релиз / ветка: сначала PR из `feat/cli-default-task-storage` в `main`; затем отдельный release `v1.30.1` от проверенного `main` и NuGet `Unlimotion.Cli` `1.30.1`.
+- Ограничения: не публиковать токены или секреты; не выпускать из неслитой ветки; NuGet package immutable; GitHub release/tag и NuGet push выполняются только после local/CI evidence и при наличии authorizations.
+- Связанные ссылки: [текущая реализация default task directory](2026-09-12-cli-default-task-storage.md); latest release `v1.30.0` от `3aa24c8f96928f16f5e319be9e098c0037adf08d`; public NuGet flat-container `unlimotion.cli` на 2026-09-12 ответил HTTP 404.
+
+## 1. Overview / Цель
+Сделать Unlimotion CLI официальным публичным .NET tool: пользователь устанавливает релиз из стандартного NuGet.org источника командой
+
+```powershell
+dotnet tool install --global Unlimotion.Cli
+```
+
+и запускает `unlimotion-cli` без `--add-source`, `--tool-path` и локальной сборки.
+
+Outcome contract:
+- Success means: опубликованный публичный пакет `Unlimotion.Cli` версии `1.30.1` доступен из NuGet.org, является .NET tool, содержит исходный README/license metadata и устанавливается/запускается в чистом временном tool-path.
+- Итоговый артефакт / output: source changes, GitHub Actions workflow с защищённым NuGet secret, PR/merge, SemVer GitHub release `v1.30.1`, NuGet package и verified read-back.
+- Stop rules: не выполнять `dotnet nuget push`, не создавать tag/release и не утверждать публикацию, если source SHA не совпадает с проверенным `main`, пакет не проходит local install/smoke, CI не green, имя/версия заняты, либо отсутствует требуемое GitHub/NuGet authorization.
+
+## 2. Текущее состояние (AS-IS)
+- `src/Unlimotion.Cli/Unlimotion.Cli.csproj` уже содержит `PackAsTool=true`, `ToolCommandName=unlimotion-cli`, `PackageId=Unlimotion.Cli`, README и `License.txt`; версия локального пакета зафиксирована как `0.3.0`.
+- `src/Unlimotion.Cli/README.md` документирует только local-feed установку с `--tool-path` и `--add-source`.
+- В `.github/workflows/` нет workflow, который pack/push-ит `Unlimotion.Cli` в NuGet.org. Существующие packaging workflows запускаются после опубликованного GitHub release и обслуживают desktop-артефакты.
+- Публичный NuGet endpoint `https://api.nuget.org/v3-flatcontainer/unlimotion.cli/index.json` вернул 404, поэтому пакет с таким id пока не опубликован; это не доказывает резервирование имени, его повторно проверить непосредственно перед push.
+- `origin/main` и release `v1.30.0` указывают на `3aa24c8f96928f16f5e319be9e098c0037adf08d`. Feature worktree содержит один локальный commit `a4268ae3` поверх него; выпускать его напрямую нельзя.
+- Текущий GitHub token имеет `repo`, но не заявляет scope `workflow`; это может блокировать push нового workflow и должно быть проверено до delivery, не маскируясь кодовой правкой.
+
+## 3. Проблема
+Пакет технически собирается локально, но не имеет публичного и воспроизводимого канала доставки. Пользователь не может установить CLI стандартной командой `dotnet tool install --global Unlimotion.Cli`.
+
+## 4. Цели дизайна
+- Привязать версию CLI к SemVer release Unlimotion, а не переиспользовать локальную `0.3.0` после публичной публикации.
+- Собирать и публиковать только проверенный код `main`, воспроизводимо и без секретов в репозитории.
+- Сделать нормальную установку основной в README, сохранив local-package путь для разработчиков.
+- Дать проверяемое доказательство реальной установки и запуска public package.
+- Сохранить существующие команду `unlimotion-cli`, JSON/text contract и явный `--tasks` override.
+
+## 5. Non-Goals (чего НЕ делаем)
+- Не меняем команды, task-graph semantics, desktop UI, storage schema или сетевые/server-mode границы CLI.
+- Не публикуем npm/winget/chocolatey/Scoop пакеты, GitHub Packages либо private NuGet feed.
+- Не добавляем NuGet API key в файлы, командные строки, логи или git history; не создаём/не изменяем account ownership NuGet.org автоматически.
+- Не делаем desktop binary-release частью этой задачи и не заявляем, что NuGet tool является self-contained desktop installer.
+
+## 6. Предлагаемое решение (TO-BE)
+### 6.1 Распределение ответственности
+
+| Компонент/файл | Ответственность |
+| --- | --- |
+| `src/Unlimotion.Cli/Unlimotion.Cli.csproj` | Публичные NuGet metadata: package version from release build, project/repository URLs, license/readme, tool contract. |
+| `src/Unlimotion.Cli/README.md` | Официальная global-install команда и совместимость с `unlimotion-cli`; local-feed instructions остаются developer fallback. |
+| `.github/workflows/nuget-cli.yml` | Проверка release tag/version, restore/build/test/pack, package inspection and clean installation smoke; authenticated push only after all gates. |
+| `src/Unlimotion.Test/*` | Existing CLI regression suite, including `TaskDirectoryResolverTests`; no new runtime behavior is required solely for publication. |
+| GitHub repository secret `NUGET_API_KEY` | Protected user-owned credential used only by the publication step. |
+| NuGet.org | Immutable public package hosting and post-push availability. |
+
+### 6.2 Детальный дизайн
+1. The CLI project receives public package metadata (`PackageProjectUrl`, `RepositoryUrl`, `RepositoryType`, `PackageReleaseNotes`) and no secret-bearing value. Its default checked-in `Version` becomes `1.30.1`, the first public CLI release matching the planned release tag.
+2. Add a dedicated `nuget-cli.yml` trigger for published GitHub release `vMAJOR.MINOR.PATCH`. It checks out that tag, strips exactly one leading `v`, requires numeric SemVer and requires it to equal the project package version. This prevents publishing an arbitrary `main` checkout or silently publishing `0.3.0` under an unrelated product tag.
+3. Before push, the workflow restores/builds the CLI and executes the relevant TUnit suite, packs `Unlimotion.Cli` to an isolated artifact directory, validates the `.nupkg` content/readme/license/tool metadata, then installs it into an isolated `--tool-path` from that directory and runs `unlimotion-cli --help` plus a read-only fixture smoke.
+4. The final workflow step runs `dotnet nuget push` only with GitHub secret `NUGET_API_KEY`, source `https://api.nuget.org/v3/index.json`, and `--skip-duplicate`. `--skip-duplicate` makes retry after a confirmed same-version push non-fatal but does not treat a skipped package as a new publication; the read-back determines the actual state.
+5. The README presents the global NuGet command first, with an explicit note that it installs executable `unlimotion-cli`, requires a compatible .NET runtime/SDK according to the package TFM, and that `--tasks` remains an override. Local packing remains as a contributor workflow.
+6. Delivery order: PR from the feature branch -> CI green -> merge into `main` -> create `v1.30.1` GitHub release from exact merged SHA -> workflow publishes -> query NuGet metadata/download -> clean global-equivalent temporary install smoke. The repository may create desktop assets from the release independently; their outcome is reported separately.
+
+No UI-facing behavior changes: visual planning artifact and UI video evidence are not applicable.
+
+### 6.3 User-Observable Scenarios
+
+| Scenario | User action / trigger | Expected visible result / output | Evidence required | Covered by AC |
+| --- | --- | --- | --- | --- |
+| First-time install | `dotnet tool install --global Unlimotion.Cli` from default NuGet.org source | SDK resolves public package and installs `unlimotion-cli` without custom source | NuGet read-back + clean temporary `--tool-path` install equivalent | AC-1, AC-5 |
+| Run installed tool | `unlimotion-cli --help` then `status --format json` with desktop settings | Command is available and preserves CLI contract/default settings behavior | package-install smoke and existing resolver test | AC-2, AC-3 |
+| Release retry | workflow is retried after NuGet accepted the version | It does not overwrite a package or expose secret; duplicate is reported honestly | workflow log + NuGet version read-back | AC-4 |
+| Invalid delivery state | tag/version, tests, authorization or pack smoke fails | No NuGet push occurs | ordered workflow gates/log | AC-6 |
+
+### 6.4 State / Interaction Matrix
+
+| Current state | Trigger | Expected transition/result | Empty/error/disabled/concurrent case | Notes |
+| --- | --- | --- | --- | --- |
+| Feature branch only | PR merged and CI green | exact commit becomes `main` candidate | CI red/pending -> no tag/release | Never publish from feature ref. |
+| Published GitHub release | `v1.30.1` workflow starts | version/source validation, pack and smoke precede push | malformed/tag-version mismatch -> hard failure before secret step | Tag is public delivery evidence. |
+| Pack validated | NuGet secret available | one push attempt to public source | secret absent/invalid -> failure, no retry with pasted credential | Secret is never logged. |
+| Version already exists | workflow retry | `--skip-duplicate`, then read-back | different content cannot replace immutable package | Human reviews package SHA/content evidence. |
+| Public package indexed | clean install | tool is installed and help/smoke succeeds | indexing delay -> bounded polling; no false PASS until success | Public API is source of truth. |
+
+### 6.5 Decision Ledger
+
+| Decision | Owner | Default / chosen option | Confidence | Risk if assumed | Needs user before EXEC |
+| --- | --- | --- | ---: | --- | --- |
+| Public feed | agent | NuGet.org, because standard `dotnet tool install` uses it and current package id is absent there | 0.98 | Package id might be unavailable/reserved when publishing | Нет |
+| Command/package identity | agent | `Unlimotion.Cli` package and `unlimotion-cli` command, preserving existing project metadata | 0.99 | Naming collision or user expects another command | Нет |
+| Release/version scheme | agent | First public tool `1.30.1`, matched to release tag `v1.30.1` | 0.86 | User may prefer independent CLI SemVer | Нет; current desktop release train and public absence make alignment the least ambiguous option |
+| Publication credential | user / NuGet owner | GitHub Actions secret `NUGET_API_KEY`, restricted to `Unlimotion.Cli` where NuGet supports scoped keys | 0.95 | Missing or overbroad credential blocks/raises blast radius | Нет для implementation; yes as runtime prerequisite for actual public push |
+| Trigger | agent | `release.published`, only after tag/version checks | 0.91 | Release can trigger desktop packaging alongside CLI workflow | Нет |
+
+### 6.6 Runtime / Config / Data Contract Matrix
+
+| Contract area | Current source of truth | Expected change | Compatibility / migration | Verification |
+| --- | --- | --- | --- | --- |
+| .NET tool identity | CLI `.csproj` | Preserve package id and command; version becomes `1.30.1` | Existing local install users may pin `0.3.0`; public users get first stable version | inspect `.nupkg` and install it |
+| Public package feed | NuGet.org | First public immutable `Unlimotion.Cli/1.30.1` | No data migration; uninstall/reinstall changes client tool only | flat-container/version read-back |
+| Release authority | GitHub release tag | workflow trusts only release tag that matches project version | Tag must point at merged `main` candidate | `git ls-remote`, `gh release view`, workflow checkout SHA |
+| Authentication | GitHub Actions secret | `NUGET_API_KEY` only in push environment | Configure separately; no repository file stores it | workflow secret availability and masked log |
+
+## 7. Бизнес-правила / Алгоритмы
+- A package is publishable iff all of: release is published and not draft/prerelease; tag matches `^v\d+\.\d+\.\d+$`; normalized tag equals project version; checked-out SHA is the tag target and is an ancestor/equal of `origin/main`; targeted/full mandatory test gates, pack inspection and local-install smoke pass; package id/version are not conflicting on NuGet; secret is available.
+- A failed prerequisite stops before `dotnet nuget push`.
+- NuGet `--skip-duplicate` is recovery behavior only. Public read-back decides whether version is available, not the command exit code alone.
+
+## 8. Точки интеграции и триггеры
+- GitHub `release.published` event invokes `.github/workflows/nuget-cli.yml`.
+- `Unlimotion.Cli.csproj` is the version and pack metadata source; workflow compares rather than overrides it.
+- README updates mirror the actual package id/command.
+
+## 9. Изменения модели данных / состояния
+Не применимо: task data, settings and storage contracts do not change. Изменяется только externally hosted immutable build artifact and CI configuration.
+
+## 10. Миграция / Rollout / Rollback
+- Rollout: publish a first stable tool only after merge/CI/release gates; then verify public install before announcing it.
+- Compatibility: `unlimotion-cli` name, CLI arguments and package README remain compatible. Existing local packs are not deleted.
+- Rollback: NuGet versions are immutable and cannot be overwritten. If a bad published version is found, unlist it in NuGet.org, publish a new corrective version from a new verified tag, and document the safe version. Do not delete or mutate a package as a substitute for a corrective release.
+
+## 11. Тестирование и критерии приёмки
+
+- AC-1: `Unlimotion.Cli` is a public package on NuGet.org; `dotnet tool install --global Unlimotion.Cli --version 1.30.1` is valid without `--add-source`.
+- AC-2: package declares `DotnetTool` metadata and exposes `unlimotion-cli`.
+- AC-3: installed tool keeps existing help and default-task-directory behavior; resolver regression suite remains green.
+- AC-4: publish workflow contains version/source/gate ordering, uses masked `NUGET_API_KEY`, no secret literals, and retry does not claim a duplicate as a new upload.
+- AC-5: package includes README and `License.txt`, with actual official-install documentation.
+- AC-6: before public push: required local/CI checks pass; after push: NuGet version/read-back and clean install smoke succeed. Any failed condition stops completion.
+
+Commands/evidence, in order:
+
+```powershell
+dotnet --info
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -c Release -- --treenode-filter "/*/*/TaskDirectoryResolverTests/*" --maximum-parallel-tests 1 --output Detailed
+dotnet build src\Unlimotion.Cli\Unlimotion.Cli.csproj -c Release
+dotnet run --project src\Unlimotion.Test\Unlimotion.Test.csproj -c Release -- --maximum-parallel-tests 1 --output Detailed
+dotnet pack src\Unlimotion.Cli\Unlimotion.Cli.csproj -c Release -o <isolated-pack-dir>
+dotnet tool install --tool-path <isolated-tool-dir> --add-source <isolated-pack-dir> Unlimotion.Cli --version 1.30.1
+<isolated-tool-dir>\unlimotion-cli --help
+gh pr checks <pr-number> --watch
+gh release view v1.30.1 --repo Kibnet/Unlimotion
+Invoke-WebRequest https://api.nuget.org/v3-flatcontainer/unlimotion.cli/index.json
+dotnet tool install --tool-path <clean-tool-dir> Unlimotion.Cli --version 1.30.1
+<clean-tool-dir>\unlimotion-cli --help
+```
+
+Long full TUnit runs remain serial (`--maximum-parallel-tests 1`) and need recorded progress/evidence. Do not retry an identical timeout; inspect the report/log and change the diagnostic scope. A public install must wait through normal NuGet indexing but has a bounded polling deadline and reports a delay rather than a false success.
+
+### Acceptance-to-Test Matrix
+
+| Acceptance criterion | Automated test | Manual / visual / log check | Evidence artifact | If not tested, why |
+| --- | --- | --- | --- | --- |
+| AC-1 public install | clean `--tool-path` install from NuGet | NuGet flat-container and Gallery read-back | workflow log + public endpoint | Not applicable after actual publication |
+| AC-2 tool metadata | package content/tool install | inspect `.nuspec` and executable | `.nupkg` inspection log | Not applicable |
+| AC-3 behavior unchanged | `TaskDirectoryResolverTests` + full TUnit | installed `--help` and status fixture smoke | TUnit report + tool output | Not applicable |
+| AC-4 safe publish gate | workflow YAML static contract checks where practical | review ordered steps and masked secret reference | workflow diff/CI run | No separate app runtime test needed |
+| AC-5 package docs | package content check | rendered/read README review | `.nupkg` file listing | Not applicable |
+| AC-6 release evidence | CI and pack/install smoke | exact SHA/tag/release/NuGet read-backs | CI URL, release URL, NuGet URL | Must remain incomplete if an external gate is unavailable |
+
+## 12. Риски и edge cases
+- NuGet package id/selected version is unavailable at execution: stop, record response, choose a new version/name only through a follow-up decision.
+- Current GitHub auth lacks `workflow` scope: do not bypass it; user refreshes authorization or uses a repository-integrated credential before workflow push.
+- NuGet API key is absent/invalid: workflow fails closed before public package upload.
+- Package indexed slowly: poll public endpoint with a bounded timeout and do not publish an announcement first.
+- A later GitHub release with unchanged package version would fail tag/version check, forcing intentional version maintenance instead of duplicate publishing.
+- `--skip-duplicate` can conceal a stale retry: compare public package version and local package SHA/content during delivery read-back.
+
+### Expected User Review Objections
+
+| Likely objection | Why likely | Mitigation in spec/code plan | Status |
+| --- | --- | --- | --- |
+| «Нужна обычная команда, а не локальный источник» | This is the primary outcome | README and public smoke use default NuGet.org source; local source is demoted to developer fallback | mitigated |
+| «Не публикуй секрет и не делай скрытый push» | NuGet publication needs credentials | Secret only in GitHub Actions; ordered workflow, explicit public read-back and no CLI arg/token logging | mitigated |
+| «Не выпускай незамёрженный feature worktree» | Current code is one commit ahead of main | PR/CI/merge/release SHA gates are required before tag/push | mitigated |
+| «Версия tool должна быть понятной» | Existing `0.3.0` is local-only while desktop release is `1.30.0` | First public version aligns to `v1.30.1`; README/release evidence shows it | mitigated |
+
+### Rework Prevention Checklist
+- User-visible install/run scenarios are named and each has evidence.
+- Public package/release/credential choices are captured in the decision ledger.
+- ACs are verifiable outcomes, not preparation tasks.
+- Role-based review includes delivery/security; UI evidence is explicitly not applicable.
+- EXEC has an end-to-end proof path and stops safely if external authorization is unavailable.
+
+## 13. План выполнения
+1. On approval, update CLI package metadata/version and official-install README; add a release-gated NuGet workflow with no secrets in source.
+2. Add/adjust narrow automation checks for packaging/workflow contracts if repository patterns permit; otherwise make pack/install smoke a required CI workflow gate.
+3. Run expected-red (new package/workflow contract where applicable), targeted tests, CLI build, serial full TUnit, local pack/content inspect/install smoke, and `git diff --check`.
+4. Complete post-EXEC review, commit, push feature branch, open PR and wait for required green CI.
+5. Merge only after review; verify `main` SHA and create public GitHub release `v1.30.1` from it.
+6. Ensure the `NUGET_API_KEY` secret/appropriate GitHub permission exists, observe workflow result, perform NuGet/read-back/clean-install verification, then report actual publication status and any desktop-package jobs separately.
+
+## 14. Открытые вопросы
+Нет блокирующих design-вопросов. External runtime prerequisites remain: repository ability to push a workflow (current token reports no `workflow` scope) and a NuGet.org owner-provided scoped `NUGET_API_KEY`. Their absence blocks publication, not the approved source implementation.
+
+## 15. Соответствие профилю
+- Профиль: `delivery-task` + `testing-dotnet` + `dotnet-desktop-client` + `github-delivery-policy` + `tool-execution-baseline` + `session-insights-context`.
+- Выполненные требования профиля: expanded SPEC due to CI/release/public contract; observable delivery scenarios and AC evidence; TUnit/full-test plan; source/tag/CI/secret/rollback gates; no UI change therefore local UI override is not applicable.
+
+## 16. Таблица изменений файлов
+
+| Файл | Изменения | Причина |
+| --- | --- | --- |
+| `src/Unlimotion.Cli/Unlimotion.Cli.csproj` | version `1.30.1` and public NuGet metadata | Stable public package identity and provenance |
+| `src/Unlimotion.Cli/README.md` | Official global installation and developer fallback | Users can use the standard command |
+| `.github/workflows/nuget-cli.yml` | New gated build/test/pack/install/publish flow | Reproducible no-secret-in-source publication |
+| `src/Unlimotion.Test/*` | Only if a narrowly scoped package/workflow contract test follows repository practice | Guard observable release contract |
+| `specs/2026-09-12-official-nuget-cli-publishing.md` | Plan, evidence and journal | QUEST governance |
+
+## 17. Таблица соответствий (было -> стало)
+
+| Область | Было | Стало |
+| --- | --- | --- |
+| Installation | local pack + custom `--add-source` and `--tool-path` | public default-source `dotnet tool install --global Unlimotion.Cli` |
+| Package version | local-only `0.3.0` | first public version `1.30.1`, paired with `v1.30.1` |
+| Publication | manual local artifact only | gated GitHub release workflow + NuGet read-back |
+| Credentials | no release credential model | protected GitHub secret only in final push step |
+
+## 18. Альтернативы и компромиссы
+- Publish `0.3.0` directly: smaller diff, but the public CLI version diverges immediately from the active product release and makes tag-to-package evidence unclear.
+- Manual local `dotnet nuget push`: faster for one version, but puts publication/audit/secret handling on a workstation and is less reproducible.
+- Publish on every `main` push: minimizes manual steps but can leak unreviewed/untagged versions and lacks a stable release identity.
+- Chosen: release-gated public package `1.30.1`; it preserves standard installation, ties immutable package to a GitHub delivery artifact, and keeps secrets in the CI boundary.
+
+## 19. Результат quality gate и review
+### SPEC Linter Result
+
+| Блок | Пункты | Статус | Комментарий |
+|---|---|---|---|
+| A. Полнота спеки | 1-5 | PASS | Цель, AS-IS, root problem, goals, explicit non-goals cover public delivery outcome. |
+| B. Качество дизайна | 6-10 | PASS | Responsibilities, trigger/order, gates/errors, performance/indexing and alternatives recorded. |
+| C. Безопасность изменений | 11-13 | PASS | No task-data change; immutable-package migration/rollback and secret boundary are explicit. |
+| D. Проверяемость | 14-16 | PASS | ACs map to package, workflow, CI, public read-back and clean install; stop rules specified. |
+| E. Готовность к автономной реализации | 17-19 | PASS | Ordered plan, decision ledger and no unresolved design decision; external prerequisites are recorded. |
+| F. Соответствие профилю | 20 | PASS | .NET, delivery, testing and GitHub release contracts applied. |
+
+Итог: ГОТОВО
+
+### SPEC Rubric Result
+
+| Критерий | Балл (0/2/5) | Обоснование |
+|---|---:|---|
+| 1. Ясность цели и границ | 5 | Standard command and prohibited scope are explicit. |
+| 2. Понимание текущего состояния | 5 | `.csproj`, README, workflow inventory, main/tag and live NuGet 404 were inspected. |
+| 3. Конкретность целевого дизайна | 5 | Version/tag, gate order, secret boundary, retry/read-back are specified. |
+| 4. Безопасность (миграция, откат) | 5 | Immutable NuGet rollback and secret/authorization failure handling are concrete. |
+| 5. Тестируемость | 5 | Every AC has automation/log/public evidence and failure stop rules. |
+| 6. Готовность к автономной реализации | 5 | No design decision remains; credentials are objective external prerequisites. |
+
+Итоговый балл: 30 / 30
+Зона: готово к автономному выполнению
+
+### Role-Based Review Result
+
+| Role | Applicability | Review question | Verdict | Required spec changes |
+| --- | --- | --- | --- | --- |
+| Business analyst / domain workflow | applicable | Does official NuGet installation meet the stated operational goal? | PASS | Standard global command is outcome and evidence. |
+| UX / designer | not applicable | Is there a UI visual/interaction surface? | PASS | CLI/package text only; README command is reviewed as output contract. |
+| Tester / validation | applicable | Are public/negative/retry states testable? | PASS | Added clean install, package inspection, CI and public API evidence. |
+| Developer / architect | applicable | Are version, source provenance and tool contracts coherent? | PASS | One package version matches one verified release tag. |
+| Delivery / operations / security | applicable | Are publication, secrets, rollback and authorization safe? | PASS | Release gating, secret isolation, immutability and current token limitation captured. |
+
+### Post-SPEC Review
+- Статус / stop decision: PASS — можно запрашивать подтверждение.
+- Scope reviewed: this SPEC; central stack listed in section 15; current feature worktree `feat/cli-default-task-storage`; planned files in section 16; no unresolved design question.
+- Review passes:
+  - Scope/Evidence: inspected CLI project/README, workflow inventory, `origin/main`, `v1.30.0`, GitHub auth and NuGet flat-container response.
+  - Contract: standard install, command name, package/release version and no-secret boundary are explicit.
+  - Adversarial risk: version collision, pre-merge publishing, missing workflow scope/key, slow indexing and duplicate retry each fail closed.
+  - Role-Based: all applicable delivery roles PASS; UX explicitly not applicable.
+  - Fix and re-review: initial draft was reviewed for feature-branch release risk and changed to require merged-main/tag provenance; matrix and stop rules rechecked.
+  - Stop decision: no BLOCKER/HIGH/MEDIUM finding remains in the source design; actual external credentials are runtime gates.
+- Evidence inspected: `Unlimotion.Cli.csproj`, CLI README, `.github/workflows` inventory, `git ls-remote`, `gh auth status`, `gh release view v1.30.0`, NuGet HTTP 404.
+- Depth checklist: scope/unrelated changes — bounded; acceptance/scenarios/ledger/objections — populated; validation evidence — layered; unsupported claims — public absence is time-stamped; regression/edge cases — enumerated; docs/changelog — README required, release notes reviewed at delivery; hidden contract — package/version/tag contract explicit; manual challenge — verify actual NuGet binary contents and tag SHA after publication.
+- No-findings justification: SPEC avoids treating a local package or successful `push` exit code as publication proof and contains an external read-back.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| LOW | delivery provenance | Initial thought of direct feature-branch release was unsafe | Require PR/CI/merge and exact-tag source gate | fixed |
+| LOW | evidence | NuGet HTTP 404 does not reserve package name | Recheck immediately before push | fixed |
+
+- Fixed before continuing: provenance gate and availability caveat integrated above.
+- Checks rerun: SPEC linter/rubric and review content self-check after amendment.
+- Needs human: only if external authorization/secret is absent at publication time.
+- Residual risks / follow-ups: desktop packaging jobs triggered by the GitHub release are outside tool publication proof and will be reported independently.
+
+### Post-EXEC Review
+- Статус: PASS для source implementation и local validation; GitHub/NuGet delivery остаётся следующим внешним этапом.
+- Scope reviewed: approved SPEC; CLI metadata/README; new `nuget-cli.yml`; current status/diff; package/install evidence; CI-style TUnit evidence. Unrelated changes отсутствуют.
+- Review passes:
+  - Scope/Evidence pass: changed files match section 16; no task/domain/UI behavior or secret was added.
+  - Contract pass: package `Unlimotion.Cli` and executable `unlimotion-cli` preserved; version is exactly `1.30.1`, paired with planned `v1.30.1`; README uses default NuGet install command.
+  - Adversarial risk pass: workflow refuses malformed/mismatched tag, tag outside `origin/main`, missing secret, missing pack entries and unindexed public package; `--skip-duplicate` is followed by read-back.
+  - Role-Based pass: business workflow, test, architecture and delivery/security contracts verified; UX remains not applicable because no UI surface changed.
+  - Fix and re-review: corrected `git fetch origin main` to explicit remote-tracking ref update before source ancestry check; YAML parse and diff/whitespace checks repeated.
+  - Stop decision: source changes may be committed and sent to PR; do not create release/NuGet package until merged `main`, green CI and credential gates.
+- Evidence inspected:
+  - expected red: pre-change pack produced `Unlimotion.Cli.0.3.0.nupkg`, not required `1.30.1`;
+  - YAML parse: PyYAML 6.0.3 parsed `nuget-cli.yml` contract;
+  - targeted `TaskDirectoryResolverTests`: PASS 2/2;
+  - Release build + pack: `Unlimotion.Cli.1.30.1.nupkg`, 660212 bytes; manifest is `Unlimotion.Cli` `1.30.1` with `DotnetTool`, README/license/runtime/tool files;
+  - clean temporary local install: PASS, `unlimotion-cli.exe --help` shows optional `--tasks` contract;
+  - repository CI runner main restore/build/test: PASS, TRX 970 total / 970 passed / 0 failed / telemetry complete, duration 20:57.
+- Depth checklist: scope drift/unrelated changes — none; AC/scenarios/matrix — all source-side entries evidenced; validation — layered; unsupported claims — package is not yet public; regression/edge cases — gate ordering and failure paths inspected; docs — official and local install paths coherent; hidden contract — tag/version equality explicit; manual challenge — inspect actual public package/read-back after NuGet indexing.
+- No-findings justification: source and workflow use no secret literals, retain CLI command/behavior, produce a verified .NET tool, and stop before external publication when provenance or credentials fail.
+
+| Severity | Area | Finding | Required action | Status |
+| --- | --- | --- | --- | --- |
+| MEDIUM | delivery provenance | `git fetch origin main` could leave stale `origin/main` ref | Fetch into `refs/remotes/origin/main` explicitly | fixed |
+| LOW | test evidence | direct TUnit HTML retained prior targeted report | Repeat through repository CI runner with fresh TRX/metadata | fixed |
+
+- Fixed before continuing: remote-tracking fetch and CI-runner evidence path.
+- Checks rerun: YAML parse; targeted test/build/pack/install; full CI runner; `git diff --check` and whitespace scan.
+- Validation evidence: listed above; pre-existing compiler warnings remain unrelated and did not fail build/test.
+
+
+- Unrelated changes: none.
+- Needs human: external delivery is blocked until a repository owner both configures a scoped `NUGET_API_KEY` GitHub Actions secret and grants/refreshes GitHub authentication with `workflow` permission. The checked secret list contains only Android signing secrets; the current token has `gist`, `read:org`, `repo`, but no `workflow`.
+- Residual risks / follow-ups: local commits `a4268ae3` and `7e3038ab` are not pushed; public NuGet availability, PR/CI status and release-triggered workflow remain unverified.
+- Delivery stop decision: NEEDS-HUMAN — do not push the workflow, create `v1.30.1`, or claim a public package before the two prerequisites above are confirmed.
+## Approval
+Ожидается фраза: "Спеку подтверждаю"
+
+## 20. Журнал действий агента
+
+| Фаза (SPEC/EXEC) | Тип намерения/сценария | Уверенность в решении (0.0-1.0) | Каких данных не хватает | Следующее действие | Нужна ли передача управления/решения человеку | Было ли фактическое обращение к человеку / решение человека | Короткое объяснение выбора | Затронутые артефакты/файлы |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| SPEC | Standard public CLI install | 0.94 | NuGet owner secret and effective workflow permission are runtime prerequisites | Request SPEC approval, then implement and validate source changes | Да, approval gate | Нет | Expanded SPEC is required because public package/release/CI contracts and irreversible publication are in scope | `specs/2026-09-12-official-nuget-cli-publishing.md` |
+| EXEC | Public tool package and release workflow | 0.96 | GitHub workflow push scope and protected NuGet secret are still external gates | Commit and deliver source change through PR | Нет | Пользователь подтвердил SPEC | `1.30.1` package/install contract, targeted tests and CI-style full suite validated locally | `.csproj`, CLI README, `nuget-cli.yml`, this SPEC |
+| EXEC | External publication preflight | 0.99 | `NUGET_API_KEY` and GitHub `workflow` permission are absent | Wait for owner to configure both prerequisites, then push/PR/release/read-back | Да, external credential/authorization | Да, reported exact blocker | Commit `7e3038ab` is local only; package was not published and no release/tag was created | this SPEC |

--- a/src/Unlimotion.Cli/Program.cs
+++ b/src/Unlimotion.Cli/Program.cs
@@ -443,6 +443,7 @@ public static class Program
         writer ??= Console.Out;
         writer.WriteLine("Usage:");
         writer.WriteLine("  unlimotion-cli status --tasks <path> [--format text|json]");
+        writer.WriteLine("  --tasks <path> is optional; without it the active local desktop task-space path is used.");
         writer.WriteLine("  unlimotion-cli unlocked --tasks <path> [--format text|json]");
         writer.WriteLine("  unlimotion-cli task --tasks <path> --id <task-id> [--format text|json]");
         writer.WriteLine("  unlimotion-cli validate --tasks <path> [--format text|json]");
@@ -543,7 +544,7 @@ public sealed record CliOptions
         return new CliOptions
         {
             Command = command,
-            TasksPath = tasksPath,
+            TasksPath = tasksPath ?? TaskDirectoryResolver.Resolve(null),
             TaskId = taskId,
             CriterionId = criterionId,
             Status = status,

--- a/src/Unlimotion.Cli/README.md
+++ b/src/Unlimotion.Cli/README.md
@@ -26,6 +26,15 @@ unlimotion-cli satisfy-criterion --tasks <task-dir> --id <task-id> --criterion <
 ```
 
 ## Availability semantics
+`--tasks` is optional for every command. When it is omitted, the CLI reads
+`TaskStorage:Path` from `%USERPROFILE%\Documents\Unlimotion\Settings.json`,
+the desktop compatibility projection of the active task space. An explicit
+`--tasks` value always takes priority.
+
+The CLI remains file-storage only. Missing, malformed, or server-mode settings
+return an error without reading credentials, connecting to a server, writing
+settings, or creating a task directory.
+
 
 Read commands use the shared file storage and `TaskAvailabilityAnalyzer` to explain the current graph:
 

--- a/src/Unlimotion.Cli/README.md
+++ b/src/Unlimotion.Cli/README.md
@@ -2,11 +2,29 @@
 
 Command-line client for inspecting and updating Unlimotion task directories without starting the UI. It is intended for agents and automation that need the same task availability semantics as Unlimotion.
 
-## Install from a local package
+## Install from NuGet.org
+
+```powershell
+dotnet tool install --global Unlimotion.Cli
+unlimotion-cli status --format json
+```
+
+The package installs the `unlimotion-cli` command from the default NuGet.org
+source. It targets .NET 10; use a compatible .NET SDK/runtime. Update an
+existing global installation with:
+
+```powershell
+dotnet tool update --global Unlimotion.Cli
+```
+
+`--tasks` remains an explicit override. Without it, the CLI reads the active
+local desktop task-space path from `%USERPROFILE%\Documents\Unlimotion\Settings.json`.
+
+## Build and install a local package
 
 ```powershell
 dotnet pack src\Unlimotion.Cli\Unlimotion.Cli.csproj -c Release -o artifacts\tools
-dotnet tool install --tool-path C:\tmp\unlimotion-cli-tool --add-source artifacts\tools Unlimotion.Cli --version 0.3.0
+dotnet tool install --tool-path C:\tmp\unlimotion-cli-tool --add-source artifacts\tools Unlimotion.Cli --version 1.30.1
 C:\tmp\unlimotion-cli-tool\unlimotion-cli status --tasks C:\Projects\ТОС\Knowledge.TOC\Tasks --format json
 ```
 

--- a/src/Unlimotion.Cli/TaskDirectoryResolver.cs
+++ b/src/Unlimotion.Cli/TaskDirectoryResolver.cs
@@ -1,0 +1,92 @@
+using System.Text.Json;
+
+namespace Unlimotion.Cli;
+
+public static class TaskDirectoryResolver
+{
+    public static string Resolve(string? explicitTasksPath, string settingsPath)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitTasksPath))
+        {
+            return explicitTasksPath;
+        }
+
+        if (string.IsNullOrWhiteSpace(settingsPath) || !File.Exists(settingsPath))
+        {
+            throw SettingsError("settingsNotFound", "Unlimotion desktop settings were not found. Specify --tasks <path> explicitly.");
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(settingsPath));
+            if (document.RootElement.ValueKind != JsonValueKind.Object ||
+                !TryGetProperty(document.RootElement, "TaskStorage", out var taskStorage) ||
+                taskStorage.ValueKind != JsonValueKind.Object)
+            {
+                throw SettingsError("settingsPathMissing", "Unlimotion desktop settings do not define TaskStorage.Path. Specify --tasks <path> explicitly.");
+            }
+
+            if (TryGetProperty(taskStorage, "IsServerMode", out var serverMode))
+            {
+                var isServerMode = serverMode.ValueKind switch
+                {
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.String when bool.TryParse(serverMode.GetString(), out var parsed) => parsed,
+                    _ => throw SettingsError("settingsInvalid", "Unlimotion desktop settings contain an invalid TaskStorage.IsServerMode value. Specify --tasks <path> explicitly.")
+                };
+
+                if (isServerMode)
+                {
+                    throw SettingsError("settingsUnsupported", "The active Unlimotion task space is a server source. Specify --tasks <path> for a local task directory.");
+                }
+            }
+
+            if (!TryGetProperty(taskStorage, "Path", out var path) ||
+                path.ValueKind != JsonValueKind.String ||
+                string.IsNullOrWhiteSpace(path.GetString()))
+            {
+                throw SettingsError("settingsPathMissing", "Unlimotion desktop settings do not define TaskStorage.Path. Specify --tasks <path> explicitly.");
+            }
+
+            return path.GetString()!;
+        }
+        catch (CliException)
+        {
+            throw;
+        }
+        catch (JsonException)
+        {
+            throw SettingsError("settingsInvalid", "Unlimotion desktop settings are not valid JSON. Specify --tasks <path> explicitly.");
+        }
+        catch (IOException)
+        {
+            throw SettingsError("settingsInvalid", "Unlimotion desktop settings cannot be read. Specify --tasks <path> explicitly.");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            throw SettingsError("settingsInvalid", "Unlimotion desktop settings cannot be read. Specify --tasks <path> explicitly.");
+        }
+    }
+
+    public static string Resolve(string? explicitTasksPath) => Resolve(
+        explicitTasksPath,
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), "Unlimotion", "Settings.json"));
+
+    private static CliException SettingsError(string kind, string message) => new(message, exitCode: 1, kind);
+
+    private static bool TryGetProperty(JsonElement element, string name, out JsonElement value)
+    {
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/src/Unlimotion.Cli/Unlimotion.Cli.csproj
+++ b/src/Unlimotion.Cli/Unlimotion.Cli.csproj
@@ -8,10 +8,14 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>unlimotion-cli</ToolCommandName>
     <PackageId>Unlimotion.Cli</PackageId>
-    <Version>0.3.0</Version>
+    <Version>1.30.1</Version>
     <Authors>Unlimotion</Authors>
     <Description>CLI for inspecting and updating Unlimotion task graphs with availability rules.</Description>
     <PackageTags>unlimotion;cli;tasks;agents</PackageTags>
+    <PackageProjectUrl>https://github.com/Kibnet/Unlimotion</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Kibnet/Unlimotion.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReleaseNotes>First public Unlimotion CLI release. See https://github.com/Kibnet/Unlimotion/releases for release notes.</PackageReleaseNotes>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>License.txt</PackageLicenseFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/Unlimotion.Test/TaskDirectoryResolverTests.cs
+++ b/src/Unlimotion.Test/TaskDirectoryResolverTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Unlimotion.Test;
+
+public sealed class TaskDirectoryResolverTests
+{
+    [Test]
+    public async Task Resolve_UsesConfiguredLocalPathAndExplicitOverride()
+    {
+        using var temp = TemporarySettingsDirectory.Create();
+        var settingsPath = Path.Combine(temp.Path, "Settings.json");
+        var configuredTasksPath = Path.Combine(temp.Path, "ConfiguredTasks");
+        await File.WriteAllTextAsync(
+            settingsPath,
+            JsonSerializer.Serialize(new
+            {
+                TaskStorage = new
+                {
+                    Path = configuredTasksPath,
+                    IsServerMode = "False"
+                }
+            }));
+
+        var configured = global::Unlimotion.Cli.TaskDirectoryResolver.Resolve(null, settingsPath);
+        var explicitOverride = global::Unlimotion.Cli.TaskDirectoryResolver.Resolve(
+            Path.Combine(temp.Path, "ExplicitTasks"),
+            Path.Combine(temp.Path, "MissingSettings.json"));
+
+        await Assert.That(configured).IsEqualTo(configuredTasksPath);
+        await Assert.That(explicitOverride).IsEqualTo(Path.Combine(temp.Path, "ExplicitTasks"));
+    }
+
+    [Test]
+    public async Task Resolve_RejectsMissingMalformedPathlessAndServerSettings()
+    {
+        using var temp = TemporarySettingsDirectory.Create();
+        var cases = new[]
+        {
+            (Path.Combine(temp.Path, "Missing.json"), "settingsNotFound", (string?)null),
+            (Path.Combine(temp.Path, "Malformed.json"), "settingsInvalid", "{"),
+            (Path.Combine(temp.Path, "Pathless.json"), "settingsPathMissing", "{\"TaskStorage\":{}}"),
+            (Path.Combine(temp.Path, "Server.json"), "settingsUnsupported", "{\"TaskStorage\":{\"Path\":\"https://example.invalid\",\"IsServerMode\":true}}")
+        };
+
+        foreach (var testCase in cases)
+        {
+            if (testCase.Item3 != null)
+            {
+                await File.WriteAllTextAsync(testCase.Item1, testCase.Item3);
+            }
+
+            try
+            {
+                _ = global::Unlimotion.Cli.TaskDirectoryResolver.Resolve(null, testCase.Item1);
+                throw new InvalidOperationException("Expected default task directory resolution to fail.");
+            }
+            catch (global::Unlimotion.Cli.CliException exception)
+            {
+                await Assert.That(exception.ExitCode).IsEqualTo(1);
+                await Assert.That(exception.Kind).IsEqualTo(testCase.Item2);
+            }
+        }
+    }
+
+    private sealed class TemporarySettingsDirectory : IDisposable
+    {
+        private TemporarySettingsDirectory(string path) => Path = path;
+
+        public string Path { get; }
+
+        public static TemporarySettingsDirectory Create()
+        {
+            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "unlimotion-cli-settings", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(path);
+            return new TemporarySettingsDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Что меняется
- CLI без --tasks читает каталог задач из стандартных настроек установленного приложения.
- Unlimotion.Cli упакован как .NET tool версии 1.30.1.
- Релиз v1.30.1 публикует пакет в NuGet.org и проверяет стандартную установку.

## Проверено локально
- 970/970 TUnit-тестов прошло.
- Выполнены pack, чистая локальная установка tool и --help.
- Добавлена проверка соответствия версии тега, csproj и nupkg.