### PR TITLE
fix(cli): address release review findings

### DIFF
--- a/.github/workflows/nuget-cli.yml
+++ b/.github/workflows/nuget-cli.yml
@@ -39,8 +39,10 @@ jobs:
     - name: Validate release source and package version
       id: release
       shell: pwsh
+      env:
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
       run: |
-        $tag = '${{ github.event.release.tag_name }}'
+        $tag = $env:RELEASE_TAG
         if ($tag -notmatch '^v(?<version>\d+\.\d+\.\d+)$') {
           throw "CLI publishing requires a stable vMAJOR.MINOR.PATCH release tag; received '$tag'."
         }

--- a/specs/2026-09-13-cli-release-review-fixes.md
+++ b/specs/2026-09-13-cli-release-review-fixes.md
@@ -1,0 +1,26 @@
+# Исправления review к CLI и NuGet workflow
+
+## Цель
+
+Устранить два P1-замечания PR #293: относительный `TaskStorage.Path` должен разрешаться от каталога `Settings.json`, а release tag в PowerShell workflow должен передаваться через environment variable.
+
+## Контракт
+
+- `--tasks` сохраняет приоритет; абсолютный persisted path не изменяется.
+- Относительный persisted path canonicalized относительно `DirectoryName(settingsPath)`.
+- `RELEASE_TAG` передаётся через step `env`; `$env:RELEASE_TAG` является единственным источником tag в release-validation script.
+- Package id/version, команда `unlimotion-cli`, schema settings и NuGet credential boundary не меняются.
+
+## Проверка
+
+- `TaskDirectoryResolverTests` покрывает relative path, absolute path и explicit override.
+- `NuGetCliWorkflowContractTests` не допускает прямую GitHub-expression interpolation в `$tag` PowerShell source.
+- Выполняются build, YAML parse/static inspection, pack и local tool smoke; CI PR — обязательный gate.
+
+## Non-goals
+
+Нет изменений UI, миграции task data, нового NuGet release или изменения секретов.
+
+## Approval
+
+Подтверждено пользователем: «Спеку подтверждаю» (2026-09-13).

--- a/src/Unlimotion.Cli/TaskDirectoryResolver.cs
+++ b/src/Unlimotion.Cli/TaskDirectoryResolver.cs
@@ -49,7 +49,11 @@ public static class TaskDirectoryResolver
                 throw SettingsError("settingsPathMissing", "Unlimotion desktop settings do not define TaskStorage.Path. Specify --tasks <path> explicitly.");
             }
 
-            return path.GetString()!;
+            var configuredPath = path.GetString()!;
+            var settingsDirectory = Path.GetDirectoryName(Path.GetFullPath(settingsPath))!;
+            return Path.IsPathFullyQualified(configuredPath)
+                ? configuredPath
+                : Path.GetFullPath(configuredPath, settingsDirectory);
         }
         catch (CliException)
         {

--- a/src/Unlimotion.Test/NuGetCliWorkflowContractTests.cs
+++ b/src/Unlimotion.Test/NuGetCliWorkflowContractTests.cs
@@ -1,0 +1,18 @@
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Unlimotion.Test;
+
+public sealed class NuGetCliWorkflowContractTests
+{
+    [Test]
+    public async Task ReleaseTag_IsPassedToPowerShellAsEnvironmentData()
+    {
+        var workflowPath = PlatformShellProjectContracts.GetRepositoryPath(".github/workflows/nuget-cli.yml");
+        var workflow = await File.ReadAllTextAsync(workflowPath);
+
+        await Assert.That(workflow).Contains("RELEASE_TAG: ${{ github.event.release.tag_name }}");
+        await Assert.That(workflow).Contains("$tag = $env:RELEASE_TAG");
+        await Assert.That(workflow).DoesNotContain("$tag = '${{ github.event.release.tag_name }}'");
+    }
+}

--- a/src/Unlimotion.Test/TaskDirectoryResolverTests.cs
+++ b/src/Unlimotion.Test/TaskDirectoryResolverTests.cs
@@ -34,6 +34,29 @@ public sealed class TaskDirectoryResolverTests
     }
 
     [Test]
+    public async Task Resolve_UsesSettingsDirectoryForRelativeConfiguredPath()
+    {
+        using var temp = TemporarySettingsDirectory.Create();
+        var settingsDirectory = Path.Combine(temp.Path, "DesktopSettings");
+        Directory.CreateDirectory(settingsDirectory);
+        var settingsPath = Path.Combine(settingsDirectory, "Settings.json");
+        await File.WriteAllTextAsync(
+            settingsPath,
+            JsonSerializer.Serialize(new
+            {
+                TaskStorage = new
+                {
+                    Path = "Tasks",
+                    IsServerMode = false
+                }
+            }));
+
+        var configured = global::Unlimotion.Cli.TaskDirectoryResolver.Resolve(null, settingsPath);
+
+        await Assert.That(configured).IsEqualTo(Path.Combine(settingsDirectory, "Tasks"));
+    }
+
+    [Test]
     public async Task Resolve_RejectsMissingMalformedPathlessAndServerSettings()
     {
         using var temp = TemporarySettingsDirectory.Create();


### PR DESCRIPTION
## Исправляет review к #293
- Relative TaskStorage.Path теперь разрешается от каталога Settings.json.
- Release tag передаётся в PowerShell validation step через environment variable.

## Проверено
- TaskDirectoryResolverTests: 3/3.
- NuGetCliWorkflowContractTests: 1/1.
- Полный TUnit: 972/972, 0 failed (17m 36s).
- CLI build, YAML parse, pack и чистая local tool install/smoke.